### PR TITLE
feat: streamline pass activity selection

### DIFF
--- a/src/pages/__tests__/EventDetails.test.tsx
+++ b/src/pages/__tests__/EventDetails.test.tsx
@@ -48,7 +48,7 @@ describe('EventDetails Page', () => {
     expect(screen.getByText(/événement introuvable/i)).toBeInTheDocument();
   });
 
-  it('adds pass to cart through modal', async () => {
+  it('adds pass with predefined activities to cart through modal', async () => {
     const refresh = vi.fn();
     vi.mocked(useEventDetails).mockReturnValue({
       event: {
@@ -65,39 +65,41 @@ describe('EventDetails Page', () => {
           description: 'desc',
           initial_stock: 10,
           remaining_stock: 5,
-          event_activities: [],
+          event_activities: [
+            {
+              id: 'activity1',
+              activity: { name: 'Activity 1', description: 'activity desc', icon: '🎉' },
+              stock_limit: null,
+              requires_time_slot: false,
+            },
+            {
+              id: 'activity2',
+              activity: { name: 'Activity 2', description: 'activity2 desc', icon: '🎯' },
+              stock_limit: null,
+              requires_time_slot: false,
+            },
+          ],
         },
       ],
-      eventActivities: [
-        {
-          id: 'activity1',
-          activity: {
-            name: 'Activity 1',
-            description: 'activity desc',
-            icon: '🎉',
-          },
-          stock_limit: null,
-          remaining_stock: 5,
-        },
-      ],
+      eventActivities: [],
       loading: false,
       error: null,
       loadTimeSlotsForActivity: vi.fn(),
       refresh,
-    });
+    } as unknown as ReturnType<typeof useEventDetails>);
 
     vi.mocked(addToCart).mockResolvedValue(true);
 
     render(<EventDetails />);
 
     fireEvent.click(screen.getByRole('button', { name: /ajouter au panier/i }));
-
-    fireEvent.click(screen.getByRole('button', { name: /activity 1/i }));
     const modalButton = screen.getAllByRole('button', { name: /ajouter au panier/i })[1];
     fireEvent.click(modalButton);
 
     await waitFor(() => {
+      expect(addToCart).toHaveBeenCalledTimes(2);
       expect(addToCart).toHaveBeenCalledWith('pass1', 'activity1', undefined, 1, undefined, undefined, expect.anything());
+      expect(addToCart).toHaveBeenCalledWith('pass1', 'activity2', undefined, 1, undefined, undefined, expect.anything());
       expect(refresh).toHaveBeenCalled();
     });
 
@@ -105,5 +107,40 @@ describe('EventDetails Page', () => {
       expect(screen.queryByText(/configurer votre achat/i)).not.toBeInTheDocument();
     });
   });
-});
 
+  it('hides last name field for baby poney passes', () => {
+    vi.mocked(useEventDetails).mockReturnValue({
+      event: {
+        id: 'event',
+        name: 'Event',
+        event_date: '2024-12-25',
+        key_info_content: 'Info',
+      },
+      passes: [
+        {
+          id: 'pass-baby',
+          name: 'Pass Baby',
+          price: 10,
+          description: 'desc',
+          initial_stock: 10,
+          remaining_stock: 5,
+          pass_type: 'baby_poney',
+          event_activities: [],
+        },
+      ],
+      eventActivities: [],
+      loading: false,
+      error: null,
+      loadTimeSlotsForActivity: vi.fn(),
+      refresh: vi.fn(),
+    } as unknown as ReturnType<typeof useEventDetails>);
+
+    render(<EventDetails />);
+
+    fireEvent.click(screen.getByRole('button', { name: /ajouter au panier/i }));
+
+    expect(screen.queryByPlaceholderText(/^Nom$/i)).not.toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/prénom/i)).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/année de naissance/i)).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- simplify PurchaseModal by showing activities per pass and per-activity slot selections
- hide last name field for baby poney participants
- add tests for purchase without activity choice and baby poney form

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b322e6cbd0832bb5623e2b5bb24e5e