### PR TITLE
test: unmock Supabase module for config checks

### DIFF
--- a/src/lib/__tests__/supabase.test.ts
+++ b/src/lib/__tests__/supabase.test.ts
@@ -9,6 +9,7 @@ describe('Supabase Configuration', () => {
     process.env.VITE_SUPABASE_ANON_KEY = 'test-key';
 
     vi.resetModules();
+    vi.doUnmock('../supabase');
     const { isSupabaseConfigured } = await import('../supabase');
 
     expect(isSupabaseConfigured()).toBe(true);
@@ -19,6 +20,7 @@ describe('Supabase Configuration', () => {
     process.env.VITE_SUPABASE_ANON_KEY = '';
 
     vi.resetModules();
+    vi.doUnmock('../supabase');
     const { isSupabaseConfigured } = await import('../supabase');
 
     expect(isSupabaseConfigured()).toBe(false);


### PR DESCRIPTION
## Summary
- unmock Supabase in configuration tests so that the real implementation is loaded

## Testing
- `npm run lint`
- `npm test` *(fails: 3 failed, 92 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68ae2f714190832baa84a46a42d19dba