### PR TITLE
feat: add admin markdown editor

### DIFF
--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -3,6 +3,7 @@ import { supabase } from '../../lib/supabase';
 import { toast } from 'react-hot-toast';
 import { X } from 'lucide-react';
 import { debugLog } from '../../lib/logger';
+import MarkdownEditor from './MarkdownEditor';
 
 interface Event {
   id: string;
@@ -200,18 +201,33 @@ export default function EventForm({ event, onClose }: EventFormProps) {
           </div>
 
           <div>
-            <label htmlFor="key_info_content" className="block text-sm font-medium text-gray-700 mb-1">Informations clés</label>
-            <textarea name="key_info_content" id="key_info_content" value={formData.key_info_content} onChange={handleChange} rows={4} className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"></textarea>
+            <MarkdownEditor
+              id="key_info_content"
+              label="Informations clés"
+              value={formData.key_info_content}
+              onChange={(value) => setFormData(prev => ({ ...prev, key_info_content: value }))}
+              rows={4}
+            />
           </div>
 
           <div>
-            <label htmlFor="cgv_content" className="block text-sm font-medium text-gray-700 mb-1">Conditions Générales de Vente (CGV)</label>
-            <textarea name="cgv_content" id="cgv_content" value={formData.cgv_content} onChange={handleChange} rows={6} className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"></textarea>
+            <MarkdownEditor
+              id="cgv_content"
+              label="Conditions Générales de Vente (CGV)"
+              value={formData.cgv_content}
+              onChange={(value) => setFormData(prev => ({ ...prev, cgv_content: value }))}
+              rows={6}
+            />
           </div>
 
           <div>
-            <label htmlFor="faq_content" className="block text-sm font-medium text-gray-700 mb-1">Foire Aux Questions (FAQ)</label>
-            <textarea name="faq_content" id="faq_content" value={formData.faq_content} onChange={handleChange} rows={6} className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"></textarea>
+            <MarkdownEditor
+              id="faq_content"
+              label="Foire Aux Questions (FAQ)"
+              value={formData.faq_content}
+              onChange={(value) => setFormData(prev => ({ ...prev, faq_content: value }))}
+              rows={6}
+            />
           </div>
 
           <div className="flex justify-end items-center p-6 bg-gray-50 border-t border-gray-200">

--- a/src/components/admin/MarkdownEditor.tsx
+++ b/src/components/admin/MarkdownEditor.tsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+import MarkdownRenderer from '../MarkdownRenderer';
+
+interface MarkdownEditorProps {
+  value: string;
+  onChange: (value: string) => void;
+  label: string;
+  rows?: number;
+  id?: string;
+}
+
+export default function MarkdownEditor({ value, onChange, label, rows = 6, id }: MarkdownEditorProps) {
+  const [error, setError] = useState<string | null>(null);
+
+  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    onChange(newValue);
+    if (!newValue.trim()) {
+      setError('Le contenu ne peut pas être vide.');
+    } else {
+      setError(null);
+    }
+  };
+
+  return (
+    <div>
+      <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      <textarea
+        id={id}
+        value={value}
+        onChange={handleChange}
+        rows={rows}
+        className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+      />
+      {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
+      <div className="mt-4">
+        <p className="text-sm font-medium text-gray-700 mb-1">Prévisualisation</p>
+        <div className="border border-gray-200 rounded-md p-3">
+          <MarkdownRenderer content={value} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/admin/__tests__/MarkdownEditor.test.tsx
+++ b/src/components/admin/__tests__/MarkdownEditor.test.tsx
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+import { render, screen } from '../../../test/utils';
+import MarkdownEditor from '../MarkdownEditor';
+
+function Wrapper() {
+  const [value, setValue] = React.useState('');
+  return <MarkdownEditor label="Description" value={value} onChange={setValue} id="desc" />;
+}
+
+describe('MarkdownEditor', () => {
+  it('updates text and renders markdown preview', async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    const textarea = screen.getByLabelText('Description');
+    await user.type(textarea, '# Hello');
+    const heading = await screen.findByRole('heading', { level: 1 });
+    expect(heading).toHaveTextContent('Hello');
+  });
+
+  it('shows error when content is empty', async () => {
+    const user = userEvent.setup();
+    render(<Wrapper />);
+    const textarea = screen.getByLabelText('Description');
+    await user.type(textarea, 'test');
+    await user.clear(textarea);
+    expect(await screen.findByText(/le contenu ne peut pas être vide/i)).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/ActivityManagement.tsx
+++ b/src/pages/admin/ActivityManagement.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Activity, Plus, Edit, Trash2, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import MarkdownEditor from '../../components/admin/MarkdownEditor';
 
 interface ActivityType {
   id: string;
@@ -259,14 +260,12 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Description
-              </label>
-              <textarea
+              <MarkdownEditor
+                id="description"
+                label="Description"
                 value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                onChange={(value) => setFormData({ ...formData, description: value })}
                 rows={3}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
 

--- a/src/pages/admin/PassManagement.tsx
+++ b/src/pages/admin/PassManagement.tsx
@@ -3,6 +3,7 @@ import { supabase, isSupabaseConfigured } from '../../lib/supabase';
 import { Ticket, Plus, Edit, Trash2, Euro, Package, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { getErrorMessage } from '../../lib/errors';
+import MarkdownEditor from '../../components/admin/MarkdownEditor';
 
 interface Pass {
   id: string;
@@ -597,14 +598,12 @@ function PassFormModal({ pass, events, onClose, onSave }: PassFormModalProps) {
             </div>
 
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Description
-              </label>
-              <textarea
+              <MarkdownEditor
+                id="description"
+                label="Description"
                 value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
+                onChange={(value) => setFormData({ ...formData, description: value })}
                 rows={3}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
 


### PR DESCRIPTION
## Summary
- add reusable MarkdownEditor with preview and validation
- use MarkdownEditor in event, activity, and pass forms
- test editor updates and renders markdown

## Testing
- ⚠️ `npm test` *(skipped: per user request)*
- ⚠️ `npm run lint` *(skipped: per user request)*

------
https://chatgpt.com/codex/tasks/task_e_68ac90047958832b9f973c9491f4d354