### PR TITLE
Handle missing event when updating

### DIFF
--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -100,7 +100,7 @@ export default function EventForm({ event, onClose }: EventFormProps) {
           .update(eventData)
           .eq('id', event.id)
           .select()
-          .maybeSingle();          // remplace .single()
+          .single();
 
         debugLog('Supabase update data:', data);
         console.log('Supabase update data:', data);
@@ -109,14 +109,14 @@ export default function EventForm({ event, onClose }: EventFormProps) {
         debugLog('Supabase update error code:', error?.code);
         console.log('Supabase update error code:', error?.code);
 
+        if (error?.code === 'PGRST116') {
+          toast.error('Événement introuvable ou accès refusé');
+          return;
+        }
+
         if (error) {
           const errorMessage = error.message || 'événement introuvable';
           throw new Error(errorMessage);
-        }
-
-        if (!data) {
-          toast.error('Événement introuvable ou accès refusé');
-          return;
         }
       } else {
         // Create new event


### PR DESCRIPTION
## Summary
- use `.single()` when updating events and handle PGRST116 error with a toast

## Testing
- `npm test` *(fails: Cannot access 'fromMock' before initialization)*
- `npm run lint` *(fails: 52 errors, 15 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ac81c1af24832ba586ebb87c20557d