### PR TITLE
refactor: centralize delay handling with wait helper

### DIFF
--- a/src/lib/wait.ts
+++ b/src/lib/wait.ts
@@ -1,0 +1,5 @@
+export async function wait(ms: number): Promise<void> {
+  const override = import.meta.env.VITE_TEST_DELAY_MS;
+  const duration = override !== undefined ? Number(override) : ms;
+  await new Promise(resolve => setTimeout(resolve, duration));
+}

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -4,6 +4,7 @@ import ConfirmationModal from '../components/ConfirmationModal';
 import CheckoutForm, { type CustomerData } from '../components/CheckoutForm';
 import { getCartItems, removeFromCart, calculateCartTotal, type CartItem } from '../lib/cart';
 import { supabase } from '../lib/supabase';
+import { wait } from '../lib/wait';
 import { ShoppingCart, Trash2, ArrowLeft, CreditCard, CheckSquare, Square } from 'lucide-react';
 import { format } from 'date-fns';
 import { toast } from 'react-hot-toast';
@@ -72,10 +73,11 @@ export default function Cart() {
     
     try {
       // Simuler le processus de paiement
-      toast.loading('Traitement du paiement...', { duration: 3000 });
-      
-      // Attendre 3 secondes pour simuler le paiement
-      await new Promise(resolve => setTimeout(resolve, 3000));
+      const paymentDelay = 3000;
+      toast.loading('Traitement du paiement...', { duration: paymentDelay });
+
+      // Attendre pour simuler le paiement
+      await wait(paymentDelay);
       
       // Créer les réservations pour chaque article du panier
       const reservations = [];

--- a/src/pages/__tests__/Cart.test.tsx
+++ b/src/pages/__tests__/Cart.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, afterAll } from 'vitest';
 import { render, screen, waitFor } from '../../test/utils';
 import Cart from '../Cart';
 
@@ -8,6 +8,11 @@ vi.mock('../../lib/cart', () => ({
   removeFromCart: vi.fn(() => Promise.resolve(true)),
   calculateCartTotal: vi.fn(() => 0),
 }));
+
+vi.stubEnv('VITE_TEST_DELAY_MS', '0');
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('Cart Page', () => {
   it('should render empty cart message when no items', async () => {

--- a/src/pages/admin/Communication.tsx
+++ b/src/pages/admin/Communication.tsx
@@ -3,6 +3,7 @@ import { supabase } from '../../lib/supabase';
 import { Mail, Send, Users, FileText, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import { logger } from '../../lib/logger';
+import { wait } from '../../lib/wait';
 
 interface Event {
   id: string;
@@ -150,7 +151,8 @@ L'équipe BilletEvent`
       setSending(true);
       
       // Simuler l'envoi d'email
-      await new Promise(resolve => setTimeout(resolve, 2000));
+      const sendDelay = 2000;
+      await wait(sendDelay);
       
       toast.success(`Email envoyé à ${recipientCount} destinataire(s)`);
       

--- a/src/pages/admin/__tests__/Communication.test.tsx
+++ b/src/pages/admin/__tests__/Communication.test.tsx
@@ -1,7 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterAll } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '../../../test/utils';
 import Communication from '../Communication';
+
+vi.stubEnv('VITE_TEST_DELAY_MS', '0');
+afterAll(() => {
+  vi.unstubAllEnvs();
+});
 
 describe('Communication', () => {
   it('opens template modal from header button', async () => {

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_TEST_DELAY_MS?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add wait helper to centralize delay handling
- use wait helper in Cart and Communication pages
- stub delay via env in tests for faster execution

## Testing
- `npm run lint`
- `npm test -- --run`

------
https://chatgpt.com/codex/tasks/task_e_68ae4a6d2e18832b9e1e7e985c5e6111