### PR TITLE
fix: default client role and user creation

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('react-hot-toast', () => ({
+  toast: { error: vi.fn(), success: vi.fn() }
+}));
+
+const insertMock = vi.fn().mockResolvedValue({ error: null });
+const singleMock = vi.fn().mockResolvedValue({ data: null, error: { message: 'No user' } });
+const eqMock = vi.fn().mockReturnValue({ single: singleMock });
+const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+const fromMock = vi.fn().mockReturnValue({ select: selectMock, insert: insertMock });
+
+vi.mock('../supabase', () => ({
+  supabase: {
+    auth: {
+      signInWithPassword: vi.fn(),
+      signOut: vi.fn(),
+      getUser: vi.fn(),
+    },
+    from: fromMock
+  }
+}));
+
+describe('signInWithEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    singleMock.mockResolvedValue({ data: null, error: { message: 'No user' } });
+    insertMock.mockResolvedValue({ error: null });
+  });
+
+  it('should assign client role when user does not exist', async () => {
+    const { signInWithEmail } = await import('../auth');
+    const { supabase } = await import('../supabase');
+
+    (supabase.auth.signInWithPassword as any).mockResolvedValue({
+      data: { user: { id: 'user-1', email: 'test@example.com' } },
+      error: null
+    });
+
+    const user = await signInWithEmail('test@example.com', 'password');
+
+    expect(user?.role).toBe('client');
+    expect(user?.role).not.toBe('admin');
+    expect(insertMock).toHaveBeenCalledWith({
+      id: 'user-1',
+      email: 'test@example.com',
+      role: 'client'
+    });
+  });
+});
+

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -7,6 +7,22 @@ export interface User {
   role: 'admin' | 'pony_provider' | 'archery_provider' | 'client';
 }
 
+const ALLOWED_ROLES: User['role'][] = ['admin', 'pony_provider', 'archery_provider', 'client'];
+
+export const createUser = async (id: string, email: string, role: User['role']): Promise<User> => {
+  if (!role || !ALLOWED_ROLES.includes(role)) {
+    throw new Error('Rôle non autorisé');
+  }
+
+  const { error } = await supabase
+    .from('users')
+    .insert({ id, email, role });
+
+  if (error) throw error;
+
+  return { id, email, role };
+};
+
 export const signInWithEmail = async (email: string, password: string): Promise<User | null> => {
   try {
     const { data, error } = await supabase.auth.signInWithPassword({
@@ -26,20 +42,7 @@ export const signInWithEmail = async (email: string, password: string): Promise<
 
       if (userError) {
         console.warn('Utilisateur non trouvé dans la table users, création...');
-        // Créer l'utilisateur avec le rôle admin par défaut
-        await supabase
-          .from('users')
-          .insert({
-            id: data.user.id,
-            email: data.user.email!,
-            role: 'admin'
-          });
-        
-        return {
-          id: data.user.id,
-          email: data.user.email!,
-          role: 'admin'
-        };
+        return await createUser(data.user.id, data.user.email!, 'client');
       }
 
       return {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,12 @@ import { vi } from 'vitest';
 import React from 'react';
 
 // Mock only specific URL methods for file download tests
+if (!('createObjectURL' in window.URL)) {
+  Object.defineProperty(window.URL, 'createObjectURL', { value: vi.fn(), writable: true });
+}
+if (!('revokeObjectURL' in window.URL)) {
+  Object.defineProperty(window.URL, 'revokeObjectURL', { value: vi.fn(), writable: true });
+}
 vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('mock-url');
 vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary
- avoid implicit admin assignment by defaulting new users to `client`
- add `createUser` helper validating allowed roles
- cover sign-in creation flow with unit test
- stub URL object methods for tests

## Testing
- `npm test` (fails: several suites) 
- `npx vitest run src/lib/__tests__/auth.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68ac58867270832b98ee25f745066bd0