### PR TITLE
fix: clear timeout in pass management effect

### DIFF
--- a/src/pages/admin/PassManagement.tsx
+++ b/src/pages/admin/PassManagement.tsx
@@ -427,15 +427,23 @@ function PassFormModal({ pass, events, onClose, onSave }: PassFormModalProps) {
 
   useEffect(() => {
     // Initialiser les activités sélectionnées après le chargement du pass
+    let timeoutId: ReturnType<typeof setTimeout>;
+
     if (pass?.event_activities && availableActivities.length > 0) {
       const passActivityIds = pass.event_activities.map(ea => ea.id);
       setSelectedActivities(passActivityIds);
-      
+
       // Calculer le stock initial après avoir défini les activités sélectionnées
-      setTimeout(() => {
+      timeoutId = setTimeout(() => {
         updateCalculatedStock();
       }, 0);
     }
+
+    return () => {
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
+    };
   }, [pass, availableActivities]);
 
   const loadEventActivities = async () => {


### PR DESCRIPTION
## Summary
- clear timeout in PassManagement useEffect

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae4a4cf604832baa6da15c7b5d768c