### PR TITLE
refactor: memoize event and recipient loaders

### DIFF
--- a/src/pages/admin/Communication.tsx
+++ b/src/pages/admin/Communication.tsx
@@ -133,7 +133,7 @@ L'équipe BilletEvent`
 
   useEffect(() => {
     loadRecipientCount();
-  }, [loadRecipientCount]);
+  }, [selectedEvent, loadRecipientCount]);
 
   const handleSendEmail = async () => {
     if (!selectedEvent || !emailSubject || !emailContent) {


### PR DESCRIPTION
## Summary
- memoize event and recipient loaders with `useCallback`
- update effects to depend on these callbacks and selected event

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2e8e472f4832b8892ca213b5985b5