### PR TITLE
feat: verify Supabase env variables in Edge function

### DIFF
--- a/supabase/functions/request-reservation-email/index.ts
+++ b/supabase/functions/request-reservation-email/index.ts
@@ -8,8 +8,16 @@
 import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
 import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
 
-const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
-const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+function getEnvVar(name: string): string {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing environment variable: ${name}`);
+  }
+  return value;
+}
+
+const supabaseUrl = getEnvVar('SUPABASE_URL');
+const serviceRoleKey = getEnvVar('SUPABASE_SERVICE_ROLE_KEY');
 
 const supabase = createClient(supabaseUrl, serviceRoleKey);
 


### PR DESCRIPTION
## Summary
- validate required Supabase environment variables in request-reservation-email function

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fe5e3bc4832b99239943bdb283fb