### PR TITLE
feat(events): add has_animations flag to type definitions

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -43,6 +43,7 @@ export type Database = {
           cgv_content: string;
           faq_content: string;
           key_info_content: string;
+          has_animations: boolean;
           created_at: string;
           updated_at: string;
         };
@@ -56,6 +57,7 @@ export type Database = {
           cgv_content?: string;
           faq_content?: string;
           key_info_content?: string;
+          has_animations?: boolean;
           created_at?: string;
           updated_at?: string;
         };
@@ -69,6 +71,7 @@ export type Database = {
           cgv_content?: string;
           faq_content?: string;
           key_info_content?: string;
+          has_animations?: boolean;
           updated_at?: string;
         };
       };


### PR DESCRIPTION
## Summary
- extend `events` table typings with new `has_animations` property

## Testing
- `npx tsc -b` *(fails: Found 83 errors)*
- `npm test` *(fails: 1 failed in cart.test.ts, CheckoutForm tests etc.)*
- `npm run lint` *(fails: 52 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac75caa2b0832bad56a91aa994a1f9