### PR TITLE
Replace `any` in tests with stricter types

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { signInWithEmail, signOut } from '../auth';
 import { supabase } from '../supabase';
@@ -30,8 +29,8 @@ vi.mock('../supabase', () => ({
 // Ensure mocks reset before each test
 beforeEach(() => {
   vi.clearAllMocks();
-  (supabase.auth as any).signInWithPassword = vi.fn();
-  (supabase.auth as any).signOut = vi.fn();
+  vi.mocked(supabase.auth.signInWithPassword).mockReset();
+  vi.mocked(supabase.auth.signOut).mockReset();
   singleMock.mockResolvedValue({ data: { role: 'admin' }, error: null });
   insertMock.mockResolvedValue({ error: null });
 });
@@ -39,7 +38,7 @@ beforeEach(() => {
 describe('signInWithEmail', () => {
   it('should return user with admin role when found in DB', async () => {
     const user = { id: 'user-1', email: 'test@example.com' };
-    (supabase.auth.signInWithPassword as any).mockResolvedValue({
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue({
       data: { user },
       error: null
     });
@@ -51,7 +50,7 @@ describe('signInWithEmail', () => {
   it('should assign client role when user does not exist', async () => {
     singleMock.mockResolvedValue({ data: null, error: { message: 'No user' } });
 
-    (supabase.auth.signInWithPassword as any).mockResolvedValue({
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue({
       data: { user: { id: 'user-2', email: 'client@example.com' } },
       error: null
     });
@@ -67,7 +66,7 @@ describe('signInWithEmail', () => {
   });
 
   it('should return null and show error on failure', async () => {
-    (supabase.auth.signInWithPassword as any).mockResolvedValue({
+    vi.mocked(supabase.auth.signInWithPassword).mockResolvedValue({
       data: { user: null },
       error: new Error('Invalid credentials')
     });
@@ -80,13 +79,13 @@ describe('signInWithEmail', () => {
 
 describe('signOut', () => {
   it('should show success when sign out succeeds', async () => {
-    (supabase.auth.signOut as any).mockResolvedValue({ error: null });
+    vi.mocked(supabase.auth.signOut).mockResolvedValue({ error: null });
     await signOut();
     expect(toast.success).toHaveBeenCalledWith('Déconnexion réussie');
   });
 
   it('should show error when sign out fails', async () => {
-    (supabase.auth.signOut as any).mockResolvedValue({ error: new Error('fail') });
+    vi.mocked(supabase.auth.signOut).mockResolvedValue({ error: new Error('fail') });
     await signOut();
     expect(toast.error).toHaveBeenCalledWith('Erreur lors de la déconnexion');
   });

--- a/src/lib/__tests__/cart.test.ts
+++ b/src/lib/__tests__/cart.test.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import {
   getSessionId,
@@ -64,8 +63,8 @@ describe('Cart Functions', () => {
 
     it('should fall back to memory when localStorage is unavailable', () => {
       safeStorage.removeItem('cart_session_id');
-      const original = (window as any).localStorage;
-      delete (window as any).localStorage;
+      const original = window.localStorage;
+      delete (window as unknown as { localStorage?: Storage }).localStorage;
 
       const sessionId1 = getSessionId();
       const sessionId2 = getSessionId();
@@ -191,7 +190,9 @@ describe('Cart Functions', () => {
           eq: vi.fn().mockResolvedValue({ error: null }),
         })),
       };
-      vi.mocked(supabase.from).mockReturnValue(builder as any);
+      vi.mocked(supabase.from).mockReturnValue(
+        builder as unknown as ReturnType<typeof supabase.from>
+      );
 
       const result = await removeFromCart('item-id');
       expect(result).toBe(true);
@@ -206,7 +207,9 @@ describe('Cart Functions', () => {
           eq: vi.fn().mockResolvedValue({ error: null }),
         })),
       };
-      vi.mocked(supabase.from).mockReturnValue(builder as any);
+      vi.mocked(supabase.from).mockReturnValue(
+        builder as unknown as ReturnType<typeof supabase.from>
+      );
       mockLocalStorage.getItem.mockReturnValue('session-123');
 
       const result = await clearCart();

--- a/src/lib/__tests__/eventStock.test.ts
+++ b/src/lib/__tests__/eventStock.test.ts
@@ -1,6 +1,6 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from 'vitest';
 import { fetchEventStock } from '../eventStock';
+import type { DatabaseClient } from '../supabase';
 
 describe('fetchEventStock', () => {
   it('retrieves passes and activities with their stock', async () => {
@@ -18,7 +18,7 @@ describe('fetchEventStock', () => {
       },
       error: null,
     });
-    const client = { rpc } as any;
+    const client = { rpc } as unknown as DatabaseClient;
 
     const result = await fetchEventStock('event1', client);
     expect(rpc).toHaveBeenCalledWith('get_event_passes_activities_stock', { event_uuid: 'event1' });
@@ -28,7 +28,7 @@ describe('fetchEventStock', () => {
 
   it('throws when rpc returns an error', async () => {
     const rpc = vi.fn().mockResolvedValue({ data: null, error: new Error('fail') });
-    const client = { rpc } as any;
+    const client = { rpc } as unknown as DatabaseClient;
 
     await expect(fetchEventStock('event1', client)).rejects.toThrow('fail');
   });

--- a/src/pages/__tests__/EventDetails.test.tsx
+++ b/src/pages/__tests__/EventDetails.test.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '../../test/utils';
 import EventDetails from '../EventDetails';
@@ -13,7 +12,7 @@ vi.mock('react-router-dom', async () => {
 
 describe('EventDetails Page', () => {
   it('should render event information when loaded', () => {
-    (useEventDetails as unknown as any).mockReturnValue({
+    vi.mocked(useEventDetails).mockReturnValue({
       event: {
         id: 'test-event-id',
         name: 'Test Event',
@@ -35,7 +34,7 @@ describe('EventDetails Page', () => {
   });
 
   it('should show loading state when loading', () => {
-    (useEventDetails as unknown as any).mockReturnValue({
+    vi.mocked(useEventDetails).mockReturnValue({
       event: null,
       passes: [],
       eventActivities: [],
@@ -51,7 +50,7 @@ describe('EventDetails Page', () => {
   });
 
   it('should render passes section', () => {
-    (useEventDetails as unknown as any).mockReturnValue({
+    vi.mocked(useEventDetails).mockReturnValue({
       event: {
         id: 'test-event-id',
         name: 'Test Event',

--- a/src/services/__tests__/eventService.test.ts
+++ b/src/services/__tests__/eventService.test.ts
@@ -1,14 +1,17 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { fetchEvent, fetchTimeSlotsForActivity, fetchPasses, fetchEventActivities } from '../eventService';
+import type { DatabaseClient } from '../../lib/supabase';
 
-const from = vi.fn((table: string) => {
+const from = vi.fn((table: string): Record<string, unknown> => {
   if (table === 'events') {
     return {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({ data: { id: '1', name: 'Event', event_date: '2024-01-01', key_info_content: 'Info' }, error: null }),
-    } as any;
+      single: vi.fn().mockResolvedValue({
+        data: { id: '1', name: 'Event', event_date: '2024-01-01', key_info_content: 'Info' },
+        error: null,
+      }),
+    };
   }
   if (table === 'time_slots') {
     return {
@@ -33,12 +36,12 @@ const from = vi.fn((table: string) => {
           error: null,
         }),
       }),
-    } as any;
+    };
   }
-  return {} as any;
+  return {};
 });
 
-const rpc = vi.fn((fn: string) => {
+const rpc = vi.fn((fn: string): Promise<unknown> => {
   if (fn === 'get_slot_remaining_capacity') {
     return Promise.resolve({ data: 5 });
   }
@@ -71,7 +74,7 @@ const rpc = vi.fn((fn: string) => {
   return Promise.resolve({ data: null });
 });
 
-const client = { from, rpc } as any;
+const client = { from, rpc } as unknown as DatabaseClient;
 
 beforeEach(() => {
   from.mockClear();

--- a/src/services/__tests__/faqService.test.ts
+++ b/src/services/__tests__/faqService.test.ts
@@ -1,26 +1,26 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { describe, it, expect, vi } from 'vitest';
 import { fetchEventFaq } from '../faqService';
+import type { DatabaseClient } from '../../lib/supabase';
 
-const from = vi.fn((table: string) => {
+const from = vi.fn((table: string): Record<string, unknown> => {
   if (table === 'events') {
     return {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue({ data: { id: '1', name: 'Test Event' }, error: null }),
-    } as any;
+    };
   }
   if (table === 'event_faqs') {
     return {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       order: vi.fn().mockResolvedValue({ data: [{ question: 'Q', answer: 'A', position: 1 }], error: null }),
-    } as any;
+    };
   }
-  return {} as any;
+  return {};
 });
 
-const client = { from } as any;
+const client = { from } as unknown as DatabaseClient;
 
 describe('faqService', () => {
   it('fetchEventFaq returns event and faqs', async () => {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import '@testing-library/jest-dom';
 import { vi, expect } from 'vitest';
 import React from 'react';
@@ -38,33 +37,41 @@ Object.defineProperty(window, 'BroadcastChannel', {
 });
 
 // Mock Supabase with proper method chaining
-const createMockQueryBuilder = () => {
-  const mockBuilder: any = {
+interface MockBuilder {
+  select: ReturnType<typeof vi.fn>;
+  eq: ReturnType<typeof vi.fn>;
+  gte: ReturnType<typeof vi.fn>;
+  lte: ReturnType<typeof vi.fn>;
+  limit: ReturnType<typeof vi.fn>;
+  order: ReturnType<typeof vi.fn>;
+  single: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+  insert: ReturnType<typeof vi.fn>;
+  update: ReturnType<typeof vi.fn>;
+  then: ReturnType<typeof vi.fn>;
+}
+
+const createMockQueryBuilder = (): MockBuilder => {
+  const mockBuilder: MockBuilder = {
     select: vi.fn(() => mockBuilder),
     eq: vi.fn(() => mockBuilder),
     gte: vi.fn(() => mockBuilder),
     lte: vi.fn(() => mockBuilder),
     limit: vi.fn(() => mockBuilder),
     order: vi.fn(() => mockBuilder),
-    single: vi.fn(() => Promise.resolve({ data: { id: '1', name: 'Test Event' }, error: null })),
+    single: vi.fn(() =>
+      Promise.resolve({ data: { id: '1', name: 'Test Event' }, error: null }),
+    ),
     delete: vi.fn(() => mockBuilder),
     insert: vi.fn(() => mockBuilder),
     update: vi.fn(() => mockBuilder),
-    then: vi.fn((callback) => {
+    then: vi.fn((callback?: (arg: { data: unknown[]; error: null }) => unknown) => {
       if (callback) {
         return callback({ data: [], error: null });
       }
       return Promise.resolve({ data: [], error: null });
     }),
   };
-
-  // Make it thenable so it can be awaited
-  mockBuilder.then = vi.fn((callback) => {
-    if (callback) {
-      return callback({ data: [], error: null });
-    }
-    return Promise.resolve({ data: [], error: null });
-  });
 
   return mockBuilder;
 };
@@ -94,7 +101,8 @@ vi.mock('react-router-dom', async () => {
     useNavigate: () => vi.fn(),
     useParams: () => ({ eventId: 'test-event-id' }),
     useLocation: () => ({ pathname: '/' }),
-    Link: ({ children, to, ...props }: any) => React.createElement('a', { href: to, ...props }, children),
+    Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) =>
+      React.createElement('a', { href: to, ...props }, children),
     Outlet: () => React.createElement('div', null, 'Outlet'),
   };
 });
@@ -136,4 +144,4 @@ class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-(window as any).ResizeObserver = ResizeObserver;
+Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver, configurable: true });


### PR DESCRIPTION
## Summary
- remove file-level no-explicit-any disables
- use typed mocks and unknown in tests instead of `any`
- add interfaces for test utilities and mocks

## Testing
- `npm run lint`
- `npm test` *(fails: Tests failed; see logs)*

------
https://chatgpt.com/codex/tasks/task_e_68ad96899b70832b8a69f73da9a3c1cc