### PR TITLE
feat: add typed supabase response models

### DIFF
--- a/src/hooks/__tests__/useEventDetails.test.ts
+++ b/src/hooks/__tests__/useEventDetails.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { renderHook, waitFor } from '@testing-library/react';
 import { useEventDetails } from '../useEventDetails';
 import {
@@ -25,16 +25,16 @@ beforeEach(() => {
 
 describe('useEventDetails', () => {
   it('aggregates data from services', async () => {
-    (fetchEvent as any).mockResolvedValue({
+    (fetchEvent as Mock).mockResolvedValue({
       id: '1',
       name: 'Event',
       event_date: '2024-01-01',
       key_info_content: 'info',
     });
-    (fetchPasses as any).mockResolvedValue([
+    (fetchPasses as Mock).mockResolvedValue([
       { id: 'p1', name: 'Pass 1', price: 10, description: 'desc', initial_stock: 10, remaining_stock: 5 },
     ]);
-    (fetchEventActivities as any).mockResolvedValue([]);
+    (fetchEventActivities as Mock).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEventDetails('1'));
 
@@ -45,7 +45,7 @@ describe('useEventDetails', () => {
   });
 
   it('handles errors from services', async () => {
-    (fetchEvent as any).mockRejectedValue(new Error('fail'));
+    (fetchEvent as Mock).mockRejectedValue(new Error('fail'));
     const { result } = renderHook(() => useEventDetails('1'));
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBeTruthy();

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,64 @@
+export interface Event {
+  id: string;
+  name: string;
+  event_date: string;
+  key_info_content: string;
+}
+
+export interface Pass {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  initial_stock: number | null;
+  remaining_stock?: number;
+}
+
+export interface Activity {
+  id: string;
+  name: string;
+  description: string;
+  icon: string;
+}
+
+export interface EventActivity {
+  id: string;
+  activity_id: string;
+  stock_limit: number | null;
+  requires_time_slot: boolean;
+  remaining_stock?: number;
+  activity: Activity;
+}
+
+export interface TimeSlot {
+  id: string;
+  event_activity_id: string;
+  slot_time: string;
+  capacity: number;
+  remaining_capacity?: number;
+  event_activity: EventActivity;
+}
+
+// Raw database row types
+export interface PassRow {
+  id: string;
+  name: string;
+  price: number;
+  description: string;
+  initial_stock: number | null;
+}
+
+export interface EventActivityRow {
+  id: string;
+  activity_id: string;
+  stock_limit: number | null;
+  requires_time_slot: boolean;
+  activities: Activity;
+}
+
+export interface TimeSlotRow {
+  id: string;
+  slot_time: string;
+  capacity: number;
+  event_activities: EventActivityRow;
+}


### PR DESCRIPTION
## Summary
- define domain models for events, passes, activities and time slots
- replace loose any usage with explicit row types for Supabase responses
- adjust tests to mock typed services

## Testing
- `npm run test:run` *(fails: Test Files 10 failed | 21 passed)*
- `npm run lint` *(fails: numerous eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68acde23a984832bab5f829077d99d86