### PR TITLE
Log event update details and handle errors

### DIFF
--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -88,23 +88,36 @@ export default function EventForm({ event, onClose }: EventFormProps) {
     };
 
     try {
-      let error;
+      debugLog('Submitting eventData:', eventData);
+      console.log('Submitting eventData:', eventData);
+      debugLog('event.id:', event?.id);
+      console.log('event.id:', event?.id);
+
       if (event) {
         // Update existing event
-        const { error: updateError } = await supabase
+        const { data, error } = await supabase
           .from('events')
           .update(eventData)
-          .eq('id', event.id);
-        error = updateError;
+          .eq('id', event.id)
+          .select()
+          .single();
+
+        debugLog('Supabase update data:', data);
+        console.log('Supabase update data:', data);
+        debugLog('Supabase update error:', error);
+        console.log('Supabase update error:', error);
+
+        if (error || !data) {
+          const errorMessage = error?.message || 'événement introuvable';
+          throw new Error(errorMessage);
+        }
       } else {
         // Create new event
         const { error: insertError } = await supabase
           .from('events')
           .insert(eventData);
-        error = insertError;
+        if (insertError) throw insertError;
       }
-
-      if (error) throw error;
 
       toast.success(`Événement ${event ? 'mis à jour' : 'créé'} avec succès`);
       onClose();


### PR DESCRIPTION
## Summary
- log event data and id before calling Supabase
- replace update call with `.select().single()` and log results
- throw explicit errors when update fails or event not found

## Testing
- `npm test` *(fails: You cannot render a <Router> inside another <Router>.)*
- `npm run lint` *(fails: 52 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75bdf314832b84a6cc423d67d5c0