### PR TITLE
feat: add safe localStorage wrapper with fallback

### DIFF
--- a/src/lib/__tests__/cart.test.ts
+++ b/src/lib/__tests__/cart.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../cart';
 import type { CartItem, Pass } from '../cart';
 import type { CartRepository } from '../cartRepository';
+import { safeStorage } from '../storage';
 
 // Mock localStorage
 const mockLocalStorage = {
@@ -57,6 +58,19 @@ describe('Cart Functions', () => {
       const sessionId = getSessionId();
       expect(sessionId).toBe('test-session-id');
       expect(mockLocalStorage.setItem).toHaveBeenCalledWith('cart_session_id', 'test-session-id');
+    });
+
+    it('should fall back to memory when localStorage is unavailable', () => {
+      safeStorage.removeItem('cart_session_id');
+      const original = (window as any).localStorage;
+      delete (window as any).localStorage;
+
+      const sessionId1 = getSessionId();
+      const sessionId2 = getSessionId();
+      expect(sessionId1).toBe('test-session-id');
+      expect(sessionId2).toBe('test-session-id');
+
+      Object.defineProperty(window, 'localStorage', { value: original, configurable: true });
     });
   });
 

--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -4,6 +4,7 @@ import { logger } from './logger';
 import type { CartRepository } from './cartRepository';
 import { SupabaseCartRepository } from './cartRepository';
 import { toastNotify, type NotifyFn } from './notifications';
+import { safeStorage } from './storage';
 
 /** Represents a pass returned by Supabase */
 export interface Pass {
@@ -39,10 +40,10 @@ export interface CartItem {
 
 // Générer un ID de session unique si pas déjà existant
 export function getSessionId(): string {
-  let sessionId = localStorage.getItem('cart_session_id');
+  let sessionId = safeStorage.getItem('cart_session_id');
   if (!sessionId) {
     sessionId = crypto.randomUUID();
-    localStorage.setItem('cart_session_id', sessionId);
+    safeStorage.setItem('cart_session_id', sessionId);
   }
   return sessionId;
 }

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,38 @@
+const memoryStorage: Record<string, string> = {};
+
+export const safeStorage = {
+  getItem(key: string): string | null {
+    if (typeof window === 'undefined') {
+      return memoryStorage[key] ?? null;
+    }
+    try {
+      return window.localStorage.getItem(key);
+    } catch {
+      return memoryStorage[key] ?? null;
+    }
+  },
+
+  setItem(key: string, value: string): void {
+    if (typeof window === 'undefined') {
+      memoryStorage[key] = value;
+      return;
+    }
+    try {
+      window.localStorage.setItem(key, value);
+    } catch {
+      memoryStorage[key] = value;
+    }
+  },
+
+  removeItem(key: string): void {
+    if (typeof window === 'undefined') {
+      delete memoryStorage[key];
+      return;
+    }
+    try {
+      window.localStorage.removeItem(key);
+    } catch {
+      delete memoryStorage[key];
+    }
+  },
+};

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -9,6 +9,7 @@ import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
 import { logger } from '../lib/logger';
+import { safeStorage } from '../lib/storage';
 
 export default function Cart() {
   const [cartItems, setCartItems] = useState<CartItem[]>([]);
@@ -97,7 +98,7 @@ export default function Cart() {
       }
       
       // Vider le panier
-      const sessionId = localStorage.getItem('cart_session_id');
+      const sessionId = safeStorage.getItem('cart_session_id');
       if (sessionId) {
         await supabase
           .from('cart_items')

--- a/src/pages/admin/Settings.tsx
+++ b/src/pages/admin/Settings.tsx
@@ -5,6 +5,7 @@ import { toast } from 'react-hot-toast';
 import { getCurrentUser } from '../../lib/auth';
 import type { User as AuthUser } from '../../lib/auth';
 import { logger } from '../../lib/logger';
+import { safeStorage } from '../../lib/storage';
 
 interface SystemSettings {
   site_name: string;
@@ -42,7 +43,7 @@ export default function Settings() {
 
       // Charger les paramètres système (simulés pour le moment)
       // En production, ces paramètres seraient stockés dans une table dédiée
-      const savedSettings = localStorage.getItem('system_settings');
+      const savedSettings = safeStorage.getItem('system_settings');
       if (savedSettings) {
         setSettings(JSON.parse(savedSettings));
       }
@@ -60,7 +61,7 @@ export default function Settings() {
       
       // Sauvegarder les paramètres (simulé avec localStorage)
       // En production, cela serait sauvegardé dans Supabase
-      localStorage.setItem('system_settings', JSON.stringify(settings));
+      safeStorage.setItem('system_settings', JSON.stringify(settings));
       
       toast.success('Paramètres sauvegardés avec succès');
     } catch (err) {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -119,7 +119,7 @@ const localStorageMock = {
   removeItem: vi.fn(),
   clear: vi.fn(),
 };
-Object.defineProperty(window, 'localStorage', { value: localStorageMock });
+Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
 
 // Mock HTMLAnchorElement.click for download tests
 Object.defineProperty(HTMLAnchorElement.prototype, 'click', {


### PR DESCRIPTION
## Summary
- add safeStorage utility with memory fallback
- use safeStorage in cart session and settings pages
- allow tests to simulate missing localStorage

## Testing
- `npm run lint` *(fails: no-unused-vars, no-explicit-any, etc.)*
- `npm run test:run` *(fails: multiple test failures)*

------
https://chatgpt.com/codex/tasks/task_e_68acdf973974832b8e9d8a5cb8840251