### PR TITLE
feat: add reservation email service

### DIFF
--- a/src/lib/__tests__/sendReservationEmail.test.ts
+++ b/src/lib/__tests__/sendReservationEmail.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('../supabase', () => ({
+  supabase: {
+    functions: {
+      invoke: vi.fn(),
+    },
+  },
+}));
+
+import { supabase } from '../supabase';
+import { sendReservationEmail } from '../sendReservationEmail';
+
+describe('sendReservationEmail', () => {
+  it('should resolve on successful email sending', async () => {
+    vi.mocked(supabase.functions.invoke).mockResolvedValue({ data: {}, error: null });
+
+    await expect(
+      sendReservationEmail({ email: 'test@example.com', reservationId: '1' })
+    ).resolves.toBeUndefined();
+
+    expect(supabase.functions.invoke).toHaveBeenCalledWith('send-reservation-email', {
+      body: { email: 'test@example.com', reservationId: '1' },
+    });
+  });
+
+  it('should throw on email sending failure', async () => {
+    vi.mocked(supabase.functions.invoke).mockResolvedValue({ data: null, error: { message: 'fail' } });
+
+    await expect(
+      sendReservationEmail({ email: 'test@example.com', reservationId: '1' })
+    ).rejects.toThrow('fail');
+  });
+});
+

--- a/src/lib/sendReservationEmail.ts
+++ b/src/lib/sendReservationEmail.ts
@@ -1,0 +1,17 @@
+import { supabase } from './supabase';
+
+export interface ReservationEmailPayload {
+  email: string;
+  reservationId: string;
+}
+
+export async function sendReservationEmail(payload: ReservationEmailPayload) {
+  const { error } = await supabase.functions.invoke('send-reservation-email', {
+    body: payload,
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+}
+

--- a/src/pages/FindTicket.tsx
+++ b/src/pages/FindTicket.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { Search, Mail, Shield, CheckCircle } from 'lucide-react';
 import { supabase } from '../lib/supabase';
+import { sendReservationEmail } from '../lib/sendReservationEmail';
 import { toast } from 'react-hot-toast';
 
 export default function FindTicket() {
@@ -36,9 +37,12 @@ export default function FindTicket() {
       if (error) throw error;
 
       if (data && data.length > 0) {
+        await sendReservationEmail({
+          email,
+          reservationId: data[0].id,
+        });
         setFound(true);
         toast.success('E-mail de confirmation renvoyé !');
-        // TODO: Déclencher l'envoi d'e-mail
       } else {
         toast.error('Aucune réservation trouvée pour cette adresse e-mail');
       }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,12 @@ import { vi } from 'vitest';
 import React from 'react';
 
 // Mock only specific URL methods for file download tests
+if (!('createObjectURL' in window.URL)) {
+  Object.defineProperty(window.URL, 'createObjectURL', { value: vi.fn(), configurable: true });
+}
+if (!('revokeObjectURL' in window.URL)) {
+  Object.defineProperty(window.URL, 'revokeObjectURL', { value: vi.fn(), configurable: true });
+}
 vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('mock-url');
 vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
 


### PR DESCRIPTION
## Summary
- trigger reservation emails with new service
- use service in `FindTicket` page
- test email service success and error cases
- ensure tests have URL helpers mocked

## Testing
- `npm test` *(fails: Test Files 4 failed | 11 passed | 5 skipped (20))*

------
https://chatgpt.com/codex/tasks/task_e_68ac58f171b4832bb6f1bc72ff90d6c1