### PR TITLE
test: check empty email toast

### DIFF
--- a/src/pages/__tests__/FindTicket.test.tsx
+++ b/src/pages/__tests__/FindTicket.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '../../test/utils';
+import { toast } from 'react-hot-toast';
 import FindTicket from '../FindTicket';
 
 describe('FindTicket Page', () => {
@@ -18,9 +19,7 @@ describe('FindTicket Page', () => {
     
     // Toast error should be called (mocked in setup)
     await waitFor(() => {
-      expect(vi.mocked(require('react-hot-toast').toast.error)).toHaveBeenCalledWith(
-        'Veuillez saisir votre adresse e-mail'
-      );
+      expect(toast.error).toHaveBeenCalledWith('Veuillez saisir votre adresse e-mail');
     });
   });
 


### PR DESCRIPTION
## Summary
- import toast in FindTicket tests
- assert toast.error called when email is missing

## Testing
- `npm run test:run`


------
https://chatgpt.com/codex/tasks/task_e_68ace6055ae0832b8189f19192ed02d4