### PR TITLE
fix: gérer les erreurs de demande d'e-mail

### DIFF
--- a/src/lib/__tests__/requestReservationEmail.test.ts
+++ b/src/lib/__tests__/requestReservationEmail.test.ts
@@ -27,7 +27,7 @@ describe('requestReservationEmail', () => {
     });
   });
 
-  it('should return null on failure', async () => {
+  it('should throw on failure', async () => {
     vi.mocked(supabase.functions.invoke).mockResolvedValue({
       data: null,
       error: { message: 'fail' },
@@ -35,7 +35,7 @@ describe('requestReservationEmail', () => {
 
     await expect(
       requestReservationEmail({ email: 'test@example.com' })
-    ).resolves.toBeNull();
+    ).rejects.toThrow('fail');
   });
 });
 

--- a/src/lib/requestReservationEmail.ts
+++ b/src/lib/requestReservationEmail.ts
@@ -1,6 +1,7 @@
 import { supabase } from './supabase';
+import { logger } from './logger';
 
-export async function requestReservationEmail(params: { email: string }): Promise<{ found: boolean; sent?: boolean } | null> {
+export async function requestReservationEmail(params: { email: string }): Promise<{ found: boolean; sent?: boolean }> {
   try {
     const { data, error } = await supabase.functions.invoke<{ found: boolean; sent?: boolean }>('request-reservation-email', {
       body: { email: params.email },
@@ -8,7 +9,8 @@ export async function requestReservationEmail(params: { email: string }): Promis
 
     if (error) throw new Error(error.message);
     return data;
-  } catch {
-    return null;
+  } catch (err) {
+    logger.error('Erreur requestReservationEmail', { error: err });
+    throw err;
   }
 }

--- a/src/pages/FindTicket.tsx
+++ b/src/pages/FindTicket.tsx
@@ -28,7 +28,6 @@ export default function FindTicket() {
       
       // Demander au serveur d'envoyer l'e-mail (sans exposer la table)
       const res = await requestReservationEmail({ email });
-      if (!res) throw new Error('Service indisponible');
 
       if (res.found && res.sent) {
         setFound(true);
@@ -38,7 +37,11 @@ export default function FindTicket() {
       }
     } catch (err) {
       logger.error('Erreur recherche billet', { error: err });
-      toast.error('Une erreur est survenue lors de la recherche');
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : 'Une erreur est survenue lors de la recherche'
+      );
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Summary
- log and rethrow errors in requestReservationEmail
- display API error messages in FindTicket page
- update requestReservationEmail tests for thrown errors

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fffe69fc832b9484834644a0b285