### PR TITLE
feat: retrieve passes with activities

### DIFF
--- a/src/hooks/__tests__/useEventDetails.test.ts
+++ b/src/hooks/__tests__/useEventDetails.test.ts
@@ -1,17 +1,11 @@
 import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { renderHook, waitFor, act } from '@testing-library/react';
 import { useEventDetails } from '../useEventDetails';
-import {
-  fetchEvent,
-  fetchPasses,
-  fetchEventActivities,
-  fetchTimeSlots,
-} from '../../lib/eventDetails';
+import { fetchEvent, fetchPasses, fetchTimeSlots } from '../../lib/eventDetails';
 
 vi.mock('../../lib/eventDetails', () => ({
   fetchEvent: vi.fn(),
   fetchPasses: vi.fn(),
-  fetchEventActivities: vi.fn(),
   fetchTimeSlots: vi.fn(),
 }));
 
@@ -32,9 +26,25 @@ describe('useEventDetails', () => {
       key_info_content: 'info',
     });
     (fetchPasses as Mock).mockResolvedValue([
-      { id: 'p1', name: 'Pass 1', price: 10, description: 'desc', initial_stock: 10, remaining_stock: 5 },
+      {
+        id: 'p1',
+        name: 'Pass 1',
+        price: 10,
+        description: 'desc',
+        initial_stock: 10,
+        remaining_stock: 5,
+        event_activities: [
+          {
+            id: 'ea1',
+            activity_id: 'a1',
+            stock_limit: null,
+            requires_time_slot: false,
+            remaining_stock: 3,
+            activity: { id: 'a1', name: 'Act', description: '', icon: 'icon' },
+          },
+        ],
+      },
     ]);
-    (fetchEventActivities as Mock).mockResolvedValue([]);
 
     const { result } = renderHook(() => useEventDetails('1'));
 
@@ -42,6 +52,7 @@ describe('useEventDetails', () => {
 
     expect(result.current.event?.name).toBe('Event');
     expect(result.current.passes).toHaveLength(1);
+    expect(result.current.eventActivities).toHaveLength(1);
   });
 
   it('handles errors from services', async () => {
@@ -66,7 +77,6 @@ describe('useEventDetails', () => {
       key_info_content: 'info',
     });
     (fetchPasses as Mock).mockResolvedValue([]);
-    (fetchEventActivities as Mock).mockResolvedValue([]);
     (fetchTimeSlots as Mock).mockRejectedValue(new Error('fail'));
 
     const { result } = renderHook(() => useEventDetails('1'));

--- a/src/hooks/useEventDetails.ts
+++ b/src/hooks/useEventDetails.ts
@@ -7,7 +7,6 @@ import {
   TimeSlot,
   fetchEvent,
   fetchPasses,
-  fetchEventActivities,
   fetchTimeSlots,
 } from '../lib/eventDetails';
 
@@ -45,14 +44,13 @@ export function useEventDetails(eventId?: string): UseEventDetailsResult {
     }
     try {
       setLoading(true);
-      const [evt, passesData, activitiesData] = await Promise.all([
+      const [evt, passesData] = await Promise.all([
         fetchEvent(eventId),
         fetchPasses(eventId),
-        fetchEventActivities(eventId),
       ]);
       setEvent(evt);
       setPasses(passesData);
-      setEventActivities(activitiesData);
+      setEventActivities(passesData.flatMap((p) => p.event_activities));
       setError(null);
     } catch (err) {
       console.error('Erreur chargement événement:', err);
@@ -78,3 +76,4 @@ export function useEventDetails(eventId?: string): UseEventDetailsResult {
 }
 
 export default useEventDetails;
+export type { Pass, EventActivity, Event, TimeSlot } from '../lib/types';

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -381,6 +381,32 @@ export type Database = {
           }[];
         };
       };
+      get_passes_with_activities: {
+        Args: { event_uuid: string };
+        Returns: {
+          id: string;
+          name: string;
+          price: number;
+          description: string;
+          initial_stock: number | null;
+          pass_type?: 'moins_8' | 'plus_8' | 'luge_seule' | 'baby_poney';
+          guaranteed_runs?: number | null;
+          remaining_stock: number;
+          event_activities: {
+            id: string;
+            activity_id: string;
+            stock_limit: number | null;
+            requires_time_slot: boolean;
+            remaining_stock: number;
+            activity: {
+              id: string;
+              name: string;
+              description: string;
+              icon: string;
+            };
+          }[];
+        }[];
+      };
       get_activity_variant_remaining_stock: {
         Args: { variant_uuid: string };
         Returns: number;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -16,6 +16,7 @@ export interface Pass {
   pass_type?: 'moins_8' | 'plus_8' | 'luge_seule' | 'baby_poney';
   /** Optional field: number of guaranteed runs for certain passes */
   guaranteed_runs?: number;
+  event_activities: EventActivity[];
 }
 
 export interface Activity {

--- a/src/pages/__tests__/EventDetails.luge-gating.test.tsx
+++ b/src/pages/__tests__/EventDetails.luge-gating.test.tsx
@@ -35,9 +35,9 @@ describe('EventDetails luge seule gating', () => {
 
   it('disables Pass Luge Seule when -8 or +8 still have stock', () => {
     mockUseEventDetails([
-      { id: 'p-moins', name: 'Pass Moins de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 1 },
-      { id: 'p-plus', name: 'Pass Plus de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 0 },
-      { id: 'p-luge', name: 'Pass Luge Seule', price: 7, description: '', initial_stock: null, remaining_stock: 999999 },
+      { id: 'p-moins', name: 'Pass Moins de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 1, event_activities: [] },
+      { id: 'p-plus', name: 'Pass Plus de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 0, event_activities: [] },
+      { id: 'p-luge', name: 'Pass Luge Seule', price: 7, description: '', initial_stock: null, remaining_stock: 999999, event_activities: [] },
     ]);
 
     render(<EventDetails />);
@@ -53,9 +53,9 @@ describe('EventDetails luge seule gating', () => {
 
   it('enables Pass Luge Seule when both -8 and +8 are sold out', () => {
     mockUseEventDetails([
-      { id: 'p-moins', name: 'Pass Moins de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 0 },
-      { id: 'p-plus', name: 'Pass Plus de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 0 },
-      { id: 'p-luge', name: 'Pass Luge Seule', price: 7, description: '', initial_stock: null, remaining_stock: 999999 },
+      { id: 'p-moins', name: 'Pass Moins de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 0, event_activities: [] },
+      { id: 'p-plus', name: 'Pass Plus de 8 ans', price: 9, description: '', initial_stock: 10, remaining_stock: 0, event_activities: [] },
+      { id: 'p-luge', name: 'Pass Luge Seule', price: 7, description: '', initial_stock: null, remaining_stock: 999999, event_activities: [] },
     ]);
 
     render(<EventDetails />);

--- a/src/pages/__tests__/EventDetails.test.tsx
+++ b/src/pages/__tests__/EventDetails.test.tsx
@@ -65,6 +65,7 @@ describe('EventDetails Page', () => {
           description: 'desc',
           initial_stock: 10,
           remaining_stock: 5,
+          event_activities: [],
         },
       ],
       eventActivities: [

--- a/supabase/sql/get_passes_with_activities.sql
+++ b/supabase/sql/get_passes_with_activities.sql
@@ -1,0 +1,39 @@
+create or replace function public.get_passes_with_activities(event_uuid uuid)
+returns json
+language sql
+security definer
+as $$
+  select coalesce(json_agg(
+    json_build_object(
+      'id', p.id,
+      'name', p.name,
+      'price', p.price,
+      'description', p.description,
+      'initial_stock', p.initial_stock,
+      'pass_type', p.pass_type,
+      'guaranteed_runs', p.guaranteed_runs,
+      'remaining_stock', get_pass_remaining_stock(p.id),
+      'event_activities', coalesce((
+        select json_agg(json_build_object(
+          'id', ea.id,
+          'activity_id', ea.activity_id,
+          'stock_limit', ea.stock_limit,
+          'requires_time_slot', ea.requires_time_slot,
+          'activity', json_build_object(
+            'id', a.id,
+            'name', a.name,
+            'description', a.description,
+            'icon', a.icon
+          ),
+          'remaining_stock', get_event_activity_remaining_stock(ea.id)
+        ))
+        from event_activities ea
+        join activities a on a.id = ea.activity_id
+        join pass_activities pa on pa.event_activity_id = ea.id
+        where pa.pass_id = p.id
+      ), '[]'::json)
+    ) order by p.name
+  ), '[]'::json)
+  from passes p
+  where p.event_id = event_uuid;
+$$;


### PR DESCRIPTION
## Summary
- add RPC to return passes with their activities
- fetch passes via new RPC and expose activities in hook
- adjust types and tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3166e8914832b932c5daf201c15d7