### PR TITLE
Handle missing event updates in EventForm

### DIFF
--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -100,16 +100,23 @@ export default function EventForm({ event, onClose }: EventFormProps) {
           .update(eventData)
           .eq('id', event.id)
           .select()
-          .single();
+          .maybeSingle();          // remplace .single()
 
         debugLog('Supabase update data:', data);
         console.log('Supabase update data:', data);
         debugLog('Supabase update error:', error);
         console.log('Supabase update error:', error);
+        debugLog('Supabase update error code:', error?.code);
+        console.log('Supabase update error code:', error?.code);
 
-        if (error || !data) {
-          const errorMessage = error?.message || 'événement introuvable';
+        if (error) {
+          const errorMessage = error.message || 'événement introuvable';
           throw new Error(errorMessage);
+        }
+
+        if (!data) {
+          toast.error('Événement introuvable ou accès refusé');
+          return;
         }
       } else {
         // Create new event


### PR DESCRIPTION
## Summary
- Use `maybeSingle()` when updating events to handle missing rows and log Supabase error codes
- Show a toast when an event update returns no data without error

## Testing
- ❌ `npm test`
- ❌ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ac7ee6f4a4832b81eaca9d5a44091a