### PR TITLE
Reserve pass stock with SQL function

### DIFF
--- a/src/lib/__tests__/cartRepository.test.ts
+++ b/src/lib/__tests__/cartRepository.test.ts
@@ -132,8 +132,7 @@ describe("SupabaseCartRepository", () => {
 
   describe("insertCartItem", () => {
     it("saves new item", async () => {
-      const insert = vi.fn().mockResolvedValue({ error: null });
-      vi.mocked(supabase.from).mockReturnValue({ insert } as never);
+      vi.mocked(supabase.rpc).mockResolvedValue({ error: null } as never);
       const result = await repo.insertCartItem(
         "sess",
         "pass",
@@ -142,24 +141,27 @@ describe("SupabaseCartRepository", () => {
         2
       );
       expect(result).toBe(true);
-      expect(insert).toHaveBeenCalledWith({
-        session_id: "sess",
-        pass_id: "pass",
-        event_activity_id: undefined,
-        time_slot_id: undefined,
-        quantity: 2,
-        product_id: null,
-        product_type: "event_pass",
-        access_conditions_ack: false,
-        attendee_birth_year: undefined,
-        attendee_first_name: undefined,
-        attendee_last_name: undefined,
-      });
+      expect(supabase.rpc).toHaveBeenCalledWith(
+        "reserve_pass_with_stock_check",
+        {
+          session_id: "sess",
+          pass_id: "pass",
+          time_slot_id: undefined,
+          quantity: 2,
+          attendee_first_name: undefined,
+          attendee_last_name: undefined,
+          attendee_birth_year: undefined,
+          access_conditions_ack: false,
+          product_type: "event_pass",
+          product_id: null,
+        }
+      );
     });
 
     it("returns false on insert error", async () => {
-      const insert = vi.fn().mockResolvedValue({ error: { message: "err" } });
-      vi.mocked(supabase.from).mockReturnValue({ insert } as never);
+      vi
+        .mocked(supabase.rpc)
+        .mockResolvedValue({ error: { message: "err" } } as never);
       const result = await repo.insertCartItem("sess", "pass");
       expect(result).toBe(false);
     });

--- a/src/lib/cartRepository.ts
+++ b/src/lib/cartRepository.ts
@@ -102,20 +102,18 @@ export class SupabaseCartRepository implements CartRepository {
     attendee?: { firstName?: string; lastName?: string; birthYear?: number; conditionsAck?: boolean },
     product?: { type?: 'event_pass' | 'activity_variant'; id?: string }
   ): Promise<boolean> {
-    const { error } = await supabase
-      .from('cart_items')
-      .insert({
-        session_id: sessionId,
-        pass_id: product?.type === 'activity_variant' ? null : passId,
-        time_slot_id: timeSlotId,
-        quantity,
-        attendee_first_name: attendee?.firstName,
-        attendee_last_name: attendee?.lastName,
-        attendee_birth_year: attendee?.birthYear,
-        access_conditions_ack: attendee?.conditionsAck ?? false,
-        product_type: product?.type ?? 'event_pass',
-        product_id: product?.id ?? null,
-      });
+    const { error } = await supabase.rpc('reserve_pass_with_stock_check', {
+      session_id: sessionId,
+      pass_id: product?.type === 'activity_variant' ? null : passId,
+      time_slot_id: timeSlotId,
+      quantity,
+      attendee_first_name: attendee?.firstName,
+      attendee_last_name: attendee?.lastName,
+      attendee_birth_year: attendee?.birthYear,
+      access_conditions_ack: attendee?.conditionsAck ?? false,
+      product_type: product?.type ?? 'event_pass',
+      product_id: product?.id ?? null,
+    });
     if (error) {
       logger.error('Erreur insertion cart_items', {
         error,

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -340,6 +340,21 @@ export type Database = {
         Args: { pass_uuid: string; quantity_requested: number };
         Returns: boolean;
       };
+      reserve_pass_with_stock_check: {
+        Args: {
+          session_id: string;
+          pass_id: string | null;
+          time_slot_id?: string | null;
+          quantity?: number;
+          attendee_first_name?: string | null;
+          attendee_last_name?: string | null;
+          attendee_birth_year?: number | null;
+          access_conditions_ack?: boolean;
+          product_type?: string;
+          product_id?: string | null;
+        };
+        Returns: void;
+      };
       get_event_passes_activities_stock: {
         Args: { event_uuid: string };
         Returns: {

--- a/supabase/migrations/20250901090000_reserve_pass_with_stock_check.sql
+++ b/supabase/migrations/20250901090000_reserve_pass_with_stock_check.sql
@@ -1,0 +1,53 @@
+-- Function to reserve a pass with stock check and locking
+CREATE OR REPLACE FUNCTION reserve_pass_with_stock_check(
+  session_id text,
+  pass_id uuid,
+  time_slot_id uuid DEFAULT NULL,
+  quantity integer DEFAULT 1,
+  attendee_first_name text DEFAULT NULL,
+  attendee_last_name text DEFAULT NULL,
+  attendee_birth_year integer DEFAULT NULL,
+  access_conditions_ack boolean DEFAULT false,
+  product_type text DEFAULT 'event_pass',
+  product_id uuid DEFAULT NULL
+)
+RETURNS void AS $$
+DECLARE
+  remaining integer;
+BEGIN
+  -- Lock the pass row to prevent concurrent modifications
+  IF pass_id IS NOT NULL THEN
+    PERFORM 1 FROM passes WHERE id = pass_id FOR UPDATE;
+    -- Check remaining stock
+    SELECT get_pass_remaining_stock(pass_id) INTO remaining;
+    IF remaining < quantity THEN
+      RAISE EXCEPTION 'insufficient_stock';
+    END IF;
+  END IF;
+
+  -- Insert the cart item
+  INSERT INTO cart_items(
+    session_id,
+    pass_id,
+    time_slot_id,
+    quantity,
+    attendee_first_name,
+    attendee_last_name,
+    attendee_birth_year,
+    access_conditions_ack,
+    product_type,
+    product_id
+  ) VALUES (
+    session_id,
+    pass_id,
+    time_slot_id,
+    quantity,
+    attendee_first_name,
+    attendee_last_name,
+    attendee_birth_year,
+    access_conditions_ack,
+    product_type,
+    product_id
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- add `reserve_pass_with_stock_check` SQL function to lock pass and prevent overselling
- call new function from `SupabaseCartRepository.insertCartItem`
- type Supabase client for new function and update tests

## Testing
- `npm run lint`
- `npm test src/lib/__tests__/cartRepository.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b30731c8fc832b905ed2852c890173