### PR TITLE
feat: add bulk user actions

### DIFF
--- a/src/pages/admin/UserManagement.tsx
+++ b/src/pages/admin/UserManagement.tsx
@@ -4,7 +4,7 @@ import { toast } from 'react-hot-toast';
 import { logger } from '../../lib/logger';
 import { getCurrentUser } from '../../lib/auth';
 import type { User as AuthUser } from '../../lib/auth';
-import { Shield, Search, Save } from 'lucide-react';
+import { Shield, Search, Save, Trash2 } from 'lucide-react';
 
 type Role = AuthUser['role'];
 const ROLES: Role[] = [
@@ -29,6 +29,11 @@ export default function UserManagement() {
   const [loading, setLoading] = useState(false);
   const [users, setUsers] = useState<UserRow[]>([]);
   const [saving, setSaving] = useState<Record<string, boolean>>({});
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  const [bulkRole, setBulkRole] = useState<Role>('client');
+  const [bulkLoading, setBulkLoading] = useState(false);
+
+  const allSelected = users.length > 0 && selectedIds.length === users.length;
 
   useEffect(() => {
     (async () => {
@@ -61,11 +66,67 @@ export default function UserManagement() {
       const { data, error } = await builder;
       if (error) throw error;
       setUsers((data ?? []) as UserRow[]);
+      setSelectedIds([]);
     } catch (err) {
       logger.error('Erreur recherche utilisateurs', { error: err });
       toast.error('Impossible de charger les utilisateurs');
     } finally {
       setLoading(false);
+    }
+  };
+
+  const toggleSelectAll = () => {
+    setSelectedIds(allSelected ? [] : users.map(u => u.id));
+  };
+
+  const toggleSelection = (id: string) => {
+    setSelectedIds((ids) =>
+      ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id]
+    );
+  };
+
+  const bulkUpdateRole = async (role: Role) => {
+    if (selectedIds.length === 0) return;
+    try {
+      setBulkLoading(true);
+      const { error } = await supabase
+        .from('users')
+        .update({ role })
+        .in('id', selectedIds);
+      if (error) throw error;
+      toast.success('Rôles mis à jour');
+      await search();
+    } catch (err) {
+      logger.error('Erreur mise à jour rôle groupée', {
+        error: err,
+        ids: selectedIds,
+        role
+      });
+      toast.error('Échec de la mise à jour');
+    } finally {
+      setBulkLoading(false);
+    }
+  };
+
+  const bulkDelete = async () => {
+    if (selectedIds.length === 0) return;
+    try {
+      setBulkLoading(true);
+      const { error } = await supabase
+        .from('users')
+        .delete()
+        .in('id', selectedIds);
+      if (error) throw error;
+      toast.success('Utilisateurs supprimés');
+      await search();
+    } catch (err) {
+      logger.error('Erreur suppression utilisateurs', {
+        error: err,
+        ids: selectedIds
+      });
+      toast.error('Échec de la suppression');
+    } finally {
+      setBulkLoading(false);
     }
   };
 
@@ -123,10 +184,49 @@ export default function UserManagement() {
         </button>
       </div>
 
+      {selectedIds.length > 0 && (
+        <div className="bg-white p-4 rounded-lg shadow-sm flex flex-wrap items-center gap-3">
+          <select
+            value={bulkRole}
+            onChange={(e) => setBulkRole(e.target.value as Role)}
+            className="px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500 text-sm"
+            aria-label="Nouveau rôle"
+          >
+            {ROLES.map((r) => (
+              <option key={r} value={r}>{r}</option>
+            ))}
+          </select>
+          <button
+            onClick={() => bulkUpdateRole(bulkRole)}
+            disabled={bulkLoading}
+            className="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-md text-sm font-medium"
+          >
+            <Save className="h-4 w-4" />
+            Modifier rôle
+          </button>
+          <button
+            onClick={bulkDelete}
+            disabled={bulkLoading}
+            className="inline-flex items-center gap-2 text-sm text-red-600 hover:text-red-800 px-4 py-2 rounded-md hover:bg-red-50"
+          >
+            <Trash2 className="h-4 w-4" />
+            Supprimer
+          </button>
+        </div>
+      )}
+
       <div className="bg-white rounded-lg shadow-sm overflow-hidden">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
+              <th className="px-6 py-3">
+                <input
+                  type="checkbox"
+                  checked={allSelected}
+                  onChange={toggleSelectAll}
+                  aria-label="Sélectionner tous les utilisateurs"
+                />
+              </th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rôle</th>
               <th className="px-6 py-3"></th>
@@ -135,6 +235,14 @@ export default function UserManagement() {
           <tbody className="bg-white divide-y divide-gray-200">
             {users.map((u) => (
               <tr key={u.id}>
+                <td className="px-6 py-4">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.includes(u.id)}
+                    onChange={() => toggleSelection(u.id)}
+                    aria-label={`Sélectionner ${u.email}`}
+                  />
+                </td>
                 <td className="px-6 py-4 text-sm text-gray-900">{u.email}</td>
                 <td className="px-6 py-4">
                   <select
@@ -164,7 +272,7 @@ export default function UserManagement() {
             ))}
             {users.length === 0 && (
               <tr>
-                <td className="px-6 py-10 text-center text-sm text-gray-500" colSpan={3}>
+                <td className="px-6 py-10 text-center text-sm text-gray-500" colSpan={4}>
                   Aucun utilisateur trouvé.
                 </td>
               </tr>

--- a/src/pages/admin/__tests__/UserManagement.test.tsx
+++ b/src/pages/admin/__tests__/UserManagement.test.tsx
@@ -107,4 +107,63 @@ describe("Admin UserManagement", () => {
       expect(successToast).toHaveBeenCalled();
     });
   });
+
+  it("bulk updates roles for selected users", async () => {
+    const users = [
+      { id: "u1", email: "a@test.com", role: "client" as const },
+      { id: "u2", email: "b@test.com", role: "client" as const }
+    ];
+
+    const updateIn = vi.fn().mockResolvedValue({ error: null });
+
+    const usersBuilder = {
+      select: vi.fn(function (this: typeof usersBuilder) {
+        return this;
+      }),
+      limit: vi.fn(function (this: typeof usersBuilder) {
+        return this;
+      }),
+      eq: vi.fn(function (this: typeof usersBuilder) {
+        return this;
+      }),
+      ilike: vi.fn().mockResolvedValue({ data: users, error: null }),
+      update: vi.fn(() => ({ in: updateIn })),
+      then: vi.fn((resolve: (value: { data: typeof users; error: null }) => unknown) =>
+        resolve({ data: users, error: null })
+      )
+    };
+
+    type UsersQueryBuilder = typeof usersBuilder;
+
+    const { default: UserManagement } = await import("../UserManagement");
+    const supa = (await import("../../../lib/supabase")) as unknown as {
+      supabase: {
+        from: (table: string) => UsersQueryBuilder | Record<string, never>;
+      };
+    };
+    supa.supabase.from = vi.fn((table: string) =>
+      table === "users" ? (usersBuilder as unknown as UsersQueryBuilder) : {}
+    );
+
+    render(<UserManagement />);
+
+    await waitFor(() => {
+      const noResultsMessage = screen.queryByText(/Aucun utilisateur trouvé/i);
+      expect(noResultsMessage).not.toBeInTheDocument();
+    });
+
+    const selectAll = screen.getByLabelText(/Sélectionner tous les utilisateurs/i);
+    fireEvent.click(selectAll);
+
+    const bulkSelect = screen.getByLabelText(/Nouveau rôle/i);
+    fireEvent.change(bulkSelect, { target: { value: "pony_provider" } });
+
+    const applyButton = screen.getByText(/Modifier rôle/i);
+    fireEvent.click(applyButton);
+
+    await waitFor(() => {
+      expect(updateIn).toHaveBeenCalledWith("id", ["u1", "u2"]);
+      expect(successToast).toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- add selectable rows and bulk actions to user management
- support bulk role update and deletion
- cover bulk role update with tests

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b229ef772c832b8fb2b25176cbdc7d