### PR TITLE
test: expand admin page coverage

### DIFF
--- a/src/pages/admin/__tests__/Communication.test.tsx
+++ b/src/pages/admin/__tests__/Communication.test.tsx
@@ -1,23 +1,18 @@
 import { describe, it, expect } from 'vitest';
-import { render, screen, waitFor } from '../../../test/utils';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../../test/utils';
 import Communication from '../Communication';
 
 describe('Communication', () => {
-  it('should render communication content', async () => {
+  it('opens template modal from header button', async () => {
+    const user = userEvent.setup();
     render(<Communication />);
-    
-    // Wait for loading to complete
-    await waitFor(() => {
-      expect(document.body).toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
 
-  it('should not be stuck in loading state', async () => {
-    render(<Communication />);
-    
-    await waitFor(() => {
-      // Should not show loading spinner after data loads
-      expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
-    }, { timeout: 3000 });
+    const openButton = await screen.findByRole('button', { name: /modèles/i });
+    await user.click(openButton);
+
+    expect(
+      await screen.findByRole('heading', { name: /modèles d'email/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/__tests__/Dashboard.test.tsx
+++ b/src/pages/admin/__tests__/Dashboard.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '../../../test/utils';
+import { render, screen } from '../../../test/utils';
 import AdminDashboard from '../Dashboard';
 
 // Mock the supabase calls to return resolved data immediately  
@@ -22,22 +22,14 @@ vi.mock('../../../lib/supabase', async () => {
 });
 
 describe('AdminDashboard', () => {
-  it('should render dashboard content', async () => {
+  it('displays statistics and quick links', async () => {
     render(<AdminDashboard />);
-    
-    // Wait for loading to complete and check for any content
-    await waitFor(() => {
-      // The component should render something, even if it's just the loading state initially
-      expect(document.body).toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
 
-  it('should not be stuck in loading state', async () => {
-    render(<AdminDashboard />);
-    
-    await waitFor(() => {
-      // Should not show loading spinner after data loads
-      expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
-    }, { timeout: 3000 });
+    // Verify main heading and a quick action link
+    expect(await screen.findByText(/Tableau de Bord/i)).toBeInTheDocument();
+    expect(screen.getByText(/Événements Total/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /Créer un Événement/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/__tests__/EventManagement.test.tsx
+++ b/src/pages/admin/__tests__/EventManagement.test.tsx
@@ -20,24 +20,6 @@ vi.mock('../../../lib/supabase', async () => {
 });
 
 describe('EventManagement', () => {
-  it('should render event management content', async () => {
-    render(<EventManagement />);
-    
-    // Wait for loading to complete
-    await waitFor(() => {
-      expect(document.body).toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
-
-  it('should not be stuck in loading state', async () => {
-    render(<EventManagement />);
-    
-    await waitFor(() => {
-      // Should not show loading spinner after data loads
-      expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
-
   it('should render header and add button', async () => {
     render(<EventManagement />);
 

--- a/src/pages/admin/__tests__/PassManagement.test.tsx
+++ b/src/pages/admin/__tests__/PassManagement.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '../../../test/utils';
+import { render, screen } from '../../../test/utils';
 import PassManagement from '../PassManagement';
 
 // Mock the supabase calls to return resolved data immediately  
@@ -20,21 +20,12 @@ vi.mock('../../../lib/supabase', async () => {
 });
 
 describe('PassManagement', () => {
-  it('should render pass management content', async () => {
+  it('shows pass header and creation button', async () => {
     render(<PassManagement />);
-    
-    // Wait for loading to complete
-    await waitFor(() => {
-      expect(document.body).toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
 
-  it('should not be stuck in loading state', async () => {
-    render(<PassManagement />);
-    
-    await waitFor(() => {
-      // Should not show loading spinner after data loads
-      expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
-    }, { timeout: 3000 });
+    expect(await screen.findByText(/Gestion des Pass/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /Nouveau Pass/i })
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/__tests__/Reports.test.tsx
+++ b/src/pages/admin/__tests__/Reports.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '../../../test/utils';
+import { render, screen } from '../../../test/utils';
 import Reports from '../Reports';
 
 // Mock the supabase calls to return resolved data immediately  
@@ -25,21 +25,13 @@ vi.mock('../../../lib/supabase', async () => {
 });
 
 describe('Reports', () => {
-  it('should render reports content', async () => {
+  it('shows filters and export action', async () => {
     render(<Reports />);
-    
-    // Wait for loading to complete
-    await waitFor(() => {
-      expect(document.body).toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
 
-  it('should not be stuck in loading state', async () => {
-    render(<Reports />);
-    
-    await waitFor(() => {
-      // Should not show loading spinner after data loads
-      expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
-    }, { timeout: 3000 });
+    expect(
+      await screen.findByText(/Rapports et Analyses/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Exporter/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/Date de début/i)).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/__tests__/ReservationManagement.test.tsx
+++ b/src/pages/admin/__tests__/ReservationManagement.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '../../../test/utils';
+import { render, screen } from '../../../test/utils';
 import ReservationManagement from '../ReservationManagement';
 
 // Mock the supabase calls to return resolved data immediately  
@@ -19,21 +19,14 @@ vi.mock('../../../lib/supabase', async () => {
 });
 
 describe('ReservationManagement', () => {
-  it('should render reservation management content', async () => {
+  it('renders search field and statistics', async () => {
     render(<ReservationManagement />);
-    
-    // Wait for loading to complete
-    await waitFor(() => {
-      expect(document.body).toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
 
-  it('should not be stuck in loading state', async () => {
-    render(<ReservationManagement />);
-    
-    await waitFor(() => {
-      // Should not show loading spinner after data loads
-      expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
-    }, { timeout: 3000 });
+    expect(
+      await screen.findByText(/Gestion des Réservations/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(/Rechercher par email/i)
+    ).toBeInTheDocument();
   });
 });

--- a/src/pages/admin/__tests__/TimeSlotManagement.test.tsx
+++ b/src/pages/admin/__tests__/TimeSlotManagement.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '../../../test/utils';
+import { render, screen } from '../../../test/utils';
 import TimeSlotManagement from '../TimeSlotManagement';
 
 // Mock the supabase calls to return resolved data immediately  
@@ -23,21 +23,14 @@ vi.mock('../../../lib/supabase', async () => {
 });
 
 describe('TimeSlotManagement', () => {
-  it('should render time slot management content', async () => {
+  it('informs user when no event is selected', async () => {
     render(<TimeSlotManagement />);
-    
-    // Wait for loading to complete
-    await waitFor(() => {
-      expect(document.body).toBeInTheDocument();
-    }, { timeout: 3000 });
-  });
 
-  it('should not be stuck in loading state', async () => {
-    render(<TimeSlotManagement />);
-    
-    await waitFor(() => {
-      // Should not show loading spinner after data loads
-      expect(screen.queryByText(/chargement/i)).not.toBeInTheDocument();
-    }, { timeout: 3000 });
+    expect(
+      await screen.findByText(/Planning des Créneaux/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/Sélectionnez un événement et une date/i)
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- expand admin dashboard test to verify stats and quick links
- check communication template modal opens from button
- cover reports, time slot, reservation, and pass pages with functional assertions

## Testing
- `npm run lint`
- `npm test` *(fails: Error: Failed to resolve import "jest-axe" from "src/test/setup.ts")*

------
https://chatgpt.com/codex/tasks/task_e_68ad96926400832bafc4f75a9aaeb7be