### PR TITLE
refactor: wrap supabase env access

### DIFF
--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,13 @@
 import { createClient } from '@supabase/supabase-js';
 import { debugLog } from './logger';
 
+const env =
+  typeof process !== 'undefined' && process.env
+    ? (process.env as Record<string, string | undefined>)
+    : (import.meta.env as Record<string, string | undefined>);
+const supabaseUrl = env.VITE_SUPABASE_URL;
+const supabaseAnonKey = env.VITE_SUPABASE_ANON_KEY;
+
 export interface DatabaseClient {
   from: (table: string) => unknown;
   rpc: (fn: string, params?: unknown) => Promise<unknown>;
@@ -11,10 +18,6 @@ export interface DatabaseClient {
  * @returns `true` si la configuration est valide
  */
 export const isSupabaseConfigured = (): boolean => {
-  const env = process.env as Record<string, string | undefined>;
-  const supabaseUrl = env['VITE_SUPABASE_URL'] ?? import.meta.env.VITE_SUPABASE_URL;
-  const supabaseAnonKey = env['VITE_SUPABASE_ANON_KEY'] ?? import.meta.env.VITE_SUPABASE_ANON_KEY;
-
   return !!supabaseUrl && !!supabaseAnonKey && supabaseUrl.includes('.supabase.co');
 };
 
@@ -34,9 +37,6 @@ if (!isSupabaseConfigured()) {
   debugLog(message);
   console.warn(message);
 }
-
-const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
-const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
 
 export const supabase: DatabaseClient = isSupabaseConfigured()
   ? (createClient(supabaseUrl, supabaseAnonKey) as unknown as DatabaseClient)


### PR DESCRIPTION
## Summary
- wrap process.env usage with runtime check in Supabase client
- derive Supabase configuration from unified env object

## Testing
- `npm run lint`
- `npm test` *(fails: Test Files 4 failed | 27 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae1fbd847c832b8df350ea62d50034