### PR TITLE
test: enable React Router v7 flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,12 @@ import ProviderStats from './pages/provider/Stats';
 
 export default function App() {
   return (
-    <Router>
+    <Router
+      future={{
+        v7_startTransition: true,
+        v7_relativeSplatPath: true,
+      }}
+    >
       <div className="App">
         <Routes>
           {/* Public Routes */}

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -5,7 +5,12 @@ import { MemoryRouter } from 'react-router-dom';
 // Custom render function with providers
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
   return (
-    <MemoryRouter>
+    <MemoryRouter
+      future={{
+        v7_startTransition: true,
+        v7_relativeSplatPath: true,
+      }}
+    >
       {children}
     </MemoryRouter>
   );


### PR DESCRIPTION
## Summary
- enable React Router v7 future flags in tests
- enable React Router v7 future flags in BrowserRouter

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1ea379ce8832ba42011a6265d7027