### PR TITLE
feat: allow injecting database client into services

### DIFF
--- a/src/lib/eventStock.ts
+++ b/src/lib/eventStock.ts
@@ -1,4 +1,4 @@
-import { supabase } from './supabase';
+import { supabase, type DatabaseClient } from './supabase';
 
 export interface PassWithStock {
   id: string;
@@ -34,8 +34,11 @@ export interface EventStockResult {
  * Fetch all passes and activities for an event with their remaining stock
  * in a single RPC call.
  */
-export const fetchEventStock = async (eventId: string): Promise<EventStockResult> => {
-  const { data, error } = await supabase.rpc('get_event_passes_activities_stock', {
+export const fetchEventStock = async (
+  eventId: string,
+  client: DatabaseClient = supabase
+): Promise<EventStockResult> => {
+  const { data, error } = await client.rpc('get_event_passes_activities_stock', {
     event_uuid: eventId,
   });
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -4,6 +4,11 @@ import { debugLog } from './logger';
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
+export interface DatabaseClient {
+  from: (table: string) => any;
+  rpc: (fn: string, params?: any) => Promise<any>;
+}
+
 // Check if Supabase is properly configured
 export const isSupabaseConfigured = () => {
   return !!supabaseUrl &&
@@ -25,9 +30,9 @@ if (!isSupabaseConfigured()) {
   console.warn(message);
 }
 
-export const supabase = isSupabaseConfigured()
-  ? createClient(supabaseUrl, supabaseAnonKey)
-  : ({} as any);
+export const supabase: DatabaseClient = isSupabaseConfigured()
+  ? (createClient(supabaseUrl, supabaseAnonKey) as unknown as DatabaseClient)
+  : ({} as DatabaseClient);
 
 export type Database = {
   public: {

--- a/src/services/__tests__/eventService.test.ts
+++ b/src/services/__tests__/eventService.test.ts
@@ -1,122 +1,108 @@
-import { describe, it, expect, vi, afterAll, afterEach } from 'vitest';
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { fetchEvent, fetchTimeSlotsForActivity, fetchPasses, fetchEventActivities } from '../eventService';
 
-vi.mock('../../lib/supabase', () => {
-  const from = vi.fn((table: string) => {
-    if (table === 'events') {
-      return {
-        select: vi.fn().mockReturnThis(),
+const from = vi.fn((table: string) => {
+  if (table === 'events') {
+    return {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: '1', name: 'Event', event_date: '2024-01-01', key_info_content: 'Info' }, error: null }),
+    } as any;
+  }
+  if (table === 'time_slots') {
+    return {
+      select: vi.fn().mockReturnValue({
         eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({ data: { id: '1', name: 'Event', event_date: '2024-01-01', key_info_content: 'Info' }, error: null }),
-      } as any;
-    }
-    if (table === 'time_slots') {
-      return {
-        select: vi.fn().mockReturnValue({
-          eq: vi.fn().mockReturnThis(),
-          gte: vi.fn().mockReturnThis(),
-          order: vi.fn().mockResolvedValue({
-            data: [
-              {
-                id: 'slot1',
-                slot_time: '2024-01-01T10:00:00Z',
-                capacity: 10,
-                event_activities: {
-                  id: 'ea1',
-                  activity_id: 'a1',
-                  stock_limit: null,
-                  requires_time_slot: true,
-                  activities: { id: 'a1', name: 'Act', description: 'Desc', icon: '🎯' },
-                },
+        gte: vi.fn().mockReturnThis(),
+        order: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'slot1',
+              slot_time: '2024-01-01T10:00:00Z',
+              capacity: 10,
+              event_activities: {
+                id: 'ea1',
+                activity_id: 'a1',
+                stock_limit: null,
+                requires_time_slot: true,
+                activities: { id: 'a1', name: 'Act', description: 'Desc', icon: '🎯' },
               },
-            ],
-            error: null,
-          }),
+            },
+          ],
+          error: null,
         }),
-      } as any;
-    }
-    return {} as any;
-  });
-
-  const rpc = vi.fn((fn: string) => {
-    if (fn === 'get_slot_remaining_capacity') {
-      return Promise.resolve({ data: 5 });
-    }
-    if (fn === 'get_event_passes_activities_stock') {
-      return Promise.resolve({
-        data: {
-          passes: [
-            {
-              id: 'p1',
-              name: 'Pass',
-              price: 10,
-              description: 'Desc',
-              initial_stock: 100,
-              remaining_stock: 50,
-            },
-          ],
-          event_activities: [
-            {
-              id: 'ea1',
-              activity_id: 'a1',
-              stock_limit: null,
-              requires_time_slot: false,
-              remaining_stock: 3,
-              activity: { id: 'a1', name: 'Act', description: 'Desc', icon: '🎯' },
-            },
-          ],
-        },
-      });
-    }
-    return Promise.resolve({ data: null });
-  });
-
-  return {
-    supabase: { from, rpc } as any,
-    isSupabaseConfigured: () => true,
-  };
+      }),
+    } as any;
+  }
+  return {} as any;
 });
 
-afterAll(() => {
-  vi.resetModules();
+const rpc = vi.fn((fn: string) => {
+  if (fn === 'get_slot_remaining_capacity') {
+    return Promise.resolve({ data: 5 });
+  }
+  if (fn === 'get_event_passes_activities_stock') {
+    return Promise.resolve({
+      data: {
+        passes: [
+          {
+            id: 'p1',
+            name: 'Pass',
+            price: 10,
+            description: 'Desc',
+            initial_stock: 100,
+            remaining_stock: 50,
+          },
+        ],
+        event_activities: [
+          {
+            id: 'ea1',
+            activity_id: 'a1',
+            stock_limit: null,
+            requires_time_slot: false,
+            remaining_stock: 3,
+            activity: { id: 'a1', name: 'Act', description: 'Desc', icon: '🎯' },
+          },
+        ],
+      },
+    });
+  }
+  return Promise.resolve({ data: null });
 });
 
-afterEach(() => {
-  vi.clearAllMocks();
-});
+const client = { from, rpc } as any;
 
-import { supabase } from '../../lib/supabase';
-import {
-  fetchEvent,
-  fetchTimeSlotsForActivity,
-  fetchPasses,
-  fetchEventActivities,
-} from '../eventService';
+beforeEach(() => {
+  from.mockClear();
+  rpc.mockClear();
+});
 
 describe('eventService', () => {
   it('fetchEvent returns event data', async () => {
-    const event = await fetchEvent('1');
+    const event = await fetchEvent('1', client);
     expect(event?.name).toBe('Event');
   });
 
   it('fetchTimeSlotsForActivity returns slots with remaining capacity', async () => {
-    const slots = await fetchTimeSlotsForActivity('ea1');
+    const slots = await fetchTimeSlotsForActivity('ea1', client);
     expect(slots[0].remaining_capacity).toBe(5);
     expect(slots[0].event_activity.activity.name).toBe('Act');
   });
 
   it('fetchPasses uses grouped RPC to return remaining stock', async () => {
-    const passes = await fetchPasses('1');
+    const passes = await fetchPasses('1', client);
     expect(passes[0].remaining_stock).toBe(50);
-    expect(supabase.rpc).toHaveBeenCalledWith('get_event_passes_activities_stock', {
+    expect(rpc).toHaveBeenCalledWith('get_event_passes_activities_stock', {
       event_uuid: '1',
     });
   });
 
   it('fetchEventActivities uses grouped RPC to return remaining stock', async () => {
-    const activities = await fetchEventActivities('1');
+    const activities = await fetchEventActivities('1', client);
     expect(activities[0].remaining_stock).toBe(3);
     expect(activities[0].activity.name).toBe('Act');
-    expect(supabase.rpc).toHaveBeenCalledWith('get_event_passes_activities_stock', {
+    expect(rpc).toHaveBeenCalledWith('get_event_passes_activities_stock', {
       event_uuid: '1',
     });
   });

--- a/src/services/__tests__/faqService.test.ts
+++ b/src/services/__tests__/faqService.test.ts
@@ -1,38 +1,30 @@
-import { describe, it, expect, vi, afterAll } from 'vitest';
-
-vi.mock('../../lib/supabase', () => {
-  const from = vi.fn((table: string) => {
-    if (table === 'events') {
-      return {
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        single: vi.fn().mockResolvedValue({ data: { id: '1', name: 'Test Event' }, error: null }),
-      } as any;
-    }
-    if (table === 'event_faqs') {
-      return {
-        select: vi.fn().mockReturnThis(),
-        eq: vi.fn().mockReturnThis(),
-        order: vi.fn().mockResolvedValue({ data: [{ question: 'Q', answer: 'A', position: 1 }], error: null }),
-      } as any;
-    }
-    return {} as any;
-  });
-  return {
-    supabase: { from } as any,
-    isSupabaseConfigured: () => true,
-  };
-});
-
-afterAll(() => {
-  vi.resetModules();
-});
-
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { describe, it, expect, vi } from 'vitest';
 import { fetchEventFaq } from '../faqService';
+
+const from = vi.fn((table: string) => {
+  if (table === 'events') {
+    return {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: '1', name: 'Test Event' }, error: null }),
+    } as any;
+  }
+  if (table === 'event_faqs') {
+    return {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [{ question: 'Q', answer: 'A', position: 1 }], error: null }),
+    } as any;
+  }
+  return {} as any;
+});
+
+const client = { from } as any;
 
 describe('faqService', () => {
   it('fetchEventFaq returns event and faqs', async () => {
-    const result = await fetchEventFaq('1');
+    const result = await fetchEventFaq('1', client);
     expect(result.event).toEqual({ id: '1', name: 'Test Event' });
     expect(result.faqs).toEqual([{ question: 'Q', answer: 'A', position: 1 }]);
   });

--- a/src/services/faqService.ts
+++ b/src/services/faqService.ts
@@ -1,4 +1,4 @@
-import { supabase, isSupabaseConfigured } from '../lib/supabase';
+import { supabase, isSupabaseConfigured, type DatabaseClient } from '../lib/supabase';
 
 export interface Event {
   id: string;
@@ -11,9 +11,12 @@ export interface FAQItem {
   position?: number;
 }
 
-export async function fetchEventFaq(eventId: string): Promise<{ event: Event | null; faqs: FAQItem[] }> {
+export async function fetchEventFaq(
+  eventId: string,
+  client: DatabaseClient = supabase
+): Promise<{ event: Event | null; faqs: FAQItem[] }> {
   if (!isSupabaseConfigured()) return { event: null, faqs: [] };
-  const { data: eventData, error: eventError } = await supabase
+  const { data: eventData, error: eventError } = await client
     .from('events')
     .select('id, name')
     .eq('id', eventId)
@@ -21,7 +24,7 @@ export async function fetchEventFaq(eventId: string): Promise<{ event: Event | n
     .single();
   if (eventError) throw eventError;
 
-  const { data: faqData, error: faqError } = await supabase
+  const { data: faqData, error: faqError } = await client
     .from('event_faqs')
     .select('question, answer, position')
     .eq('event_id', eventId)


### PR DESCRIPTION
## Summary
- expose a DatabaseClient interface for supabase
- allow event and FAQ services to receive a custom database client
- update event stock helper and tests to use injectable clients

## Testing
- `npx vitest run src/services/__tests__/eventService.test.ts src/services/__tests__/faqService.test.ts src/lib/__tests__/eventStock.test.ts`
- `npm run lint` *(fails: 70 problems (57 errors, 13 warnings))*

------
https://chatgpt.com/codex/tasks/task_e_68acdb24cd34832b85bde844c8edb894