### PR TITLE
Add tests for EventFAQ page states

### DIFF
--- a/src/pages/EventFAQ.tsx
+++ b/src/pages/EventFAQ.tsx
@@ -1,12 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, HelpCircle } from 'lucide-react';
 import FAQAccordion from '../components/FAQAccordion';
 import { useFaq } from '../hooks/useFaq';
+import { toast } from 'react-hot-toast';
 
 export default function EventFAQ() {
   const { eventId } = useParams<{ eventId: string }>();
-  const { event, faqs, loading } = useFaq(eventId);
+  const { event, faqs, loading, error } = useFaq(eventId) as any;
+
+  useEffect(() => {
+    if (error) {
+      toast.error('Erreur lors du chargement de la FAQ');
+    }
+  }, [error]);
 
   if (loading) {
     return (

--- a/src/pages/__tests__/EventFAQ.test.tsx
+++ b/src/pages/__tests__/EventFAQ.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '../../test/utils';
+import EventFAQ from '../EventFAQ';
+import { useFaq } from '../../hooks/useFaq';
+import { toast } from 'react-hot-toast';
+
+vi.mock('../../hooks/useFaq');
+
+describe('EventFAQ Page', () => {
+  it('shows spinner and loading text when loading', () => {
+    (useFaq as unknown as any).mockReturnValue({ event: null, faqs: [], loading: true });
+
+    const { container } = render(<EventFAQ />);
+
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+    expect(screen.getByText(/chargement de la faq/i)).toBeInTheDocument();
+  });
+
+  it('shows not found message when no event', () => {
+    (useFaq as unknown as any).mockReturnValue({ event: null, faqs: [], loading: false });
+
+    render(<EventFAQ />);
+
+    expect(screen.getByText(/faq introuvable/i)).toBeInTheDocument();
+  });
+
+  it('renders event name and FAQ content', () => {
+    (useFaq as unknown as any).mockReturnValue({
+      event: { id: '1', name: 'Event' },
+      faqs: [{ question: 'Q', answer: 'A' }],
+      loading: false,
+    });
+
+    render(<EventFAQ />);
+
+    expect(screen.getByText('Event')).toBeInTheDocument();
+    const question = screen.getByText('Q');
+    expect(question).toBeInTheDocument();
+    fireEvent.click(question);
+    expect(screen.getByText('A')).toBeInTheDocument();
+  });
+
+  it('displays error toast when request fails', async () => {
+    (useFaq as unknown as any).mockReturnValue({
+      event: null,
+      faqs: [],
+      loading: false,
+      error: new Error('network'),
+    });
+
+    render(<EventFAQ />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for EventFAQ page covering loading, missing FAQ, successful render, and error scenarios
- show toast notification when FAQ loading fails

## Testing
- `npm test src/pages/__tests__/EventFAQ.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68acd3113438832bbf13e1225090b1f1