### PR TITLE
Planifie le nettoyage automatique des paniers expirés

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ Ce script lit les variables d'environnement fournies et les enregistre via `supa
 VITE_SUPABASE_ANON_KEY="votre_clef_anon"
 ```
 
+### Tâches planifiées
+
+Une tâche `pg_cron` exécute `cleanup_expired_cart_items` toutes les 15 minutes afin de supprimer automatiquement les paniers expirés. Elle est définie dans `supabase/migrations/20250901093000_schedule_cleanup_expired_cart_items.sql` et est appliquée lors de l'exécution des migrations (`supabase db reset` ou `supabase migration up`).
+
 ## Rôles et Accès
 
 - Rôles supportés: `admin`, `pony_provider`, `archery_provider`, `luge_provider`, `atlm_collaborator`, `client`.

--- a/supabase/migrations/20250901093000_schedule_cleanup_expired_cart_items.sql
+++ b/supabase/migrations/20250901093000_schedule_cleanup_expired_cart_items.sql
@@ -1,0 +1,15 @@
+-- Enable pg_cron extension for scheduling tasks
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Remove existing job if present to avoid duplicates
+SELECT cron.unschedule(jobid)
+FROM cron.job
+WHERE jobname = 'cleanup_expired_cart_items';
+
+-- Schedule cleanup of expired cart items every 15 minutes
+SELECT
+  cron.schedule(
+    'cleanup_expired_cart_items',
+    '*/15 * * * *',
+    $$SELECT public.cleanup_expired_cart_items();$$
+  );


### PR DESCRIPTION
## Summary
- documente la tâche cron de nettoyage des paniers dans Supabase
- programme l'exécution régulière de `cleanup_expired_cart_items`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b308d87bd4832b86b136099537c880