### PR TITLE
fix: calcule le stock maximum des pass via useMemo

### DIFF
--- a/src/__tests__/PassManagement.modal.test.tsx
+++ b/src/__tests__/PassManagement.modal.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import PassManagement from '../pages/admin/PassManagement';
 import { render, screen } from '../test/utils';
@@ -27,5 +27,21 @@ describe('PassManagement add/edit modal', () => {
 
     // Accessibility sanity checks
     expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  it('opens modal without maximum update depth warning', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<PassManagement />);
+
+    const openBtn = await screen.findByRole('button', { name: /Nouveau Pass/i });
+    await userEvent.click(openBtn);
+
+    await screen.findByRole('dialog');
+
+    const hasWarning = errorSpy.mock.calls.some(([msg]) =>
+      String(msg).includes('Maximum update depth exceeded')
+    );
+    expect(hasWarning).toBe(false);
+    errorSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- dérive le stock maximum avec `useMemo` pour les pass admin
- supprime les effets redondants et synchronise le stock initial
- teste l'ouverture de la modale sans avertissement de profondeur

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b31f2c441c832ba8f2b8a945f7ded0