### PR TITLE
Remove deprecated park_offer references

### DIFF
--- a/src/lib/cart.ts
+++ b/src/lib/cart.ts
@@ -463,9 +463,6 @@ export function calculateCartTotal(items: CartItem[]): number {
   return items.reduce((total, item) => total + item.pass.price * item.quantity, 0);
 }
 
-// Add a park offer to cart
-// Removed deprecated park_offer flow
-
 // Add an activity variant to cart (Parc activity-first model)
 export async function addActivityVariantToCart(
   variantId: string,

--- a/supabase/migrations/20250828001000_cart_items_product.sql
+++ b/supabase/migrations/20250828001000_cart_items_product.sql
@@ -1,6 +1,6 @@
 -- Extend cart_items to support multiple product types
 ALTER TABLE cart_items
-  ADD COLUMN IF NOT EXISTS product_type text CHECK (product_type IN ('event_pass','park_offer')),
+  ADD COLUMN IF NOT EXISTS product_type text CHECK (product_type IN ('event_pass','activity_variant')),
   ADD COLUMN IF NOT EXISTS product_id uuid;
 
 CREATE INDEX IF NOT EXISTS idx_cart_items_product ON cart_items(product_type, product_id);


### PR DESCRIPTION
## Summary
- drop obsolete park_offer comment in cart helpers
- restrict cart_items product_type to event_pass and activity_variant

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b2cb3c3740832ba9723304f4570e14