### PR TITLE
test: add EventCGV page tests

### DIFF
--- a/src/pages/__tests__/EventCGV.test.tsx
+++ b/src/pages/__tests__/EventCGV.test.tsx
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen } from '../../test/utils';
+import { toast } from 'react-hot-toast';
+import EventCGV from '../EventCGV';
+import { supabase } from '../../lib/supabase';
+
+const mockFrom = supabase.from as unknown as vi.Mock;
+
+const createQueryBuilder = () => {
+  const single = vi.fn();
+  const builder = {
+    select: vi.fn(() => builder),
+    eq: vi.fn(() => builder),
+    single,
+  };
+  return { builder, single };
+};
+
+describe('EventCGV Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    mockFrom.mockReset();
+  });
+
+  it('shows loading spinner while fetching CGV', () => {
+    const { builder, single } = createQueryBuilder();
+    single.mockReturnValue(new Promise(() => {}));
+    mockFrom.mockReturnValue(builder);
+
+    render(<EventCGV />);
+
+    expect(screen.getByText(/chargement des cgv/i)).toBeInTheDocument();
+  });
+
+  it('renders event name and markdown content on success', async () => {
+    const { builder, single } = createQueryBuilder();
+    single.mockResolvedValue({
+      data: {
+        id: '1',
+        name: 'Test Event',
+        cgv_content: '# Title\n\nThis is **content**',
+      },
+      error: null,
+    });
+    mockFrom.mockReturnValue(builder);
+
+    render(<EventCGV />);
+
+    expect(await screen.findByText('Test Event')).toBeInTheDocument();
+    expect(screen.getByText('This is content')).toBeInTheDocument();
+  });
+
+  it('renders fallback when no CGV data', async () => {
+    const { builder, single } = createQueryBuilder();
+    single.mockResolvedValue({ data: null, error: null });
+    mockFrom.mockReturnValue(builder);
+
+    render(<EventCGV />);
+
+    expect(await screen.findByText(/cgv introuvables/i)).toBeInTheDocument();
+  });
+
+  it('handles error by showing toast and fallback', async () => {
+    const { builder, single } = createQueryBuilder();
+    single.mockRejectedValue(new Error('oops'));
+    mockFrom.mockReturnValue(builder);
+
+    render(<EventCGV />);
+
+    expect(await screen.findByText(/cgv introuvables/i)).toBeInTheDocument();
+    expect(toast.error).toHaveBeenCalledWith('Erreur lors du chargement des CGV');
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests for EventCGV page covering loading, success, missing data, and error states

## Testing
- `npm run test:run`

------
https://chatgpt.com/codex/tasks/task_e_68acd3242fc4832bbc7ceaa5fce67c41