### PR TITLE
Use role-based BilletEvent queries in tests

### DIFF
--- a/src/__tests__/App.test.tsx
+++ b/src/__tests__/App.test.tsx
@@ -8,7 +8,9 @@ describe('App Component', () => {
     const { container } = render(<App />);
 
     // Should render the layout with header
-    expect(screen.getByText('BilletEvent')).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: /BilletEvent/i })
+    ).toBeInTheDocument();
 
     // Ensure no accessibility violations
     const results = await axe(container);

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -10,8 +10,10 @@ vi.mock('../../lib/cart', () => ({
 describe('Layout Component', () => {
   it('should render header with logo and navigation', () => {
     render(<Layout />);
-    
-    expect(screen.getByText('BilletEvent')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('link', { name: /BilletEvent/i })
+    ).toBeInTheDocument();
     expect(screen.getByText(/événements/i)).toBeInTheDocument();
     expect(screen.getByText('Retrouver mon Billet')).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- use accessible role-based query for "BilletEvent" in App test
- use accessible role-based query for "BilletEvent" in Layout test

## Testing
- `npm run lint`
- `npm test` *(fails: 4 failed, 91 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f528470832b88121420068a9e6c