### PR TITLE
test: wrap admin tests in act and waitFor

### DIFF
--- a/src/pages/admin/__tests__/Communication.test.tsx
+++ b/src/pages/admin/__tests__/Communication.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, afterAll } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen } from '../../../test/utils';
+import { render, screen, act, waitFor } from '../../../test/utils';
 import Communication from '../Communication';
 
 vi.stubEnv('VITE_TEST_DELAY_MS', '0');
@@ -14,10 +14,14 @@ describe('Communication', () => {
     render(<Communication />);
 
     const openButton = await screen.findByRole('button', { name: /modèles/i });
-    await user.click(openButton);
+    await act(async () => {
+      await user.click(openButton);
+    });
 
-    expect(
-      await screen.findByRole('heading', { name: /modèles d'email/i })
-    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: /modèles d'email/i })
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/admin/__tests__/EventManagement.test.tsx
+++ b/src/pages/admin/__tests__/EventManagement.test.tsx
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import { render, screen, waitFor } from '../../../test/utils';
+import { render, screen, waitFor, act } from '../../../test/utils';
 import EventManagement from '../EventManagement';
 
 // Mock the supabase calls to return resolved data immediately  
@@ -34,10 +34,14 @@ describe('EventManagement', () => {
     render(<EventManagement />);
 
     const button = await screen.findByRole('button', { name: /nouvel événement/i });
-    await user.click(button);
+    await act(async () => {
+      await user.click(button);
+    });
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /nouvel événement/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /nouvel événement/i })
+      ).toBeInTheDocument();
     });
   });
 


### PR DESCRIPTION
## Summary
- wrap Communication page test click in `act` and assert via `waitFor`
- wrap EventManagement add-button click in `act` with `waitFor` assertion

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea3273d4832b91f1ce5ffad7b449