### PR TITLE
Active la protection de la branche principale

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# CODEOWNERS
+* @billeterie-maido/maintainers
+src/ @billeterie-maido/frontend
+supabase/ @billeterie-maido/backend
+.github/ @billeterie-maido/devops

--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,32 @@
+name: Branch protection
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+  administration: write
+
+jobs:
+  enforce:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.repos.updateBranchProtection({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              branch: 'main',
+              required_status_checks: {
+                strict: true,
+                contexts: ['CI']
+              },
+              required_pull_request_reviews: {
+                required_approving_review_count: 1
+              },
+              enforce_admins: true,
+              restrictions: null
+            })

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,5 +33,5 @@ Ce document définit les règles à suivre pour contribuer au projet. **Chaque c
 ## Definition of Done
 - Les tests et le lint passent (`npm test`, `npm run lint`).
 - La fonctionnalité est documentée et testée.
-- La Pull Request est relue et approuvée.
+- La Pull Request est relue et reçoit au moins une approbation.
 - Pas de TODO ou de code mort restant.


### PR DESCRIPTION
## Summary
- configure branch protection to require CI and an approving review
- define CODEOWNERS for automatic reviewer assignment
- document the need for at least one PR approval

## Testing
- `npm run lint` (fails: 54 errors, 14 warnings)
- `npm test` (fails: 9 failed, 22 passed)


------
https://chatgpt.com/codex/tasks/task_e_68ad7c726558832ba326320dde369183