### PR TITLE
Check admin role against users table

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,9 @@
    ```
 
    Cette requête garantit que l'entrée de `public.users` correspond à `auth.uid()` avec `role = 'admin'`.
-3. Si l'application utilise des rôles via un claim JWT, ajoutez également `{"role": "admin"}` aux claims du token de l'utilisateur afin que la policy "Admins can manage events" le reconnaisse.
+3. La policy `"Admins can manage events"` s'appuie sur cette table pour vérifier le rôle administrateur.
+   Si votre application préfère utiliser un claim JWT pour stocker le rôle, adaptez la policy en conséquence et
+   assurez‑vous que le token contient `{"role": "admin"}`.
 
 ## Debugging
 

--- a/supabase/migrations/20250825130000_orange_forest.sql
+++ b/supabase/migrations/20250825130000_orange_forest.sql
@@ -1,0 +1,29 @@
+/*
+  # Revert admin policy to use users table
+
+  1. Security Updates
+    - Replace JWT claim check with table lookup
+*/
+
+-- Drop existing admin policy if it exists
+DROP POLICY IF EXISTS "Admins can manage events" ON public.events;
+
+-- Create policy checking role from public.users table
+CREATE POLICY "Admins can manage events"
+  ON public.events
+  FOR ALL
+  TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role = 'admin'
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.users
+      WHERE users.id = auth.uid()
+      AND users.role = 'admin'
+    )
+  );


### PR DESCRIPTION
## Summary
- replace JWT claim check with users table lookup for `Admins can manage events` policy
- clarify README on how policy relies on `public.users` or JWT claim

## Testing
- `npm test` (fails: You cannot render a <Router> inside another <Router>. You should never have more than one in your app.)
- `curl -i "$VITE_SUPABASE_URL/auth/v1/signup" -H "apikey: $VITE_SUPABASE_ANON_KEY" -H "Content-Type: application/json" -d '{"email":"fake_admin@example.com","password":"Password1!"}'` (HTTP/1.1 403 Forbidden)
- `curl -i "$VITE_SUPABASE_URL/rest/v1/events" -H "apikey: $VITE_SUPABASE_ANON_KEY" -H "Content-Type: application/json" -d '{"title":"Test Event"}'` (HTTP/1.1 403 Forbidden)
- `curl -i "$VITE_SUPABASE_URL/rest/v1/events?id=eq.0" -H "apikey: $VITE_SUPABASE_ANON_KEY" -H "Content-Type: application/json" -X PATCH -d '{"title":"Updated"}'` (HTTP/1.1 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_68ac81c6a5e4832b98f4cedc6ed3b5f2