### PR TITLE
fix: wrap loaders with useCallback

### DIFF
--- a/src/components/admin/AnimationsManager.tsx
+++ b/src/components/admin/AnimationsManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { X, Plus, Edit, Trash2, Clock, MapPin, Users, Eye, EyeOff } from 'lucide-react';
 import { format } from 'date-fns';
@@ -34,11 +34,7 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
   const [showCreateForm, setShowCreateForm] = useState(false);
   const [editingAnimation, setEditingAnimation] = useState<Animation | null>(null);
 
-  useEffect(() => {
-    loadAnimations();
-  }, []);
-
-  const loadAnimations = async () => {
+  const loadAnimations = useCallback(async () => {
     try {
       setLoading(true);
       const { data, error } = await supabase
@@ -58,7 +54,11 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
     } finally {
       setLoading(false);
     }
-  };
+  }, [event.id]);
+
+  useEffect(() => {
+    loadAnimations();
+  }, [loadAnimations]);
 
   const handleDeleteAnimation = async (animationId: string) => {
     if (!confirm('Êtes-vous sûr de vouloir supprimer cette animation ?')) return;

--- a/src/components/admin/EventActivitiesManager.tsx
+++ b/src/components/admin/EventActivitiesManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { X, Plus, Settings, Clock, Users, Target, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
@@ -42,11 +42,7 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
   const [showAddModal, setShowAddModal] = useState(false);
   const [showTimeSlotsModal, setShowTimeSlotsModal] = useState<EventActivity | null>(null);
 
-  useEffect(() => {
-    loadData();
-  }, []);
-
-  const loadData = async () => {
+  const loadData = useCallback(async () => {
     try {
       setLoading(true);
       
@@ -101,7 +97,11 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
     } finally {
       setLoading(false);
     }
-  };
+  }, [event.id]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
 
   const handleRemoveActivity = async (eventActivityId: string) => {
     if (!confirm('Êtes-vous sûr de vouloir retirer cette activité de l\'événement ?')) return;

--- a/src/components/admin/TimeSlotsManager.tsx
+++ b/src/components/admin/TimeSlotsManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { X, Plus, Trash2, Clock, Users } from 'lucide-react';
 import { format, addMinutes, startOfDay } from 'date-fns';
@@ -38,11 +38,7 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
   const [loading, setLoading] = useState(true);
   const [showCreateForm, setShowCreateForm] = useState(false);
 
-  useEffect(() => {
-    loadTimeSlots();
-  }, []);
-
-  const loadTimeSlots = async () => {
+  const loadTimeSlots = useCallback(async () => {
     try {
       setLoading(true);
       const { data, error } = await supabase
@@ -73,7 +69,11 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
     } finally {
       setLoading(false);
     }
-  };
+  }, [eventActivity.id]);
+
+  useEffect(() => {
+    loadTimeSlots();
+  }, [loadTimeSlots]);
 
   const handleDeleteSlot = async (slotId: string) => {
     if (!confirm('Êtes-vous sûr de vouloir supprimer ce créneau ?')) return;

--- a/src/pages/EventCGV.tsx
+++ b/src/pages/EventCGV.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, FileText } from 'lucide-react';
@@ -17,16 +17,11 @@ export default function EventCGV() {
   const [event, setEvent] = useState<Event | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    if (eventId) {
-      loadEventCGV();
-    }
-  }, [eventId]);
-
-  const loadEventCGV = async () => {
+  const loadEventCGV = useCallback(async () => {
+    if (!eventId) return;
     try {
       setLoading(true);
-      
+
       const { data, error } = await supabase
         .from('events')
         .select('id, name, cgv_content')
@@ -42,7 +37,11 @@ export default function EventCGV() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [eventId]);
+
+  useEffect(() => {
+    loadEventCGV();
+  }, [loadEventCGV]);
 
   if (loading) {
     return (

--- a/src/pages/admin/FlowManagement.tsx
+++ b/src/pages/admin/FlowManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Users, Clock, Calendar, Download, Mail, CheckCircle, AlertCircle } from 'lucide-react';
 import { format } from 'date-fns';
@@ -42,17 +42,7 @@ export default function FlowManagement() {
   const [selectedSlot, setSelectedSlot] = useState<TimeSlotWithReservations | null>(null);
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    loadEvents();
-  }, []);
-
-  useEffect(() => {
-    if (selectedEvent && selectedDate) {
-      loadTimeSlots();
-    }
-  }, [selectedEvent, selectedDate]);
-
-  const loadEvents = async () => {
+  const loadEvents = useCallback(async () => {
     try {
       const { data, error } = await supabase
         .from('events')
@@ -74,12 +64,13 @@ export default function FlowManagement() {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const loadTimeSlots = async () => {
+  const loadTimeSlots = useCallback(async () => {
+    if (!selectedEvent || !selectedDate) return;
     try {
       setLoading(true);
-      
+
       const startDate = new Date(selectedDate);
       startDate.setHours(0, 0, 0, 0);
       const endDate = new Date(selectedDate);
@@ -139,7 +130,15 @@ export default function FlowManagement() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedEvent, selectedDate]);
+
+  useEffect(() => {
+    loadEvents();
+  }, [loadEvents]);
+
+  useEffect(() => {
+    loadTimeSlots();
+  }, [loadTimeSlots]);
 
   const exportParticipantsList = (slot: TimeSlotWithReservations) => {
     const csvContent = [

--- a/src/pages/admin/Reports.tsx
+++ b/src/pages/admin/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { BarChart3, TrendingUp, Euro, Users, Download } from 'lucide-react';
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, PieChart, Pie, Cell } from 'recharts';
@@ -35,11 +35,7 @@ export default function Reports() {
     end: format(endOfMonth(new Date()), 'yyyy-MM-dd')
   });
 
-  useEffect(() => {
-    loadReportData();
-  }, [dateRange]);
-
-  const loadReportData = async () => {
+  const loadReportData = useCallback(async () => {
     try {
       setLoading(true);
 
@@ -134,7 +130,11 @@ export default function Reports() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [dateRange]);
+
+  useEffect(() => {
+    loadReportData();
+  }, [loadReportData]);
 
   const exportReport = () => {
     if (!reportData) return;

--- a/src/pages/admin/TimeSlotManagement.tsx
+++ b/src/pages/admin/TimeSlotManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Calendar, Clock, Users, Filter, Eye, BarChart3, AlertCircle } from 'lucide-react';
 import { format, startOfDay, endOfDay, eachHourOfInterval, isSameHour } from 'date-fns';
@@ -41,17 +41,7 @@ export default function TimeSlotManagement() {
   const [viewMode, setViewMode] = useState<ViewMode>('dashboard');
   const [loading, setLoading] = useState(true);
 
-  useEffect(() => {
-    loadEvents();
-  }, []);
-
-  useEffect(() => {
-    if (selectedEvent && selectedDate) {
-      loadTimeSlots();
-    }
-  }, [selectedEvent, selectedDate]);
-
-  const loadEvents = async () => {
+  const loadEvents = useCallback(async () => {
     try {
       setLoading(true);
       const { data, error } = await supabase
@@ -74,12 +64,13 @@ export default function TimeSlotManagement() {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
-  const loadTimeSlots = async () => {
+  const loadTimeSlots = useCallback(async () => {
+    if (!selectedEvent || !selectedDate) return;
     try {
       setLoading(true);
-      
+
       const startDate = startOfDay(new Date(selectedDate));
       const endDate = endOfDay(new Date(selectedDate));
 
@@ -138,7 +129,15 @@ export default function TimeSlotManagement() {
     } finally {
       setLoading(false);
     }
-  };
+  }, [selectedEvent, selectedDate]);
+
+  useEffect(() => {
+    loadEvents();
+  }, [loadEvents]);
+
+  useEffect(() => {
+    loadTimeSlots();
+  }, [loadTimeSlots]);
 
   const getCapacityColor = (remaining: number, total: number) => {
     const percentage = (remaining / total) * 100;

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-refresh/only-export-components */
 import React from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';


### PR DESCRIPTION
## Summary
- memoize animation loading with `useCallback`
- add missing hook dependencies across admin pages
- silence `react-refresh/only-export-components` warning in test utils

## Testing
- `npm run lint`
- `npx vitest run --reporter=basic`

------
https://chatgpt.com/codex/tasks/task_e_68b2d92c4318832b86e61c6c858705e9