### PR TITLE
feat: centralize error message handling

### DIFF
--- a/src/lib/__tests__/errors.test.ts
+++ b/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { getErrorMessage } from '../errors';
+
+describe('getErrorMessage', () => {
+  it('returns message from Error instance', () => {
+    const error = new Error('boom');
+    expect(getErrorMessage(error)).toBe('boom');
+  });
+
+  it('extracts message from objects with message property', () => {
+    const errorLike = { message: 'bad' } as const;
+    expect(getErrorMessage(errorLike)).toBe('bad');
+  });
+
+  it('handles non-standard values', () => {
+    expect(getErrorMessage('oops')).toBe('oops');
+    expect(getErrorMessage({ foo: 'bar' })).toBe(JSON.stringify({ foo: 'bar' }));
+    expect(getErrorMessage(null)).toBe('');
+  });
+});

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabase';
 import { toast } from 'react-hot-toast';
+import { getErrorMessage } from './errors';
 
 export interface User {
   id: string;
@@ -52,7 +53,7 @@ export const signInWithEmail = async (email: string, password: string): Promise<
     return null;
   } catch (err) {
     console.error('Erreur connexion:', err);
-    toast.error(err.message || 'Erreur lors de la connexion');
+    toast.error(getErrorMessage(err) || 'Erreur lors de la connexion');
     return null;
   }
 };

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase';
 import { isSupabaseConfigured } from './supabase';
 import { toast } from 'react-hot-toast';
+import { getErrorMessage } from './errors';
 
 export interface CartItem {
   id: string;
@@ -186,7 +187,8 @@ export async function getCartItems(): Promise<CartItem[]> {
     if (error) {
       console.error('Erreur récupération panier:', error);
       // Si c'est une erreur de connectivité, retourner un tableau vide plutôt que de faire planter l'app
-      if (error.message?.includes('Failed to fetch') || error.message?.includes('fetch')) {
+      const errorMessage = getErrorMessage(error);
+      if (errorMessage.includes('Failed to fetch') || errorMessage.includes('fetch')) {
         console.warn('Network error, returning empty cart');
         return [];
       }

--- a/src/lib/errors.ts
+++ b/src/lib/errors.ts
@@ -1,0 +1,22 @@
+export function getErrorMessage(err: unknown): string {
+  if (err instanceof Error) {
+    return err.message;
+  }
+  if (typeof err === 'string') {
+    return err;
+  }
+  if (err && typeof err === 'object' && 'message' in err) {
+    const message = (err as { message?: unknown }).message;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+  if (err == null) {
+    return '';
+  }
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
+  }
+}

--- a/src/pages/admin/PassManagement.tsx
+++ b/src/pages/admin/PassManagement.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { supabase, isSupabaseConfigured } from '../../lib/supabase';
 import { Ticket, Plus, Edit, Trash2, Euro, Package, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import { getErrorMessage } from '../../lib/errors';
 
 interface Pass {
   id: string;
@@ -207,7 +208,7 @@ export default function PassManagement() {
       await loadData();
     } catch (err) {
       console.error('Erreur suppression pass:', err);
-      toast.error(`Erreur lors de la suppression: ${err.message || 'Erreur inconnue'}`);
+      toast.error(`Erreur lors de la suppression: ${getErrorMessage(err) || 'Erreur inconnue'}`);
     }
   };
 


### PR DESCRIPTION
## Summary
- add `getErrorMessage` helper to normalize unknown error values
- use `getErrorMessage` in auth, cart and pass management pages
- cover helper with unit tests for standard and non-standard errors

## Testing
- `npm run test:run` *(fails: createObjectURL does not exist)*
- `npm run lint` *(fails: 42 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac58f3a9b0832bb62db5c3e8c37b2c