### PR TITLE
Add CI workflow and badge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test
+      - run: npm run build
+      - run: npm audit --production
+      - run: npx semgrep --config=auto
+      - run: npm run test:ui

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Billeterie Maïdo
 
+[![CI](https://github.com/OWNER/billeterie-maido/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/billeterie-maido/actions/workflows/ci.yml)
+
 ## Prérequis
 
 * [Node.js](https://nodejs.org/) version 18 ou supérieure


### PR DESCRIPTION
## Summary
- add CI workflow running lint, tests, build, audit, semgrep and UI checks
- show CI status badge in README

## Testing
- `npm run lint` *(fails: multiple lint errors)*
- `npm test` *(fails: multiple failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7859cac0832baa925ad28cf2ac52