### PR TITLE
test: add settings page tests

### DIFF
--- a/src/pages/admin/__tests__/Settings.test.tsx
+++ b/src/pages/admin/__tests__/Settings.test.tsx
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import userEvent from '@testing-library/user-event';
+import { render, screen } from '../../../test/utils';
+import { toast } from 'react-hot-toast';
+import { safeStorage } from '../../../lib/storage';
+
+vi.mock('../../../lib/auth', async () => {
+  const actual = await vi.importActual<typeof import('../../../lib/auth')>(
+    '../../../lib/auth'
+  );
+  return {
+    ...actual,
+    getCurrentUser: vi.fn(),
+  };
+});
+
+import { getCurrentUser } from '../../../lib/auth';
+import Settings from '../Settings';
+
+describe('Settings Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getCurrentUser).mockResolvedValue({
+      email: 'admin@example.com',
+      role: 'admin',
+    });
+  });
+
+  it('loads user and saved settings', async () => {
+    vi.spyOn(safeStorage, 'getItem').mockReturnValue(
+      JSON.stringify({
+        site_name: 'My Site',
+        site_description: 'Desc',
+        contact_email: 'contact@mysite.com',
+        notification_email: 'notify@mysite.com',
+        maintenance_mode: true,
+        registration_enabled: false,
+      })
+    );
+
+    render(<Settings />);
+
+    expect(await screen.findByDisplayValue('My Site')).toBeInTheDocument();
+    expect(screen.getByDisplayValue('contact@mysite.com')).toBeInTheDocument();
+    expect(await screen.findByDisplayValue('admin@example.com')).toBeInTheDocument();
+    expect(getCurrentUser).toHaveBeenCalled();
+  });
+
+  it('updates state on user input and saves successfully', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(safeStorage, 'getItem').mockReturnValue(null);
+    const setItemMock = vi
+      .spyOn(safeStorage, 'setItem')
+      .mockImplementation(() => {});
+
+    render(<Settings />);
+
+    const nameInput = await screen.findByDisplayValue('BilletEvent');
+    await user.clear(nameInput);
+    await user.type(nameInput, 'New Name');
+
+    const saveBtn = screen.getByRole('button', {
+      name: /sauvegarder les paramètres/i,
+    });
+    await user.click(saveBtn);
+
+    expect(setItemMock).toHaveBeenCalledWith(
+      'system_settings',
+      expect.stringContaining('"site_name":"New Name"')
+    );
+    expect(toast.success).toHaveBeenCalledWith(
+      'Paramètres sauvegardés avec succès'
+    );
+  });
+
+  it('shows validation error for invalid email', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(safeStorage, 'getItem').mockReturnValue(null);
+
+    render(<Settings />);
+
+    const emailInput = await screen.findByDisplayValue('contact@billetevent.com');
+    await user.clear(emailInput);
+    await user.type(emailInput, 'invalid');
+
+    expect(emailInput).toBeInvalid();
+  });
+
+  it('shows error toast when save fails', async () => {
+    const user = userEvent.setup();
+    vi.spyOn(safeStorage, 'getItem').mockReturnValue(null);
+    vi.spyOn(safeStorage, 'setItem').mockImplementation(() => {
+      throw new Error('fail');
+    });
+
+    render(<Settings />);
+
+    const saveBtn = await screen.findByRole('button', {
+      name: /sauvegarder les paramètres/i,
+    });
+    await user.click(saveBtn);
+
+    expect(toast.error).toHaveBeenCalledWith('Erreur lors de la sauvegarde');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add comprehensive tests for Settings admin page
- cover user input, validation and toast notifications

## Testing
- `npm test`
- `npx vitest run --coverage`


------
https://chatgpt.com/codex/tasks/task_e_68ae58f7b3ac832b90eb61146f634e2f