### PR TITLE
test: check markdown content with text predicate

### DIFF
--- a/src/pages/__tests__/EventCGV.test.tsx
+++ b/src/pages/__tests__/EventCGV.test.tsx
@@ -50,7 +50,10 @@ describe('EventCGV Page', () => {
     render(<EventCGV />);
 
     expect(await screen.findByText('Test Event')).toBeInTheDocument();
-    expect(screen.getByText(/This is\s+content/)).toBeInTheDocument();
+    expect(
+      screen.getByText((_, node) => node.textContent === 'This is content'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('content').tagName).toBe('STRONG');
   });
 
   it('renders fallback when no CGV data', async () => {


### PR DESCRIPTION
## Summary
- verify CGV markdown content using text predicate
- assert that markdown emphasis renders as `<strong>`

## Testing
- `npm run lint`
- `npm test` *(fails: should render all form fields, should call onSubmit with form data when submitted, should render confirmation details when open, should render time slot information when provided)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16c2e51c832b9e2a5892e45c3798