### PR TITLE
test: remove router wrapper in App test

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -1,16 +1,13 @@
 import { describe, it, expect } from 'vitest';
-import { MemoryRouter } from 'react-router-dom';
 import { render, screen } from '@testing-library/react';
 import App from '../App';
 
 describe('App Component', () => {
   it('should render without crashing', () => {
     render(
-      <MemoryRouter>
-        <App />
-      </MemoryRouter>
+      <App />
     );
-    
+
     // Should render the layout with header
     expect(screen.getByText('BilletEvent')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- simplify App test by removing unnecessary MemoryRouter wrapper

## Testing
- `npm run test:run` *(fails: Test Files 10 failed | 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ace54c91ec832bbcfe1b6a7cf64649