### PR TITLE
test: mock supabase eq in time slot tests

### DIFF
--- a/src/pages/admin/__tests__/TimeSlotManagement.test.tsx
+++ b/src/pages/admin/__tests__/TimeSlotManagement.test.tsx
@@ -10,7 +10,10 @@ vi.mock('../../../lib/supabase', async () => {
     supabase: {
       from: vi.fn(() => ({
         select: vi.fn(() => ({
-          order: vi.fn(() => Promise.resolve({ data: [], error: null }))
+          order: vi.fn(() => Promise.resolve({ data: [], error: null })),
+          eq: vi.fn(() => ({
+            order: vi.fn(() => Promise.resolve({ data: [], error: null }))
+          }))
         }))
       })),
       rpc: vi.fn(() => Promise.resolve({ data: 0, error: null }))


### PR DESCRIPTION
## Summary
- include `eq` chaining in Supabase mock for time slot management tests

## Testing
- `npm run test:run` *(fails: 10 failed, 21 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ace8dcbfc4832b916084dc26723673