### PR TITLE
test: improve content query

### DIFF
--- a/src/pages/__tests__/EventCGV.test.tsx
+++ b/src/pages/__tests__/EventCGV.test.tsx
@@ -50,7 +50,7 @@ describe('EventCGV Page', () => {
     render(<EventCGV />);
 
     expect(await screen.findByText('Test Event')).toBeInTheDocument();
-    expect(screen.getByText('This is content')).toBeInTheDocument();
+    expect(screen.getByText(/This is\s+content/)).toBeInTheDocument();
   });
 
   it('renders fallback when no CGV data', async () => {


### PR DESCRIPTION
## Summary
- use regex for EventCGV test content match

## Testing
- `npm run test:run -- src/pages/__tests__/EventCGV.test.tsx` *(fails: Unable to find an element with the text: /This is\s+content/)*

------
https://chatgpt.com/codex/tasks/task_e_68ace7479f64832b940b9a0ffc744a2e