### PR TITLE
feat: add event details hook and tests

### DIFF
--- a/src/hooks/useEventDetails.ts
+++ b/src/hooks/useEventDetails.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useState } from 'react';
+import { isSupabaseConfigured } from '../lib/supabase';
+import {
+  Event,
+  Pass,
+  EventActivity,
+  TimeSlot,
+  fetchEvent,
+  fetchPasses,
+  fetchEventActivities,
+  fetchTimeSlots,
+} from '../lib/eventDetails';
+
+interface UseEventDetailsResult {
+  event: Event | null;
+  passes: Pass[];
+  eventActivities: EventActivity[];
+  loading: boolean;
+  error: string | null;
+  loadTimeSlotsForActivity: (eventActivityId: string) => Promise<TimeSlot[]>;
+  refresh: () => Promise<void>;
+}
+
+export function useEventDetails(eventId?: string): UseEventDetailsResult {
+  const [event, setEvent] = useState<Event | null>(null);
+  const [passes, setPasses] = useState<Pass[]>([]);
+  const [eventActivities, setEventActivities] = useState<EventActivity[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadTimeSlotsForActivity = useCallback(async (eventActivityId: string) => {
+    try {
+      return await fetchTimeSlots(eventActivityId);
+    } catch (err) {
+      console.error('Erreur chargement créneaux pour l\'activité:', err);
+      setError('Erreur lors du chargement des créneaux');
+      return [];
+    }
+  }, []);
+
+  const load = useCallback(async () => {
+    if (!eventId || !isSupabaseConfigured()) {
+      setLoading(false);
+      return;
+    }
+    try {
+      setLoading(true);
+      const [evt, passesData, activitiesData] = await Promise.all([
+        fetchEvent(eventId),
+        fetchPasses(eventId),
+        fetchEventActivities(eventId),
+      ]);
+      setEvent(evt);
+      setPasses(passesData);
+      setEventActivities(activitiesData);
+      setError(null);
+    } catch (err) {
+      console.error('Erreur chargement événement:', err);
+      setError('Erreur lors du chargement de l\'événement');
+    } finally {
+      setLoading(false);
+    }
+  }, [eventId]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return {
+    event,
+    passes,
+    eventActivities,
+    loading,
+    error,
+    loadTimeSlotsForActivity,
+    refresh: load,
+  };
+}
+
+export default useEventDetails;

--- a/src/lib/eventDetails.ts
+++ b/src/lib/eventDetails.ts
@@ -1,0 +1,142 @@
+import { supabase } from './supabase';
+
+export interface Event {
+  id: string;
+  name: string;
+  event_date: string;
+  key_info_content: string;
+}
+
+export interface Pass {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  initial_stock: number | null;
+  remaining_stock?: number;
+}
+
+export interface Activity {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+}
+
+export interface EventActivity {
+  id: string;
+  activity_id: string;
+  stock_limit: number | null;
+  requires_time_slot: boolean;
+  remaining_stock?: number;
+  activity: Activity;
+}
+
+export interface TimeSlot {
+  id: string;
+  event_activity_id: string;
+  slot_time: string;
+  capacity: number;
+  remaining_capacity?: number;
+  event_activity: EventActivity;
+}
+
+export async function fetchEvent(eventId: string): Promise<Event> {
+  const { data, error } = await supabase
+    .from('events')
+    .select('id, name, event_date, key_info_content')
+    .eq('id', eventId)
+    .eq('status', 'published')
+    .single();
+
+  if (error) throw error;
+  return data as Event;
+}
+
+export async function fetchPasses(eventId: string): Promise<Pass[]> {
+  const { data, error } = await supabase
+    .from('passes')
+    .select('id, name, price, description, initial_stock')
+    .eq('event_id', eventId);
+
+  if (error) throw error;
+
+  const passesWithStock = await Promise.all(
+    (data || []).map(async (pass) => {
+      if (pass.initial_stock === null) {
+        return { ...pass, remaining_stock: 999999 };
+      }
+
+      const { data: stockData } = await supabase
+        .rpc('get_pass_remaining_stock', { pass_uuid: pass.id });
+
+      return { ...pass, remaining_stock: stockData || 0 };
+    })
+  );
+
+  return passesWithStock as Pass[];
+}
+
+export async function fetchEventActivities(eventId: string): Promise<EventActivity[]> {
+  const { data, error } = await supabase
+    .from('event_activities')
+    .select(`
+      *,
+      activities (*)
+    `)
+    .eq('event_id', eventId);
+
+  if (error) throw error;
+
+  const activitiesWithStock = await Promise.all(
+    (data || []).map(async (eventActivity: any) => {
+      const { data: stockData } = await supabase
+        .rpc('get_event_activity_remaining_stock', { event_activity_id_param: eventActivity.id });
+
+      return {
+        ...eventActivity,
+        activity: eventActivity.activities,
+        remaining_stock: stockData || 0
+      };
+    })
+  );
+
+  return activitiesWithStock as EventActivity[];
+}
+
+export async function fetchTimeSlots(eventActivityId: string): Promise<TimeSlot[]> {
+  const { data, error } = await supabase
+    .from('time_slots')
+    .select(`
+      id,
+      slot_time,
+      capacity,
+      event_activities!inner (
+        *,
+        activities (*)
+      )
+    `)
+    .eq('event_activity_id', eventActivityId)
+    .gte('slot_time', new Date().toISOString())
+    .order('slot_time');
+
+  if (error) throw error;
+
+  const slotsWithCapacity = await Promise.all(
+    (data || []).map(async (slot: any) => {
+      const { data: capacityData } = await supabase
+        .rpc('get_slot_remaining_capacity', { slot_uuid: slot.id });
+
+      return {
+        ...slot,
+        remaining_capacity: capacityData || 0,
+        event_activity: {
+          ...slot.event_activities,
+          activity: slot.event_activities.activities
+        }
+      };
+    })
+  );
+
+  return slotsWithCapacity as TimeSlot[];
+}

--- a/src/pages/__tests__/EventDetails.test.tsx
+++ b/src/pages/__tests__/EventDetails.test.tsx
@@ -1,70 +1,72 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '../../test/utils';
+import { render, screen } from '../../test/utils';
 import EventDetails from '../EventDetails';
+import useEventDetails from '../../hooks/useEventDetails';
 
-// Mock router params
+vi.mock('../../hooks/useEventDetails');
+
 vi.mock('react-router-dom', async () => {
   const actual = await vi.importActual('react-router-dom');
   return { ...actual, useParams: () => ({ eventId: 'test-event-id' }) };
 });
 
-// Mock the supabase calls
-vi.mock('../../lib/supabase', () => ({
-  supabase: {
-    from: vi.fn((table: string) => {
-      if (table === 'events') {
-        return {
-          select: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                single: vi.fn(() => Promise.resolve({
-                  data: {
-                    id: 'test-event-id',
-                    name: 'Test Event',
-                    event_date: '2024-12-25',
-                    key_info_content: 'Test information'
-                  },
-                  error: null
-                }))
-              }))
-            }))
-          }))
-        };
-      }
-      return {
-        select: vi.fn(() => ({
-          eq: vi.fn(() => ({
-            order: vi.fn(() => Promise.resolve({ data: [], error: null }))
-          }))
-        }))
-      };
-    }),
-    rpc: vi.fn(() => Promise.resolve({ data: 10, error: null }))
-  },
-  isSupabaseConfigured: vi.fn(() => true)
-}));
-
 describe('EventDetails Page', () => {
-  it('should render event information when loaded', async () => {
-    render(<EventDetails />);
-    
-    await waitFor(() => {
-      expect(screen.getByText('Test Event')).toBeInTheDocument();
-      expect(screen.getByText('Test information')).toBeInTheDocument();
+  it('should render event information when loaded', () => {
+    (useEventDetails as unknown as any).mockReturnValue({
+      event: {
+        id: 'test-event-id',
+        name: 'Test Event',
+        event_date: '2024-12-25',
+        key_info_content: 'Test information',
+      },
+      passes: [],
+      eventActivities: [],
+      loading: false,
+      error: null,
+      loadTimeSlotsForActivity: vi.fn(),
+      refresh: vi.fn(),
     });
+
+    render(<EventDetails />);
+
+    expect(screen.getByText('Test Event')).toBeInTheDocument();
+    expect(screen.getByText('Test information')).toBeInTheDocument();
   });
 
-  it('should show loading state initially', () => {
+  it('should show loading state when loading', () => {
+    (useEventDetails as unknown as any).mockReturnValue({
+      event: null,
+      passes: [],
+      eventActivities: [],
+      loading: true,
+      error: null,
+      loadTimeSlotsForActivity: vi.fn(),
+      refresh: vi.fn(),
+    });
+
     render(<EventDetails />);
-    
+
     expect(screen.getByText(/chargement de l'événement/i)).toBeInTheDocument();
   });
 
-  it('should render passes section', async () => {
-    render(<EventDetails />);
-    
-    await waitFor(() => {
-      expect(screen.getByText(/nos pass/i)).toBeInTheDocument();
+  it('should render passes section', () => {
+    (useEventDetails as unknown as any).mockReturnValue({
+      event: {
+        id: 'test-event-id',
+        name: 'Test Event',
+        event_date: '2024-12-25',
+        key_info_content: 'Info',
+      },
+      passes: [],
+      eventActivities: [],
+      loading: false,
+      error: null,
+      loadTimeSlotsForActivity: vi.fn(),
+      refresh: vi.fn(),
     });
+
+    render(<EventDetails />);
+
+    expect(screen.getByText(/nos pass/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- add service functions to load event, pass, activity, and time slot data
- create `useEventDetails` hook aggregating event data and expose refresh helper
- refactor `EventDetails` page to focus on display
- test `useEventDetails` aggregation and error paths

## Testing
- `npm test` *(fails: 12 failed, 53 passed)*
- `npx vitest run src/hooks/__tests__/useEventDetails.test.ts src/pages/__tests__/EventDetails.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acca37f3b0832b8263c11b449b92be