### PR TITLE
Link end date label to input in reports page

### DIFF
--- a/src/pages/admin/Reports.tsx
+++ b/src/pages/admin/Reports.tsx
@@ -228,10 +228,14 @@ export default function Reports() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="endDate"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Date de fin
             </label>
             <input
+              id="endDate"
               type="date"
               value={dateRange.end}
               onChange={(e) => setDateRange({ ...dateRange, end: e.target.value })}


### PR DESCRIPTION
## Summary
- link "Date de fin" label to its input in reports page

## Testing
- `npm run lint`
- `CI=1 npm test src/pages/admin/__tests__/Reports.test.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea264b38832bb59923114386be66