### PR TITLE
Read Supabase env dynamically

### DIFF
--- a/src/lib/__tests__/supabase.test.ts
+++ b/src/lib/__tests__/supabase.test.ts
@@ -1,35 +1,41 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, afterAll } from 'vitest';
 
-// Mock environment variables using vi.hoisted
-const mockEnv = vi.hoisted(() => ({
-  VITE_SUPABASE_URL: '',
-  VITE_SUPABASE_ANON_KEY: '',
-}));
-
-vi.mock('~/.vite/import-meta-env', () => ({
-  default: mockEnv,
-}));
-
-// Import after mocking
-const { isSupabaseConfigured } = await import('../supabase');
+const originalUrl = process.env.VITE_SUPABASE_URL;
+const originalKey = process.env.VITE_SUPABASE_ANON_KEY;
 
 describe('Supabase Configuration', () => {
-  beforeEach(() => {
-    // Reset mocks before each test
-    vi.clearAllMocks();
-  });
+  it('should return true when Supabase is properly configured', async () => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.VITE_SUPABASE_ANON_KEY = 'test-key';
 
-  it('should return true when Supabase is properly configured', () => {
-    mockEnv.VITE_SUPABASE_URL = 'https://test.supabase.co';
-    mockEnv.VITE_SUPABASE_ANON_KEY = 'test-key';
-    
+    vi.resetModules();
+    const { isSupabaseConfigured } = await import('../supabase');
+
     expect(isSupabaseConfigured()).toBe(true);
   });
 
-  it('should return false when Supabase is not configured', () => {
-    mockEnv.VITE_SUPABASE_URL = '';
-    mockEnv.VITE_SUPABASE_ANON_KEY = '';
-    
+  it('should return false when Supabase is not configured', async () => {
+    process.env.VITE_SUPABASE_URL = '';
+    process.env.VITE_SUPABASE_ANON_KEY = '';
+
+    vi.resetModules();
+    const { isSupabaseConfigured } = await import('../supabase');
+
     expect(isSupabaseConfigured()).toBe(false);
   });
 });
+
+afterAll(() => {
+  if (originalUrl !== undefined) {
+    process.env.VITE_SUPABASE_URL = originalUrl;
+  } else {
+    delete process.env.VITE_SUPABASE_URL;
+  }
+
+  if (originalKey !== undefined) {
+    process.env.VITE_SUPABASE_ANON_KEY = originalKey;
+  } else {
+    delete process.env.VITE_SUPABASE_ANON_KEY;
+  }
+});
+

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,9 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import { debugLog } from './logger';
 
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
-
 export interface DatabaseClient {
   from: (table: string) => unknown;
   rpc: (fn: string, params?: unknown) => Promise<unknown>;
@@ -14,6 +11,10 @@ export interface DatabaseClient {
  * @returns `true` si la configuration est valide
  */
 export const isSupabaseConfigured = (): boolean => {
+  const env = process.env as Record<string, string | undefined>;
+  const supabaseUrl = env['VITE_SUPABASE_URL'] ?? import.meta.env.VITE_SUPABASE_URL;
+  const supabaseAnonKey = env['VITE_SUPABASE_ANON_KEY'] ?? import.meta.env.VITE_SUPABASE_ANON_KEY;
+
   return !!supabaseUrl && !!supabaseAnonKey && supabaseUrl.includes('.supabase.co');
 };
 
@@ -33,6 +34,9 @@ if (!isSupabaseConfigured()) {
   debugLog(message);
   console.warn(message);
 }
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase: DatabaseClient = isSupabaseConfigured()
   ? (createClient(supabaseUrl, supabaseAnonKey) as unknown as DatabaseClient)


### PR DESCRIPTION
## Summary
- read Supabase env on each call to determine configuration
- add tests resetting modules to validate dynamic env

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: test suite has failing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68ae16b75c50832b9385b55203d857d8