### PR TITLE
Handle FAQ fetch errors in EventFAQ

### DIFF
--- a/src/hooks/useFaq.ts
+++ b/src/hooks/useFaq.ts
@@ -5,17 +5,29 @@ export function useFaq(eventId?: string) {
   const [event, setEvent] = useState<Event | null>(null);
   const [faqs, setFaqs] = useState<FAQItem[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
 
   useEffect(() => {
     if (!eventId) return;
     setLoading(true);
-    fetchEventFaq(eventId)
-      .then(({ event, faqs }) => {
+    setError(null);
+
+    const loadFaq = async () => {
+      try {
+        const { event, faqs } = await fetchEventFaq(eventId);
         setEvent(event);
         setFaqs(faqs);
-      })
-      .finally(() => setLoading(false));
+      } catch (err) {
+        setError(err as Error);
+        setEvent(null);
+        setFaqs([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadFaq();
   }, [eventId]);
 
-  return { event, faqs, loading };
+  return { event, faqs, loading, error };
 }

--- a/src/pages/EventFAQ.tsx
+++ b/src/pages/EventFAQ.tsx
@@ -1,12 +1,19 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, HelpCircle } from 'lucide-react';
 import FAQAccordion from '../components/FAQAccordion';
 import { useFaq } from '../hooks/useFaq';
+import { toast } from 'react-hot-toast';
 
 export default function EventFAQ() {
   const { eventId } = useParams<{ eventId: string }>();
-  const { event, faqs, loading } = useFaq(eventId);
+  const { event, faqs, loading, error } = useFaq(eventId);
+
+  useEffect(() => {
+    if (error) {
+      toast.error('Erreur lors du chargement de la FAQ');
+    }
+  }, [error]);
 
   if (loading) {
     return (

--- a/src/pages/__tests__/EventFAQ.test.tsx
+++ b/src/pages/__tests__/EventFAQ.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '../../test/utils';
+import { toast } from 'react-hot-toast';
+
+vi.mock('../../hooks/useFaq', () => ({
+  useFaq: vi.fn(),
+}));
+
+import EventFAQ from '../EventFAQ';
+import { useFaq } from '../../hooks/useFaq';
+
+const mockedUseFaq = vi.mocked(useFaq);
+
+describe('EventFAQ Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should display FAQ when loaded', () => {
+    mockedUseFaq.mockReturnValue({
+      event: { id: '1', name: 'Test Event' },
+      faqs: [],
+      loading: false,
+      error: null,
+    });
+
+    render(<EventFAQ />);
+
+    expect(screen.getByText('Test Event')).toBeInTheDocument();
+  });
+
+  it('should show error message when loading fails', async () => {
+    mockedUseFaq.mockReturnValue({
+      event: null,
+      faqs: [],
+      loading: false,
+      error: new Error('fail'),
+    });
+
+    render(<EventFAQ />);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Erreur lors du chargement de la FAQ');
+    });
+    expect(screen.getByText(/FAQ introuvable/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add error state and try/catch in `useFaq`
- surface load errors with toast in `EventFAQ`
- test FAQ page error handling

## Testing
- `npm test` *(fails: 10 failed, 20 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68acd32a7ef0832b8e3d4e700d984874