### PR TITLE
Use MarkdownRenderer in admin pages

### DIFF
--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -10,7 +10,7 @@ interface MarkdownRendererProps {
 
 export default function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
   if (!content || content.trim() === '') {
-    return <p className={className}>Aucun contenu à afficher.</p>;
+    return <p className={className}>Aucune information définie</p>;
   }
 
   try {

--- a/src/components/__tests__/MarkdownRenderer.test.tsx
+++ b/src/components/__tests__/MarkdownRenderer.test.tsx
@@ -28,4 +28,9 @@ describe('MarkdownRenderer', () => {
     // @ts-expect-error - ensure global not set
     expect((window as any).hacked).toBeUndefined();
   });
+
+  it('renders fallback message when content is empty', () => {
+    render(<MarkdownRenderer content="" />);
+    expect(screen.getByText('Aucune information définie')).toBeInTheDocument();
+  });
 });

--- a/src/pages/admin/ActivityManagement.tsx
+++ b/src/pages/admin/ActivityManagement.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Activity, Plus, Edit, Trash2, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import MarkdownRenderer from '../../components/MarkdownRenderer';
 
 interface ActivityType {
   id: string;
@@ -123,7 +124,10 @@ export default function ActivityManagement() {
                     <div className="text-3xl">{activity.icon}</div>
                     <div>
                       <h3 className="text-lg font-semibold text-gray-900">{activity.name}</h3>
-                      <p className="text-gray-600">{activity.description}</p>
+                      <MarkdownRenderer
+                        content={activity.description}
+                        className="text-gray-600"
+                      />
                     </div>
                   </div>
                   

--- a/src/pages/admin/EventManagement.tsx
+++ b/src/pages/admin/EventManagement.tsx
@@ -7,6 +7,7 @@ import { toast } from 'react-hot-toast';
 import EventForm from '../../components/admin/EventForm';
 import AnimationsManager from '../../components/admin/AnimationsManager';
 import EventActivitiesManager from '../../components/admin/EventActivitiesManager';
+import MarkdownRenderer from '../../components/MarkdownRenderer';
 import { debugLog } from '../../lib/logger';
 
 interface Event {
@@ -223,9 +224,10 @@ export default function EventManagement() {
                       </div>
                     </div>
                     
-                    <p className="text-gray-600 text-sm line-clamp-2">
-                      {event.key_info_content || 'Aucune information clé définie'}
-                    </p>
+                    <MarkdownRenderer
+                      content={event.key_info_content}
+                      className="text-gray-600 text-sm line-clamp-2"
+                    />
                   </div>
                   
                   <div className="flex items-center gap-2 ml-4">

--- a/src/pages/admin/PassManagement.tsx
+++ b/src/pages/admin/PassManagement.tsx
@@ -3,6 +3,7 @@ import { supabase, isSupabaseConfigured } from '../../lib/supabase';
 import { Ticket, Plus, Edit, Trash2, Euro, Package, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { getErrorMessage } from '../../lib/errors';
+import MarkdownRenderer from '../../components/MarkdownRenderer';
 
 interface Pass {
   id: string;
@@ -279,8 +280,11 @@ export default function PassManagement() {
                       <span className="text-2xl font-bold text-blue-600">{pass.price}€</span>
                     </div>
                     
-                    <p className="text-gray-600 mb-2">{pass.description}</p>
-                    
+                    <MarkdownRenderer
+                      content={pass.description}
+                      className="text-gray-600 mb-2"
+                    />
+
                     <div className="flex items-center gap-6 text-sm text-gray-500">
                       <div className="flex items-center gap-1">
                         <Package className="h-4 w-4" />


### PR DESCRIPTION
## Summary
- render Markdown content in admin lists via MarkdownRenderer
- handle empty content and sanitize HTML
- add test for MarkdownRenderer fallback

## Testing
- `npm run test:run` *(fails: TestingLibraryElementError and other errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ac8e2ad638832bbc309bf0930ac87c