### PR TITLE
Silence React Router warnings in tests

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -2,6 +2,9 @@ import '@testing-library/jest-dom';
 import { vi, expect } from 'vitest';
 import React from 'react';
 import { toHaveNoViolations } from 'jest-axe';
+import { installConsoleFilters } from '../lib/consoleFilters';
+
+installConsoleFilters();
 
 expect.extend(toHaveNoViolations);
 


### PR DESCRIPTION
## Summary
- add console filter installation in test setup to ignore React Router future flag warnings

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f8eb3d1c832b9fbd6e608b4d6bbe