### PR TITLE
feat: verify Supabase configuration on load

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,4 +1,5 @@
 import { createClient } from '@supabase/supabase-js';
+import { debugLog } from './logger';
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
@@ -9,6 +10,20 @@ export const isSupabaseConfigured = () => {
          !!supabaseAnonKey &&
          supabaseUrl.includes('.supabase.co');
 };
+
+// Helper to ensure Supabase configuration is present
+export const ensureSupabaseConfigured = () => {
+  if (!isSupabaseConfigured()) {
+    throw new Error('Supabase configuration is missing. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.');
+  }
+};
+
+// Warn during module initialization if configuration is missing
+if (!isSupabaseConfigured()) {
+  const message = 'Supabase configuration is missing. Please set VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY.';
+  debugLog(message);
+  console.warn(message);
+}
 
 export const supabase = isSupabaseConfigured()
   ? createClient(supabaseUrl, supabaseAnonKey)


### PR DESCRIPTION
## Summary
- log a warning when Supabase env vars are missing
- add `ensureSupabaseConfigured` helper

## Testing
- `npm test` *(fails: Supabase configuration is missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67d0856c832bae98fea6993b5282