### PR TITLE
test: add auth and cart coverage

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { signInWithEmail, signOut } from '../auth';
+import { supabase } from '../supabase';
+import { toast } from 'react-hot-toast';
+
+// Ensure auth methods exist on supabase mock
+beforeEach(() => {
+  vi.clearAllMocks();
+  (supabase.auth as any).signInWithPassword = vi.fn();
+  (supabase.auth as any).signOut = vi.fn();
+});
+
+describe('signInWithEmail', () => {
+  it('should return user when sign in succeeds', async () => {
+    const user = { id: 'user-1', email: 'test@example.com' };
+    (supabase.auth.signInWithPassword as any).mockResolvedValue({
+      data: { user },
+      error: null,
+    });
+    supabase.from.mockReturnValue({
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null }),
+      insert: vi.fn(),
+    });
+
+    const result = await signInWithEmail('test@example.com', 'password');
+    expect(result).toEqual({ id: 'user-1', email: 'test@example.com', role: 'admin' });
+  });
+
+  it('should return null and show error on failure', async () => {
+    (supabase.auth.signInWithPassword as any).mockResolvedValue({
+      data: { user: null },
+      error: new Error('Invalid credentials'),
+    });
+
+    const result = await signInWithEmail('test@example.com', 'wrong');
+    expect(result).toBeNull();
+    expect(toast.error).toHaveBeenCalled();
+  });
+});
+
+describe('signOut', () => {
+  it('should show success when sign out succeeds', async () => {
+    (supabase.auth.signOut as any).mockResolvedValue({ error: null });
+    await signOut();
+    expect(toast.success).toHaveBeenCalledWith('Déconnexion réussie');
+  });
+
+  it('should show error when sign out fails', async () => {
+    (supabase.auth.signOut as any).mockResolvedValue({ error: new Error('fail') });
+    await signOut();
+    expect(toast.error).toHaveBeenCalledWith('Erreur lors de la déconnexion');
+  });
+});

--- a/src/lib/__tests__/cart.test.ts
+++ b/src/lib/__tests__/cart.test.ts
@@ -67,9 +67,26 @@ describe('Cart Functions', () => {
     it('should return false when Supabase is not configured', async () => {
       const { isSupabaseConfigured } = await import('../supabase');
       vi.mocked(isSupabaseConfigured).mockReturnValue(false);
-      
+
       const result = await addToCart('pass-id');
       expect(result).toBe(false);
+    });
+
+    it('should add item to cart when Supabase is configured', async () => {
+      const { supabase } = await import('../supabase');
+      const builder = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        is: vi.fn().mockReturnThis(),
+        maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        insert: vi.fn().mockResolvedValue({ error: null }),
+      };
+      vi.mocked(supabase.from).mockReturnValue(builder as any);
+      mockLocalStorage.getItem.mockReturnValue('session-123');
+
+      const result = await addToCart('pass-id');
+      expect(result).toBe(true);
+      expect(builder.insert).toHaveBeenCalled();
     });
   });
 
@@ -77,9 +94,40 @@ describe('Cart Functions', () => {
     it('should return empty array when Supabase is not configured', async () => {
       const { isSupabaseConfigured } = await import('../supabase');
       vi.mocked(isSupabaseConfigured).mockReturnValue(false);
-      
+
       const result = await getCartItems();
       expect(result).toEqual([]);
+    });
+  });
+
+  describe('removeFromCart', () => {
+    it('should remove item successfully', async () => {
+      const { supabase } = await import('../supabase');
+      const builder = {
+        delete: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      };
+      vi.mocked(supabase.from).mockReturnValue(builder as any);
+
+      const result = await removeFromCart('item-id');
+      expect(result).toBe(true);
+    });
+  });
+
+  describe('clearCart', () => {
+    it('should clear cart successfully', async () => {
+      const { supabase } = await import('../supabase');
+      const builder = {
+        delete: vi.fn(() => ({
+          eq: vi.fn().mockResolvedValue({ error: null }),
+        })),
+      };
+      vi.mocked(supabase.from).mockReturnValue(builder as any);
+      mockLocalStorage.getItem.mockReturnValue('session-123');
+
+      const result = await clearCart();
+      expect(result).toBe(true);
     });
   });
 });

--- a/src/pages/admin/__tests__/EventManagement.test.tsx
+++ b/src/pages/admin/__tests__/EventManagement.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
+import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor } from '../../../test/utils';
 import EventManagement from '../EventManagement';
 
@@ -35,5 +36,24 @@ describe('EventManagement', () => {
       // Should not show loading spinner after data loads
       expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
     }, { timeout: 3000 });
+  });
+
+  it('should render header and add button', async () => {
+    render(<EventManagement />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /gestion des événements/i })).toBeInTheDocument();
+    });
+    expect(screen.getByRole('button', { name: /nouvel événement/i })).toBeInTheDocument();
+  });
+
+  it('should open create modal when clicking add button', async () => {
+    const user = userEvent.setup();
+    render(<EventManagement />);
+
+    const button = await screen.findByRole('button', { name: /nouvel événement/i });
+    await user.click(button);
+
+    expect(await screen.findByText(/nouvel événement/i)).toBeInTheDocument();
   });
 });

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,8 +3,21 @@ import { vi } from 'vitest';
 import React from 'react';
 
 // Mock only specific URL methods for file download tests
-vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('mock-url');
-vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+if (!window.URL.createObjectURL) {
+  Object.defineProperty(window.URL, 'createObjectURL', {
+    value: vi.fn(() => 'mock-url'),
+  });
+} else {
+  vi.spyOn(window.URL, 'createObjectURL').mockReturnValue('mock-url');
+}
+
+if (!window.URL.revokeObjectURL) {
+  Object.defineProperty(window.URL, 'revokeObjectURL', {
+    value: vi.fn(),
+  });
+} else {
+  vi.spyOn(window.URL, 'revokeObjectURL').mockImplementation(() => {});
+}
 
 // Mock BroadcastChannel for Supabase auth
 Object.defineProperty(window, 'BroadcastChannel', {


### PR DESCRIPTION
## Summary
- test signIn and signOut flows, including success and failure paths
- cover cart operations with Supabase mocks
- add basic admin page interaction tests and fix URL method mocks

## Testing
- `npm test` *(fails: multiple suites failing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac58f87478832bb836b5114ac66d69