### PR TITLE
feat: robust Supabase client and error reporting

### DIFF
--- a/src/components/AdminLogin.tsx
+++ b/src/components/AdminLogin.tsx
@@ -2,6 +2,8 @@ import React, { useState } from 'react';
 import { Lock, Mail, Eye, EyeOff } from 'lucide-react';
 import { signInWithEmail } from '../lib/auth';
 import type { User } from '../lib/auth';
+import { logger } from '../lib/logger';
+import { toast } from 'react-hot-toast';
 
 interface AdminLoginProps {
   onLogin: (user: User) => void;
@@ -31,7 +33,8 @@ export default function AdminLogin({ onLogin }: AdminLoginProps) {
         alert('Accès refusé. Seuls les administrateurs peuvent accéder au dashboard.');
       }
     } catch (err) {
-      console.error('Erreur connexion:', err);
+      logger.error('Erreur connexion', { error: err });
+      toast.error('Erreur de connexion');
     } finally {
       setLoading(false);
     }

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
+import { logger } from '../lib/logger';
+import { toast } from 'react-hot-toast';
 
 interface MarkdownRendererProps {
   content?: string;
@@ -22,7 +24,8 @@ export default function MarkdownRenderer({ content, className }: MarkdownRendere
       </div>
     );
   } catch (error) {
-    console.error('Erreur de rendu Markdown:', error);
+    logger.error('Erreur de rendu Markdown', { error });
+    toast.error("Erreur lors de l'affichage du contenu.");
     return <p className={className}>Erreur lors de l'affichage du contenu.</p>;
   }
 }

--- a/src/components/admin/EventActivitiesManager.tsx
+++ b/src/components/admin/EventActivitiesManager.tsx
@@ -5,6 +5,7 @@ import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
 import TimeSlotsManager from './TimeSlotsManager';
+import { logger } from '../../lib/logger';
 
 interface Activity {
   id: string;
@@ -95,7 +96,7 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
       if (activitiesError) throw activitiesError;
       setAvailableActivities(activitiesData || []);
     } catch (err) {
-      console.error('Erreur chargement données:', err);
+      logger.error('Erreur chargement données', { error: err });
       toast.error('Erreur lors du chargement');
     } finally {
       setLoading(false);
@@ -116,7 +117,7 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
       toast.success('Activité retirée de l\'événement');
       loadData();
     } catch (err) {
-      console.error('Erreur suppression activité:', err);
+      logger.error('Erreur suppression activité', { error: err });
       toast.error('Erreur lors de la suppression');
     }
   };
@@ -321,7 +322,7 @@ function AddActivityModal({ event, availableActivities, existingActivityIds, onC
       toast.success('Activité ajoutée à l\'événement');
       onSave();
     } catch (err) {
-      console.error('Erreur ajout activité:', err);
+      logger.error('Erreur ajout activité', { error: err });
       toast.error('Erreur lors de l\'ajout');
     } finally {
       setSaving(false);

--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { supabase } from '../../lib/supabase';
 import { toast } from 'react-hot-toast';
 import { X } from 'lucide-react';
-import { debugLog } from '../../lib/logger';
+import { logger, debugLog } from '../../lib/logger';
 import MarkdownEditor from './MarkdownEditor';
 import FAQEditor, { FAQFormItem } from './FAQEditor';
 import type { FAQItem } from '../FAQAccordion';
@@ -161,7 +161,7 @@ export default function EventForm({ event, onClose }: EventFormProps) {
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : JSON.stringify(err);
       debugLog('Erreur sauvegarde événement:', err);
-      console.error('Erreur sauvegarde événement:', err);
+      logger.error('Erreur sauvegarde événement', { error: err });
       toast.error(`Erreur lors de la sauvegarde de l'événement: ${message}`);
     } finally {
       setLoading(false);

--- a/src/components/admin/TimeSlotsManager.tsx
+++ b/src/components/admin/TimeSlotsManager.tsx
@@ -4,6 +4,7 @@ import { X, Plus, Trash2, Clock, Users, Calendar } from 'lucide-react';
 import { format, addMinutes, startOfDay } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
+import { logger } from '../../lib/logger';
 
 interface TimeSlot {
   id: string;
@@ -67,7 +68,7 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
 
       setTimeSlots(slotsWithCapacity);
     } catch (err) {
-      console.error('Erreur chargement créneaux:', err);
+      logger.error('Erreur chargement créneaux', { error: err });
       toast.error('Erreur lors du chargement des créneaux');
     } finally {
       setLoading(false);
@@ -88,7 +89,7 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
       toast.success('Créneau supprimé');
       loadTimeSlots();
     } catch (err) {
-      console.error('Erreur suppression créneau:', err);
+      logger.error('Erreur suppression créneau', { error: err });
       toast.error('Erreur lors de la suppression');
     }
   };
@@ -290,7 +291,7 @@ function CreateTimeSlotsForm({ eventActivity, event, onClose }: CreateTimeSlotsF
       toast.success(`${slotsToCreate.length} créneaux créés avec succès`);
       onClose();
     } catch (err) {
-      console.error('Erreur création créneaux:', err);
+      logger.error('Erreur création créneaux', { error: err });
       toast.error('Erreur lors de la création des créneaux');
     } finally {
       setCreating(false);

--- a/src/lib/__tests__/apiClient.test.ts
+++ b/src/lib/__tests__/apiClient.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { apiCall } from '../apiClient';
+import { logger } from '../logger';
+
+vi.mock('react-hot-toast', () => ({ toast: { error: vi.fn() } }));
+import { toast } from 'react-hot-toast';
+
+describe('apiCall', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('retries on failure and eventually succeeds', async () => {
+    const op = vi
+      .fn()
+      .mockResolvedValueOnce({ data: null, error: new Error('fail') })
+      .mockResolvedValueOnce({ data: 'ok', error: null });
+
+    const result = await apiCall(() => op(), 'def', 'test');
+    expect(op).toHaveBeenCalledTimes(2);
+    expect(result).toBe('ok');
+  });
+
+  it('returns default value after retries', async () => {
+    const op = vi.fn().mockResolvedValue({ data: null, error: new Error('fail') });
+    const spy = vi.spyOn(logger, 'error');
+    const result = await apiCall(() => op(), 'def', 'test');
+    expect(op).toHaveBeenCalledTimes(3);
+    expect(result).toBe('def');
+    expect(spy).toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+  });
+
+  it('handles offline scenario', async () => {
+    Object.defineProperty(navigator, 'onLine', { value: false, configurable: true });
+    const op = vi.fn();
+    const result = await apiCall(() => op(), [], 'offline');
+    expect(op).not.toHaveBeenCalled();
+    expect(result).toEqual([]);
+    expect(toast.error).toHaveBeenCalled();
+    Object.defineProperty(navigator, 'onLine', { value: true, configurable: true });
+  });
+});

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,52 @@
+import { logger } from './logger';
+import { supabase } from './supabase';
+import { toast } from 'react-hot-toast';
+
+const MAX_RETRIES = 3;
+const BASE_DELAY = 500;
+
+function wait(ms: number) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isOnline(): boolean {
+  return typeof navigator === 'undefined' ? true : navigator.onLine;
+}
+
+export async function apiCall<T>(
+  operation: () => Promise<{ data: T; error: unknown }>,
+  defaultValue: T,
+  context: string
+): Promise<T> {
+  if (!isOnline()) {
+    const message = 'Aucune connexion réseau';
+    logger.error(message, { context });
+    toast.error(message);
+    return defaultValue;
+  }
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const { data, error } = await operation();
+      if (error) throw error;
+      return data ?? defaultValue;
+    } catch (error) {
+      logger.error('Supabase request failed', { context, error, attempt: attempt + 1 });
+      if (attempt < MAX_RETRIES - 1 && isOnline()) {
+        await wait(BASE_DELAY * 2 ** attempt);
+        continue;
+      }
+      toast.error('Une erreur est survenue');
+      return defaultValue;
+    }
+  }
+
+  return defaultValue;
+}
+
+export const apiClient = {
+  from: <T extends string>(table: T) => supabase.from(table),
+  call: apiCall,
+};
+
+export type { SupabaseClient } from '@supabase/supabase-js';

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -8,6 +8,7 @@ import { ShoppingCart, Trash2, ArrowLeft, CreditCard, CheckSquare, Square } from
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
+import { logger } from '../lib/logger';
 
 export default function Cart() {
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
@@ -28,7 +29,7 @@ export default function Cart() {
       const items = await getCartItems();
       setCartItems(items);
     } catch (err) {
-      console.error('Erreur chargement panier:', err);
+      logger.error('Erreur chargement panier', { error: err });
       toast.error('Erreur lors du chargement du panier');
     } finally {
       setLoading(false);
@@ -128,7 +129,7 @@ export default function Cart() {
       toast.success('Paiement réussi ! Réservation confirmée.');
       
     } catch (err) {
-      console.error('Erreur lors du paiement:', err);
+      logger.error('Erreur lors du paiement', { error: err });
       toast.error('Erreur lors du paiement. Veuillez réessayer.');
     } finally {
       setProcessingPayment(false);

--- a/src/pages/EventCGV.tsx
+++ b/src/pages/EventCGV.tsx
@@ -3,6 +3,8 @@ import { useParams, Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, FileText } from 'lucide-react';
 import MarkdownRenderer from '../components/MarkdownRenderer';
+import { logger } from '../lib/logger';
+import { toast } from 'react-hot-toast';
 
 interface Event {
   id: string;
@@ -35,7 +37,8 @@ export default function EventCGV() {
       if (error) throw error;
       setEvent(data);
     } catch (err) {
-      console.error('Erreur chargement CGV:', err);
+      logger.error('Erreur chargement CGV', { error: err });
+      toast.error('Erreur lors du chargement des CGV');
     } finally {
       setLoading(false);
     }

--- a/src/pages/EventDetails.tsx
+++ b/src/pages/EventDetails.tsx
@@ -6,6 +6,8 @@ import { Calendar, Users, Euro, Info, Clock, Target, Plus, Minus } from 'lucide-
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import MarkdownRenderer from '../components/MarkdownRenderer';
+import { toast } from 'react-hot-toast';
+import { logger } from '../lib/logger';
 
 interface Event {
   id: string;
@@ -138,7 +140,8 @@ export default function EventDetails() {
       
       setEventActivities(activitiesWithStock);
     } catch (err) {
-      console.error('Erreur chargement événement:', err);
+      logger.error('Erreur chargement événement', { error: err });
+      toast.error("Erreur lors du chargement de l'événement");
     } finally {
       setLoading(false);
     }
@@ -182,7 +185,8 @@ export default function EventDetails() {
       
       return slotsWithCapacity;
     } catch (err) {
-      console.error('Erreur chargement créneaux pour l\'activité:', err);
+      logger.error("Erreur chargement créneaux pour l'activité", { error: err });
+      toast.error('Erreur lors du chargement des créneaux');
       return [];
     }
   };
@@ -385,7 +389,8 @@ function PurchaseModal({
         [eventActivityId]: slotsWithCapacity
       }));
     } catch (err) {
-      console.error('Erreur chargement créneaux:', err);
+      logger.error('Erreur chargement créneaux', { error: err });
+      toast.error('Erreur lors du chargement des créneaux');
     }
   };
   

--- a/src/pages/EventFAQ.tsx
+++ b/src/pages/EventFAQ.tsx
@@ -3,6 +3,8 @@ import { useParams, Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, HelpCircle } from 'lucide-react';
 import FAQAccordion, { FAQItem } from '../components/FAQAccordion';
+import { logger } from '../lib/logger';
+import { toast } from 'react-hot-toast';
 
 interface Event {
   id: string;
@@ -43,7 +45,8 @@ export default function EventFAQ() {
       if (faqError) throw faqError;
       setFaqs(faqData || []);
     } catch (err) {
-      console.error('Erreur chargement FAQ:', err);
+      logger.error('Erreur chargement FAQ', { error: err });
+      toast.error('Erreur lors du chargement de la FAQ');
     } finally {
       setLoading(false);
     }

--- a/src/pages/FindTicket.tsx
+++ b/src/pages/FindTicket.tsx
@@ -3,6 +3,7 @@ import { Search, Mail, Shield, CheckCircle } from 'lucide-react';
 import { supabase } from '../lib/supabase';
 import { sendReservationEmail } from '../lib/sendReservationEmail';
 import { toast } from 'react-hot-toast';
+import { logger } from '../lib/logger';
 
 export default function FindTicket() {
   const [email, setEmail] = useState('');
@@ -47,7 +48,7 @@ export default function FindTicket() {
         toast.error('Aucune réservation trouvée pour cette adresse e-mail');
       }
     } catch (err) {
-      console.error('Erreur recherche billet:', err);
+      logger.error('Erreur recherche billet', { error: err });
       toast.error('Une erreur est survenue lors de la recherche');
     } finally {
       setLoading(false);

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { supabase, isSupabaseConfigured } from '../lib/supabase';
 import EventCard from '../components/EventCard';
 import { Calendar, Loader2 } from 'lucide-react';
+import { logger } from '../lib/logger';
+import { toast } from 'react-hot-toast';
 
 interface Event {
   id: string;
@@ -44,7 +46,8 @@ export default function Home() {
 
       setEvents(data || []);
     } catch (err) {
-      console.error('Erreur lors du chargement des événements:', err);
+      logger.error('Erreur lors du chargement des événements', { error: err });
+      toast.error('Impossible de charger les événements');
       setError('Impossible de charger les événements');
     } finally {
       setLoading(false);

--- a/src/pages/admin/ActivityManagement.tsx
+++ b/src/pages/admin/ActivityManagement.tsx
@@ -4,6 +4,7 @@ import { Activity, Plus, Edit, Trash2, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import MarkdownRenderer from '../../components/MarkdownRenderer';
 import MarkdownEditor from '../../components/admin/MarkdownEditor';
+import { logger } from '../../lib/logger';
 
 interface ActivityType {
   id: string;
@@ -34,7 +35,7 @@ export default function ActivityManagement() {
       if (error) throw error;
       setActivities(data || []);
     } catch (err) {
-      console.error('Erreur chargement activités:', err);
+      logger.error('Erreur chargement activités', { error: err });
       toast.error('Erreur lors du chargement des activités');
     } finally {
       setLoading(false);
@@ -55,7 +56,7 @@ export default function ActivityManagement() {
       toast.success('Activité supprimée avec succès');
       loadActivities();
     } catch (err) {
-      console.error('Erreur suppression activité:', err);
+      logger.error('Erreur suppression activité', { error: err });
       toast.error('Erreur lors de la suppression');
     }
   };
@@ -227,7 +228,7 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
       
       onSave();
     } catch (err) {
-      console.error('Erreur sauvegarde activité:', err);
+      logger.error('Erreur sauvegarde activité', { error: err });
       toast.error('Erreur lors de la sauvegarde');
     } finally {
       setSaving(false);

--- a/src/pages/admin/AdminLayout.tsx
+++ b/src/pages/admin/AdminLayout.tsx
@@ -17,6 +17,8 @@ import {
 import AdminLogin from '../../components/AdminLogin';
 import { getCurrentUser, signOut } from '../../lib/auth';
 import type { User } from '../../lib/auth';
+import { logger } from '../../lib/logger';
+import { toast } from 'react-hot-toast';
 
 export default function AdminLayout() {
   const location = useLocation();
@@ -32,7 +34,8 @@ export default function AdminLayout() {
       const currentUser = await getCurrentUser();
       setUser(currentUser);
     } catch (err) {
-      console.error('Erreur vérification auth:', err);
+      logger.error('Erreur vérification auth', { error: err });
+      toast.error('Erreur lors de la vérification des permissions');
     } finally {
       setLoading(false);
     }

--- a/src/pages/admin/Communication.tsx
+++ b/src/pages/admin/Communication.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Mail, Send, Users, Calendar, FileText, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
+import { logger } from '../../lib/logger';
 
 interface Event {
   id: string;
@@ -104,7 +105,7 @@ L'équipe BilletEvent`
       if (error) throw error;
       setEvents(data || []);
     } catch (err) {
-      console.error('Erreur chargement événements:', err);
+      logger.error('Erreur chargement événements', { error: err });
       toast.error('Erreur lors du chargement des événements');
     }
   };
@@ -128,7 +129,8 @@ L'équipe BilletEvent`
       const uniqueEmails = new Set((data || []).map(r => r.client_email));
       setRecipientCount(uniqueEmails.size);
     } catch (err) {
-      console.error('Erreur comptage destinataires:', err);
+      logger.error('Erreur comptage destinataires', { error: err });
+      toast.error('Erreur lors du comptage des destinataires');
       setRecipientCount(0);
     }
   };
@@ -158,7 +160,7 @@ L'équipe BilletEvent`
       setSelectedEvent('');
       setRecipientCount(0);
     } catch (err) {
-      console.error('Erreur envoi email:', err);
+      logger.error('Erreur envoi email', { error: err });
       toast.error('Erreur lors de l\'envoi');
     } finally {
       setSending(false);

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -2,6 +2,8 @@ import React, { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { Calendar, Users, Euro, TrendingUp, Activity } from 'lucide-react';
+import { logger } from '../../lib/logger';
+import { toast } from 'react-hot-toast';
 
 interface DashboardStats {
   totalEvents: number;
@@ -69,7 +71,8 @@ export default function AdminDashboard() {
         activeEvents: activeEventCount || 0
       });
     } catch (err) {
-      console.error('Erreur chargement statistiques:', err);
+      logger.error('Erreur chargement statistiques', { error: err });
+      toast.error('Erreur lors du chargement des statistiques');
     } finally {
       setLoading(false);
     }

--- a/src/pages/admin/EventManagement.tsx
+++ b/src/pages/admin/EventManagement.tsx
@@ -8,7 +8,7 @@ import EventForm from '../../components/admin/EventForm';
 import AnimationsManager from '../../components/admin/AnimationsManager';
 import EventActivitiesManager from '../../components/admin/EventActivitiesManager';
 import MarkdownRenderer from '../../components/MarkdownRenderer';
-import { debugLog } from '../../lib/logger';
+import { logger, debugLog } from '../../lib/logger';
 import type { FAQItem } from '../../components/FAQAccordion';
 
 interface Event {
@@ -77,7 +77,7 @@ export default function EventManagement() {
       debugLog('🔧 EventManagement Events loaded with has_animations:', eventsWithFaqs.map(e => ({ id: e.id, name: e.name, has_animations: e.has_animations })));
       setEvents(eventsWithFaqs);
     } catch (err) {
-      console.error('Erreur chargement événements:', err);
+      logger.error('Erreur chargement événements', { error: err });
       toast.error('Erreur lors du chargement des événements');
     } finally {
       setLoading(false);
@@ -98,7 +98,7 @@ export default function EventManagement() {
       toast.success('Événement supprimé avec succès');
       loadEvents();
     } catch (err) {
-      console.error('Erreur suppression événement:', err);
+      logger.error('Erreur suppression événement', { error: err });
       toast.error('Erreur lors de la suppression');
     }
   };

--- a/src/pages/admin/FlowManagement.tsx
+++ b/src/pages/admin/FlowManagement.tsx
@@ -4,6 +4,7 @@ import { Users, Clock, Calendar, Download, Mail, CheckCircle, AlertCircle } from
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
+import { logger } from '../../lib/logger';
 
 interface TimeSlotWithReservations {
   id: string;
@@ -73,7 +74,7 @@ export default function FlowManagement() {
         setSelectedDate(format(new Date(data[0].event_date), 'yyyy-MM-dd'));
       }
     } catch (err) {
-      console.error('Erreur chargement événements:', err);
+      logger.error('Erreur chargement événements', { error: err });
       toast.error('Erreur lors du chargement des événements');
     } finally {
       setLoading(false);
@@ -144,7 +145,7 @@ export default function FlowManagement() {
 
       setTimeSlots(slotsWithCapacity);
     } catch (err) {
-      console.error('Erreur chargement créneaux:', err);
+      logger.error('Erreur chargement créneaux', { error: err });
       toast.error('Erreur lors du chargement des créneaux');
     } finally {
       setLoading(false);

--- a/src/pages/admin/PassManagement.tsx
+++ b/src/pages/admin/PassManagement.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-hot-toast';
 import { getErrorMessage } from '../../lib/errors';
 import MarkdownRenderer from '../../components/MarkdownRenderer';
 import MarkdownEditor from '../../components/admin/MarkdownEditor';
+import { logger } from '../../lib/logger';
 
 interface Pass {
   id: string;
@@ -53,7 +54,7 @@ export default function PassManagement() {
       
       // Check if Supabase is properly configured
       if (!isSupabaseConfigured()) {
-        console.error('Supabase is not configured');
+        logger.error('Supabase is not configured');
         toast.error('Configuration Supabase manquante. Veuillez configurer la base de données.');
         setLoading(false);
         return;
@@ -161,7 +162,7 @@ export default function PassManagement() {
       if (eventsError) throw eventsError;
       setEvents(eventsData || []);
     } catch (err) {
-      console.error('Erreur chargement pass:', err);
+      logger.error('Erreur chargement pass', { error: err });
       toast.error('Erreur lors du chargement des pass');
     } finally {
       setLoading(false);
@@ -194,7 +195,7 @@ export default function PassManagement() {
       console.log('Réponse Supabase:', { data, error, count });
       
       if (error) {
-        console.error('Erreur Supabase lors de la suppression:', error);
+        logger.error('Erreur Supabase lors de la suppression', { error });
         throw error;
       }
       
@@ -209,7 +210,7 @@ export default function PassManagement() {
       toast.success('Pass supprimé avec succès');
       await loadData();
     } catch (err) {
-      console.error('Erreur suppression pass:', err);
+      logger.error('Erreur suppression pass', { error: err });
       toast.error(`Erreur lors de la suppression: ${getErrorMessage(err) || 'Erreur inconnue'}`);
     }
   };
@@ -457,7 +458,8 @@ function PassFormModal({ pass, events, onClose, onSave }: PassFormModalProps) {
       });
       setActivityStocks(stocksMap);
     } catch (err) {
-      console.error('Erreur chargement activités:', err);
+      logger.error('Erreur chargement activités', { error: err });
+      toast.error('Erreur lors du chargement des activités');
     }
   };
 
@@ -533,7 +535,7 @@ function PassFormModal({ pass, events, onClose, onSave }: PassFormModalProps) {
       
       onSave();
     } catch (err) {
-      console.error('Erreur sauvegarde pass:', err);
+      logger.error('Erreur sauvegarde pass', { error: err });
       toast.error('Erreur lors de la sauvegarde');
     } finally {
       setSaving(false);

--- a/src/pages/admin/Reports.tsx
+++ b/src/pages/admin/Reports.tsx
@@ -5,6 +5,7 @@ import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContaine
 import { format, startOfMonth, endOfMonth, eachDayOfInterval, subMonths } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
+import { logger } from '../../lib/logger';
 
 interface ReportData {
   totalRevenue: number;
@@ -129,7 +130,7 @@ export default function Reports() {
         activityStats
       });
     } catch (err) {
-      console.error('Erreur chargement rapports:', err);
+      logger.error('Erreur chargement rapports', { error: err });
       toast.error('Erreur lors du chargement des rapports');
     } finally {
       setLoading(false);

--- a/src/pages/admin/ReservationManagement.tsx
+++ b/src/pages/admin/ReservationManagement.tsx
@@ -4,6 +4,7 @@ import { Users, Search, Download, Filter, Mail } from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
+import { logger } from '../../lib/logger';
 
 interface Reservation {
   id: string;
@@ -70,7 +71,7 @@ export default function ReservationManagement() {
       if (error) throw error;
       setReservations(data || []);
     } catch (err) {
-      console.error('Erreur chargement réservations:', err);
+      logger.error('Erreur chargement réservations', { error: err });
       toast.error('Erreur lors du chargement des réservations');
     } finally {
       setLoading(false);

--- a/src/pages/admin/Settings.tsx
+++ b/src/pages/admin/Settings.tsx
@@ -4,6 +4,7 @@ import { Settings as SettingsIcon, Save, User, Mail, Shield, Database, Globe, Be
 import { toast } from 'react-hot-toast';
 import { getCurrentUser } from '../../lib/auth';
 import type { User as AuthUser } from '../../lib/auth';
+import { logger } from '../../lib/logger';
 
 interface SystemSettings {
   site_name: string;
@@ -46,7 +47,7 @@ export default function Settings() {
         setSettings(JSON.parse(savedSettings));
       }
     } catch (err) {
-      console.error('Erreur chargement paramètres:', err);
+      logger.error('Erreur chargement paramètres', { error: err });
       toast.error('Erreur lors du chargement des paramètres');
     } finally {
       setLoading(false);
@@ -63,7 +64,7 @@ export default function Settings() {
       
       toast.success('Paramètres sauvegardés avec succès');
     } catch (err) {
-      console.error('Erreur sauvegarde paramètres:', err);
+      logger.error('Erreur sauvegarde paramètres', { error: err });
       toast.error('Erreur lors de la sauvegarde');
     } finally {
       setSaving(false);
@@ -92,7 +93,7 @@ export default function Settings() {
       
       toast.success('Base de données réinitialisée avec succès');
     } catch (err) {
-      console.error('Erreur réinitialisation:', err);
+      logger.error('Erreur réinitialisation', { error: err });
       toast.error('Erreur lors de la réinitialisation');
     } finally {
       setSaving(false);

--- a/src/pages/admin/TimeSlotManagement.tsx
+++ b/src/pages/admin/TimeSlotManagement.tsx
@@ -4,6 +4,7 @@ import { Calendar, Clock, Users, Filter, Eye, BarChart3, AlertCircle } from 'luc
 import { format, startOfDay, endOfDay, eachHourOfInterval, isSameHour } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
+import { logger } from '../../lib/logger';
 
 interface Event {
   id: string;
@@ -69,7 +70,7 @@ export default function TimeSlotManagement() {
         setSelectedDate(format(new Date(data[0].event_date), 'yyyy-MM-dd'));
       }
     } catch (err) {
-      console.error('Erreur chargement événements:', err);
+      logger.error('Erreur chargement événements', { error: err });
       toast.error('Erreur lors du chargement des événements');
     } finally {
       setLoading(false);
@@ -133,7 +134,7 @@ export default function TimeSlotManagement() {
 
       setTimeSlots(slotsWithDetails);
     } catch (err) {
-      console.error('Erreur chargement créneaux:', err);
+      logger.error('Erreur chargement créneaux', { error: err });
       toast.error('Erreur lors du chargement des créneaux');
     } finally {
       setLoading(false);


### PR DESCRIPTION
## Summary
- add apiClient wrapper for Supabase with retry, offline detection and default fallbacks
- replace console.error with logger.error and toast notifications across UI
- test apiClient behaviour under network issues

## Testing
- `npm test` *(fails: 10 failed | 15 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68acca1a0e48832bb2c38f3efbd2ec40