### PR TITLE
Use getAllByText in layout test and label cart link

### DIFF
--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -63,8 +63,9 @@ export default function Layout() {
             
             {/* Actions */}
             <div className="flex items-center space-x-4">
-              <Link 
-                to="/cart" 
+              <Link
+                to="/cart"
+                aria-label="Panier"
                 className="relative p-2 text-gray-400 hover:text-gray-500 transition-colors group"
               >
                 <ShoppingCart className="h-6 w-6 group-hover:text-blue-600 transition-colors" />

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -14,13 +14,15 @@ describe('Layout Component', () => {
     expect(
       screen.getByRole('link', { name: /BilletEvent/i })
     ).toBeInTheDocument();
-    expect(screen.getByText(/événements/i)).toBeInTheDocument();
-    expect(screen.getByText('Retrouver mon Billet')).toBeInTheDocument();
+    const eventLinks = screen.getAllByText(/événements/i);
+    expect(eventLinks.length).toBeGreaterThan(0);
+    const findTicketLinks = screen.getAllByText('Retrouver mon Billet');
+    expect(findTicketLinks.length).toBeGreaterThan(0);
   });
 
   it('should render admin link', () => {
     render(<Layout />);
-    
+
     expect(screen.getByText('Admin')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- adjust layout test to handle multiple "Événements" and "Retrouver mon Billet" links
- add accessible label to cart link in layout

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68ae3a27d730832bb46383dc87bccb8b