### PR TITLE
Disable native form validation and stub Supabase env

### DIFF
--- a/src/lib/__tests__/supabase.test.ts
+++ b/src/lib/__tests__/supabase.test.ts
@@ -1,12 +1,13 @@
 import { describe, it, expect, vi, afterAll } from 'vitest';
 
-const originalUrl = process.env.VITE_SUPABASE_URL;
-const originalKey = process.env.VITE_SUPABASE_ANON_KEY;
-
 describe('Supabase Configuration', () => {
+  afterAll(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('should return true when Supabase is properly configured', async () => {
-    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
-    process.env.VITE_SUPABASE_ANON_KEY = 'test-key';
+    vi.stubEnv('VITE_SUPABASE_URL', 'https://test.supabase.co');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', 'test-key');
 
     vi.resetModules();
     const { isSupabaseConfigured } = await import('../supabase');
@@ -15,8 +16,8 @@ describe('Supabase Configuration', () => {
   });
 
   it('should return false when Supabase is not configured', async () => {
-    process.env.VITE_SUPABASE_URL = '';
-    process.env.VITE_SUPABASE_ANON_KEY = '';
+    vi.stubEnv('VITE_SUPABASE_URL', '');
+    vi.stubEnv('VITE_SUPABASE_ANON_KEY', '');
 
     vi.resetModules();
     const { isSupabaseConfigured } = await import('../supabase');
@@ -25,17 +26,4 @@ describe('Supabase Configuration', () => {
   });
 });
 
-afterAll(() => {
-  if (originalUrl !== undefined) {
-    process.env.VITE_SUPABASE_URL = originalUrl;
-  } else {
-    delete process.env.VITE_SUPABASE_URL;
-  }
-
-  if (originalKey !== undefined) {
-    process.env.VITE_SUPABASE_ANON_KEY = originalKey;
-  } else {
-    delete process.env.VITE_SUPABASE_ANON_KEY;
-  }
-});
 

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -5,9 +5,6 @@ const env =
   typeof process !== 'undefined' && process.env
     ? (process.env as Record<string, string | undefined>)
     : (import.meta.env as Record<string, string | undefined>);
-const supabaseUrl = env.VITE_SUPABASE_URL;
-const supabaseAnonKey = env.VITE_SUPABASE_ANON_KEY;
-
 export interface DatabaseClient {
   from: (table: string) => unknown;
   rpc: (fn: string, params?: unknown) => Promise<unknown>;
@@ -18,8 +15,13 @@ export interface DatabaseClient {
  * @returns `true` si la configuration est valide
  */
 export const isSupabaseConfigured = (): boolean => {
-  return !!supabaseUrl && !!supabaseAnonKey && supabaseUrl.includes('.supabase.co');
+  const url = env.VITE_SUPABASE_URL;
+  const anonKey = env.VITE_SUPABASE_ANON_KEY;
+  return !!url && !!anonKey && url.includes('.supabase.co');
 };
+
+const supabaseUrl = env.VITE_SUPABASE_URL;
+const supabaseAnonKey = env.VITE_SUPABASE_ANON_KEY;
 
 /**
  * Lance une erreur si la configuration Supabase est absente.

--- a/src/pages/FindTicket.tsx
+++ b/src/pages/FindTicket.tsx
@@ -81,7 +81,7 @@ export default function FindTicket() {
       {!found ? (
         /* Formulaire de recherche */
         <div className="bg-white rounded-lg shadow-sm p-8">
-          <form onSubmit={handleSubmit}>
+          <form onSubmit={handleSubmit} noValidate>
             <div className="mb-6">
               <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
                 Adresse e-mail


### PR DESCRIPTION
## Summary
- disable browser validation on ticket search form
- make Supabase configuration check read environment values dynamically
- stub Supabase env vars in tests

## Testing
- `npm run lint`
- `npm test -- --run` *(fails: App Component should render without crashing; Supabase Configuration should return false when Supabase is not configured)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f60dea0832ba2fbf1c128674717