### PR TITLE
test: check dashboard renders without warnings

### DIFF
--- a/src/pages/admin/__tests__/Dashboard.test.tsx
+++ b/src/pages/admin/__tests__/Dashboard.test.tsx
@@ -32,4 +32,19 @@ describe('AdminDashboard', () => {
       screen.getByRole('link', { name: /Créer un Événement/i })
     ).toBeInTheDocument();
   });
+
+  it('renders without console warnings', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<AdminDashboard />);
+
+    await screen.findByText(/Tableau de Bord/i);
+
+    expect(warnSpy).not.toHaveBeenCalled();
+    expect(errorSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
 });


### PR DESCRIPTION
## Summary
- assert AdminDashboard renders without console warnings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea2d404c832bafa775cf67b9a6f0