### PR TITLE
test: remove MemoryRouter future flags in test utils

### DIFF
--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -5,13 +5,16 @@ import { MemoryRouter } from 'react-router-dom';
 
 // Custom render function with providers
 const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
+  const futureConfig =
+    import.meta.env.MODE === 'test'
+      ? undefined
+      : {
+          v7_startTransition: true,
+          v7_relativeSplatPath: true,
+        };
+
   return (
-    <MemoryRouter
-      future={{
-        v7_startTransition: true,
-        v7_relativeSplatPath: true,
-      }}
-    >
+    <MemoryRouter future={futureConfig}>
       {children}
     </MemoryRouter>
   );


### PR DESCRIPTION
## Summary
- conditionally apply react-router future flags in MemoryRouter during tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2f9e6b0a4832b8b3a4b77721d7dd9