### PR TITLE
fix: include date range in report effect dependencies

### DIFF
--- a/src/pages/admin/Reports.tsx
+++ b/src/pages/admin/Reports.tsx
@@ -134,7 +134,7 @@ export default function Reports() {
 
   useEffect(() => {
     loadReportData();
-  }, [loadReportData]);
+  }, [dateRange, loadReportData]);
 
   const exportReport = () => {
     if (!reportData) return;


### PR DESCRIPTION
## Summary
- memoize report loader with useCallback and ensure effect depends on date range changes

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f2a223f8832ba6bfffa5b30c11ec