### PR TITLE
test: cover useEventDetails edge cases

### DIFF
--- a/src/hooks/__tests__/useEventDetails.test.ts
+++ b/src/hooks/__tests__/useEventDetails.test.ts
@@ -1,16 +1,18 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
-import { renderHook, waitFor } from '@testing-library/react';
+import { renderHook, waitFor, act } from '@testing-library/react';
 import { useEventDetails } from '../useEventDetails';
 import {
   fetchEvent,
   fetchPasses,
   fetchEventActivities,
+  fetchTimeSlots,
 } from '../../lib/eventDetails';
 
 vi.mock('../../lib/eventDetails', () => ({
   fetchEvent: vi.fn(),
   fetchPasses: vi.fn(),
   fetchEventActivities: vi.fn(),
+  fetchTimeSlots: vi.fn(),
 }));
 
 vi.mock('../../lib/supabase', () => ({
@@ -47,5 +49,36 @@ describe('useEventDetails', () => {
     const { result } = renderHook(() => useEventDetails('1'));
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.error).toBeTruthy();
+  });
+
+  it("doesn't load data when eventId is missing", async () => {
+    const { result } = renderHook(() => useEventDetails());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(fetchEvent).not.toHaveBeenCalled();
+  });
+
+  it('sets error and returns empty array if loadTimeSlotsForActivity fails', async () => {
+    (fetchEvent as Mock).mockResolvedValue({
+      id: '1',
+      name: 'Event',
+      event_date: '2024-01-01',
+      key_info_content: 'info',
+    });
+    (fetchPasses as Mock).mockResolvedValue([]);
+    (fetchEventActivities as Mock).mockResolvedValue([]);
+    (fetchTimeSlots as Mock).mockRejectedValue(new Error('fail'));
+
+    const { result } = renderHook(() => useEventDetails('1'));
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let slots: unknown;
+    await act(async () => {
+      slots = await result.current.loadTimeSlotsForActivity('activity-1');
+    });
+
+    expect(slots).toEqual([]);
+    expect(result.current.error).toBe('Erreur lors du chargement des créneaux');
   });
 });


### PR DESCRIPTION
## Summary
- ensure hook skips loading when eventId is missing
- verify loadTimeSlotsForActivity error handling

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ae58dedd34832bb34ff7bad55ad3c6