### PR TITLE
test: use explicit label selectors in CheckoutForm tests

### DIFF
--- a/src/components/__tests__/CheckoutForm.test.tsx
+++ b/src/components/__tests__/CheckoutForm.test.tsx
@@ -12,11 +12,11 @@ describe('CheckoutForm Component', () => {
   it('should render all form fields', () => {
     render(<CheckoutForm onSubmit={mockOnSubmit} loading={false} />);
     
-    expect(screen.getByLabelText(/prénom/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/nom/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Prénom *')).toBeInTheDocument();
+    expect(screen.getByLabelText('Nom *')).toBeInTheDocument();
     expect(screen.getByLabelText(/adresse email/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/téléphone/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/adresse/i)).toBeInTheDocument();
+    expect(screen.getByLabelText('Adresse *')).toBeInTheDocument();
     expect(screen.getByLabelText(/ville/i)).toBeInTheDocument();
     expect(screen.getByLabelText(/code postal/i)).toBeInTheDocument();
   });
@@ -24,11 +24,11 @@ describe('CheckoutForm Component', () => {
   it('should call onSubmit with form data when submitted', async () => {
     render(<CheckoutForm onSubmit={mockOnSubmit} loading={false} />);
     
-    fireEvent.change(screen.getByLabelText(/prénom/i), { target: { value: 'John' } });
-    fireEvent.change(screen.getByLabelText(/nom/i), { target: { value: 'Doe' } });
+    fireEvent.change(screen.getByLabelText('Prénom *'), { target: { value: 'John' } });
+    fireEvent.change(screen.getByLabelText('Nom *'), { target: { value: 'Doe' } });
     fireEvent.change(screen.getByLabelText(/adresse email/i), { target: { value: 'john@example.com' } });
     fireEvent.change(screen.getByLabelText(/téléphone/i), { target: { value: '0692123456' } });
-    fireEvent.change(screen.getByLabelText(/adresse/i), { target: { value: '123 Test St' } });
+    fireEvent.change(screen.getByLabelText('Adresse *'), { target: { value: '123 Test St' } });
     fireEvent.change(screen.getByLabelText(/ville/i), { target: { value: 'Saint-Denis' } });
     fireEvent.change(screen.getByLabelText(/code postal/i), { target: { value: '97400' } });
     


### PR DESCRIPTION
## Summary
- use precise label selectors for first name, last name, and address fields in CheckoutForm tests

## Testing
- `npm run lint`
- `npx vitest run src/components/__tests__/CheckoutForm.test.tsx`
- `npx vitest run src/lib/__tests__/supabase.test.ts` *(fails: expected true to be false)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16831624832bbe7624710e317352