### PR TITLE
refactor: hoist supabase mocks

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -9,11 +9,14 @@ vi.mock('react-hot-toast', () => ({
 }));
 
 // Mock supabase
-const insertMock = vi.fn().mockResolvedValue({ error: null });
-const singleMock = vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null });
-const eqMock = vi.fn().mockReturnValue({ single: singleMock });
-const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
-const fromMock = vi.fn().mockReturnValue({ select: selectMock, insert: insertMock });
+const { insertMock, singleMock, fromMock } = vi.hoisted(() => {
+  const insertMock = vi.fn().mockResolvedValue({ error: null });
+  const singleMock = vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null });
+  const eqMock = vi.fn().mockReturnValue({ single: singleMock });
+  const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
+  const fromMock = vi.fn().mockReturnValue({ select: selectMock, insert: insertMock });
+  return { insertMock, singleMock, fromMock };
+});
 
 vi.mock('../supabase', () => ({
   supabase: {


### PR DESCRIPTION
## Summary
- hoist Supabase mocks in auth tests to avoid top-level references

## Testing
- `npm run lint`
- `npm test` *(fails: Test Files 5 failed | 26 passed)*
- `npm test src/lib/__tests__/auth.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68ae16a79bf0832b92b835a6eb736c01