### PR TITLE
test: activate CAPTCHA before searching

### DIFF
--- a/src/pages/__tests__/FindTicket.test.tsx
+++ b/src/pages/__tests__/FindTicket.test.tsx
@@ -14,7 +14,11 @@ describe('FindTicket Page', () => {
 
   it('should show error when email is empty', async () => {
     render(<FindTicket />);
-    
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /je ne suis pas un robot/i })
+    );
+
     fireEvent.click(screen.getByText(/rechercher mes billets/i));
     
     // Toast error should be called (mocked in setup)


### PR DESCRIPTION
## Summary
- ensure FindTicket test clicks CAPTCHA before submitting

## Testing
- `npm run lint` *(fails: 13 warnings)*
- `npm test` *(fails: 10 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16d1048c832b9c5cfd830a1f389d