### PR TITLE
feat: add centralized logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,13 @@
 
 ## Debugging
 
-Définissez la variable d'environnement `VITE_DEBUG=true` lors de l'exécution en développement pour activer les logs détaillés.
+Définissez la variable d'environnement `VITE_DEBUG=true` lors de l'exécution en développement pour activer le logger centralisé et obtenir des messages détaillés.
+Par exemple :
+
+```bash
+VITE_DEBUG=true npm run dev
+```
+
 Les logs sont automatiquement désactivés dans les builds de production.
 
 ## Mode démonstration

--- a/src/components/admin/AnimationsManager.tsx
+++ b/src/components/admin/AnimationsManager.tsx
@@ -4,6 +4,7 @@ import { X, Plus, Edit, Trash2, Clock, MapPin, Users, Eye, EyeOff } from 'lucide
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
+import { logger } from '../../lib/logger';
 
 interface Animation {
   id: string;
@@ -49,7 +50,10 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
       if (error) throw error;
       setAnimations(data || []);
     } catch (err) {
-      console.error('Erreur chargement animations:', err);
+      logger.error('Erreur chargement animations', {
+        error: err,
+        query: { table: 'event_animations', action: 'select', eventId: event.id }
+      });
       toast.error('Erreur lors du chargement des animations');
     } finally {
       setLoading(false);
@@ -66,11 +70,14 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
         .eq('id', animationId);
 
       if (error) throw error;
-      
+
       toast.success('Animation supprimée avec succès');
       loadAnimations();
     } catch (err) {
-      console.error('Erreur suppression animation:', err);
+      logger.error('Erreur suppression animation', {
+        error: err,
+        query: { table: 'event_animations', action: 'delete', id: animationId }
+      });
       toast.error('Erreur lors de la suppression');
     }
   };
@@ -83,11 +90,19 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
         .eq('id', animation.id);
 
       if (error) throw error;
-      
+
       toast.success(`Animation ${!animation.is_active ? 'activée' : 'désactivée'}`);
       loadAnimations();
     } catch (err) {
-      console.error('Erreur changement statut animation:', err);
+      logger.error('Erreur changement statut animation', {
+        error: err,
+        query: {
+          table: 'event_animations',
+          action: 'update',
+          id: animation.id,
+          is_active: !animation.is_active
+        }
+      });
       toast.error('Erreur lors du changement de statut');
     }
   };
@@ -300,10 +315,17 @@ function AnimationForm({ event, animation, onClose }: AnimationFormProps) {
         if (error) throw error;
         toast.success('Animation créée avec succès');
       }
-      
+
       onClose();
     } catch (err) {
-      console.error('Erreur sauvegarde animation:', err);
+      logger.error('Erreur sauvegarde animation', {
+        error: err,
+        query: {
+          table: 'event_animations',
+          action: animation ? 'update' : 'insert',
+          animationId: animation?.id
+        }
+      });
       toast.error('Erreur lors de la sauvegarde');
     } finally {
       setSaving(false);

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase';
 import { toast } from 'react-hot-toast';
 import { getErrorMessage } from './errors';
+import { logger } from './logger';
 
 export interface User {
   id: string;
@@ -42,7 +43,10 @@ export const signInWithEmail = async (email: string, password: string): Promise<
         .single();
 
       if (userError) {
-        console.warn('Utilisateur non trouvé dans la table users, création...');
+        logger.warn('Utilisateur non trouvé dans la table users, création...', {
+          error: userError,
+          query: { table: 'users', action: 'select', userId: data.user.id }
+        });
         return await createUser(data.user.id, data.user.email!, 'client');
       }
 
@@ -55,7 +59,10 @@ export const signInWithEmail = async (email: string, password: string): Promise<
 
     return null;
   } catch (err) {
-    console.error('Erreur connexion:', err);
+    logger.error('Erreur connexion', {
+      error: err,
+      query: { action: 'auth.signInWithPassword', email }
+    });
     toast.error(getErrorMessage(err) || 'Erreur lors de la connexion');
     return null;
   }
@@ -67,7 +74,10 @@ export const signOut = async (): Promise<void> => {
     if (error) throw error;
     toast.success('Déconnexion réussie');
   } catch (err) {
-    console.error('Erreur déconnexion:', err);
+    logger.error('Erreur déconnexion', {
+      error: err,
+      query: { action: 'auth.signOut' }
+    });
     toast.error('Erreur lors de la déconnexion');
   }
 };
@@ -92,7 +102,10 @@ export const getCurrentUser = async (): Promise<User | null> => {
       role: userData.role
     };
   } catch (err) {
-    console.error('Erreur récupération utilisateur:', err);
+    logger.error('Erreur récupération utilisateur', {
+      error: err,
+      query: { table: 'users', action: 'select' }
+    });
     return null;
   }
 };

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,5 +1,40 @@
-export function debugLog(...args: unknown[]): void {
-  if (import.meta.env.DEV && import.meta.env.VITE_DEBUG === 'true') {
-    console.log(...args);
+export type LogContext = Record<string, unknown>;
+
+function formatValue(value: unknown): unknown {
+  if (value instanceof Error) {
+    return { name: value.name, message: value.message, stack: value.stack };
+  }
+  return value;
+}
+
+function formatContext(context: LogContext): string {
+  return Object.entries(context)
+    .map(([key, value]) => `${key}=${JSON.stringify(formatValue(value))}`)
+    .join(' ');
+}
+
+function output(level: 'debug' | 'info' | 'warn' | 'error', message: string, context?: LogContext): void {
+  if (level === 'debug' && !(import.meta.env.DEV && import.meta.env.VITE_DEBUG === 'true')) {
+    return;
+  }
+  const ctx = context ? ` | ${formatContext(context)}` : '';
+  const fn = level === 'debug' ? console.log : console[level];
+  fn(`${message}${ctx}`);
+}
+
+export const logger = {
+  debug: (message: string, context?: LogContext) => output('debug', message, context),
+  info: (message: string, context?: LogContext) => output('info', message, context),
+  warn: (message: string, context?: LogContext) => output('warn', message, context),
+  error: (message: string, context?: LogContext) => output('error', message, context),
+};
+
+export function debugLog(message: string, context?: unknown): void {
+  if (context && typeof context === 'object' && !Array.isArray(context)) {
+    logger.debug(message, context as LogContext);
+  } else if (context !== undefined) {
+    logger.debug(message, { value: context });
+  } else {
+    logger.debug(message);
   }
 }


### PR DESCRIPTION
## Summary
- add a context-aware logger utility guarded by `VITE_DEBUG`
- replace scattered `console.error`/`console.warn` calls with logger usage including Supabase query details
- document enabling verbose logging in development

## Testing
- `npm run lint` *(fails: MapPin is defined but never used, 52 errors, etc.)*
- `npm test` *(fails: 15 failed | 49 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac67e0cfc0832bb32552fb9b2b1c38