### PR TITLE
feat(cart): track activities per cart item

### DIFF
--- a/src/lib/__tests__/cart.test.ts
+++ b/src/lib/__tests__/cart.test.ts
@@ -95,7 +95,7 @@ describe('Cart Functions', () => {
     it('should return false when repository is not configured', async () => {
       const repo = createRepo({ isConfigured: vi.fn().mockReturnValue(false) });
       const notify = vi.fn();
-      const result = await addToCart('pass-id', undefined, undefined, 1, repo, notify);
+      const result = await addToCart('pass-id', [], 1, repo, notify);
       expect(result).toBe(false);
       expect(notify).toHaveBeenCalledWith('error', 'Configuration requise. Veuillez connecter Supabase.');
     });
@@ -105,7 +105,7 @@ describe('Cart Functions', () => {
       const notify = vi.fn();
       mockLocalStorage.getItem.mockReturnValue('session-123');
 
-      const result = await addToCart('pass-id', undefined, undefined, 1, repo, notify);
+      const result = await addToCart('pass-id', [], 1, repo, notify);
       expect(result).toBe(true);
       expect(repo.insertCartItem).toHaveBeenCalled();
       expect(notify).toHaveBeenCalledWith('success', 'Article ajouté au panier');
@@ -114,7 +114,7 @@ describe('Cart Functions', () => {
     it('should return false for invalid quantity', async () => {
       const repo = createRepo();
       const notify = vi.fn();
-      const result = await addToCart('pass-id', undefined, undefined, 0, repo, notify);
+      const result = await addToCart('pass-id', [], 0, repo, notify);
       expect(result).toBe(false);
       expect(notify).toHaveBeenCalledWith('error', 'La quantité doit être un entier positif');
     });
@@ -123,7 +123,7 @@ describe('Cart Functions', () => {
       const repo = createRepo({ insertCartItem: vi.fn().mockRejectedValue(new Error('fail')) });
       const notify = vi.fn();
       const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
-      const result = await addToCart('pass-id', undefined, undefined, 1, repo, notify);
+      const result = await addToCart('pass-id', [], 1, repo, notify);
       expect(result).toBe(false);
       expect(notify).toHaveBeenCalledWith('error', 'Une erreur est survenue');
       expect(spy).toHaveBeenCalled();
@@ -133,13 +133,13 @@ describe('Cart Functions', () => {
   describe('validateStock', () => {
     it('should return null when stock is sufficient', async () => {
       const repo = createRepo();
-      const result = await validateStock(repo, 'pass', undefined, undefined, 1);
+      const result = await validateStock(repo, 'pass', [], 1);
       expect(result).toBeNull();
     });
 
     it('should return error message when stock is insufficient', async () => {
       const repo = createRepo({ getPassRemainingStock: vi.fn().mockResolvedValue(0) });
-      const result = await validateStock(repo, 'pass', undefined, undefined, 1);
+      const result = await validateStock(repo, 'pass', [], 1);
       expect(result).toBe('Stock insuffisant pour ce pass');
     });
   });
@@ -158,9 +158,9 @@ describe('Cart Functions', () => {
     it('should insert item using repository', async () => {
       const insertCartItem = vi.fn().mockResolvedValue(true);
       const repo = createRepo({ insertCartItem });
-      const success = await insertNewItem(repo, 'sess', 'pass', undefined, undefined, 1);
+      const success = await insertNewItem(repo, 'sess', 'pass', [], 1);
       expect(success).toBe(true);
-      expect(insertCartItem).toHaveBeenCalledWith('sess', 'pass', undefined, undefined, 1, undefined, undefined);
+      expect(insertCartItem).toHaveBeenCalledWith('sess', 'pass', [], 1, undefined, undefined);
     });
   });
 

--- a/src/lib/__tests__/cartRepository.test.ts
+++ b/src/lib/__tests__/cartRepository.test.ts
@@ -64,45 +64,33 @@ describe("SupabaseCartRepository", () => {
   });
 
   describe("findCartItem", () => {
-    it("loads item with time slot", async () => {
+    it("loads item", async () => {
       const builder = {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        is: vi.fn().mockReturnThis(),
-        maybeSingle: vi
-          .fn()
-          .mockResolvedValue({ data: { id: "1", quantity: 2 } }),
+        maybeSingle: vi.fn().mockResolvedValue({ data: { id: "1", quantity: 2 } }),
       };
       vi.mocked(supabase.from).mockReturnValue(builder as never);
-      const result = await repo.findCartItem(
-        "sess",
-        "pass",
-        "activity",
-        "slot"
-      );
+      const result = await repo.findCartItem("sess", "pass");
       expect(result).toEqual({ id: "1", quantity: 2 });
-      expect(builder.eq).toHaveBeenCalledWith("time_slot_id", "slot");
-      expect(builder.is).not.toHaveBeenCalled();
+      expect(builder.eq).toHaveBeenCalledWith("pass_id", "pass");
     });
 
-    it("loads item without time slot", async () => {
+    it("returns null when not found", async () => {
       const builder = {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        is: vi.fn().mockReturnThis(),
         maybeSingle: vi.fn().mockResolvedValue({ data: null }),
       };
       vi.mocked(supabase.from).mockReturnValue(builder as never);
       const result = await repo.findCartItem("sess", "pass");
       expect(result).toBeNull();
-      expect(builder.is).toHaveBeenCalledWith("time_slot_id", null);
     });
 
     it("propagates errors from query", async () => {
       const builder = {
         select: vi.fn().mockReturnThis(),
         eq: vi.fn().mockReturnThis(),
-        is: vi.fn().mockReturnThis(),
         maybeSingle: vi.fn().mockRejectedValue(new Error("fail")),
       };
       vi.mocked(supabase.from).mockReturnValue(builder as never);
@@ -133,20 +121,14 @@ describe("SupabaseCartRepository", () => {
   describe("insertCartItem", () => {
     it("saves new item", async () => {
       vi.mocked(supabase.rpc).mockResolvedValue({ error: null } as never);
-      const result = await repo.insertCartItem(
-        "sess",
-        "pass",
-        undefined,
-        undefined,
-        2
-      );
+      const result = await repo.insertCartItem("sess", "pass", [], 2);
       expect(result).toBe(true);
       expect(supabase.rpc).toHaveBeenCalledWith(
         "reserve_pass_with_stock_check",
         {
           session_id: "sess",
           pass_id: "pass",
-          time_slot_id: undefined,
+          activities: [],
           quantity: 2,
           attendee_first_name: undefined,
           attendee_last_name: undefined,

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -238,6 +238,26 @@ export type Database = {
           product_id?: string | null;
         };
       };
+      cart_item_activities: {
+        Row: {
+          id: string;
+          cart_item_id: string;
+          event_activity_id: string;
+          time_slot_id: string | null;
+        };
+        Insert: {
+          id?: string;
+          cart_item_id: string;
+          event_activity_id: string;
+          time_slot_id?: string | null;
+        };
+        Update: {
+          id?: string;
+          cart_item_id?: string;
+          event_activity_id?: string;
+          time_slot_id?: string | null;
+        };
+      };
       park_time_slots: {
         Row: {
           id: string;
@@ -344,7 +364,7 @@ export type Database = {
         Args: {
           session_id: string;
           pass_id: string | null;
-          time_slot_id?: string | null;
+          activities?: { event_activity_id: string; time_slot_id?: string | null }[] | null;
           quantity?: number;
           attendee_first_name?: string | null;
           attendee_last_name?: string | null;

--- a/src/pages/EventDetails.tsx
+++ b/src/pages/EventDetails.tsx
@@ -56,21 +56,21 @@ export default function EventDetails() {
         birthYear: a.birthYear ? parseInt(a.birthYear) : undefined,
         conditionsAck: a.ack === true,
       };
-      for (const eventActivity of selectedPass.event_activities) {
-        const timeSlotId = selectedSlots[i]?.[eventActivity.id];
-        const success = await addToCart(
-          selectedPass.id,
-          eventActivity.id,
-          timeSlotId,
-          1,
-          undefined,
-          undefined,
-          attendee
-        );
-        if (!success) {
-          toast.error(`Erreur lors de l'ajout du pass ${i + 1}`);
-          return;
-        }
+      const activities = selectedPass.event_activities.map((eventActivity) => ({
+        eventActivityId: eventActivity.id,
+        timeSlotId: selectedSlots[i]?.[eventActivity.id],
+      }));
+      const success = await addToCart(
+        selectedPass.id,
+        activities,
+        1,
+        undefined,
+        undefined,
+        attendee
+      );
+      if (!success) {
+        toast.error(`Erreur lors de l'ajout du pass ${i + 1}`);
+        return;
       }
     }
 

--- a/src/pages/__tests__/EventDetails.test.tsx
+++ b/src/pages/__tests__/EventDetails.test.tsx
@@ -97,9 +97,18 @@ describe('EventDetails Page', () => {
     fireEvent.click(modalButton);
 
     await waitFor(() => {
-      expect(addToCart).toHaveBeenCalledTimes(2);
-      expect(addToCart).toHaveBeenCalledWith('pass1', 'activity1', undefined, 1, undefined, undefined, expect.anything());
-      expect(addToCart).toHaveBeenCalledWith('pass1', 'activity2', undefined, 1, undefined, undefined, expect.anything());
+      expect(addToCart).toHaveBeenCalledTimes(1);
+      expect(addToCart).toHaveBeenCalledWith(
+        'pass1',
+        [
+          { eventActivityId: 'activity1', timeSlotId: undefined },
+          { eventActivityId: 'activity2', timeSlotId: undefined },
+        ],
+        1,
+        undefined,
+        undefined,
+        expect.anything()
+      );
       expect(refresh).toHaveBeenCalled();
     });
 

--- a/supabase/migrations/20250902000000_cart_item_activities.sql
+++ b/supabase/migrations/20250902000000_cart_item_activities.sql
@@ -1,0 +1,12 @@
+-- Create cart_item_activities table to store selected activities per cart item
+CREATE TABLE IF NOT EXISTS cart_item_activities (
+  id uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+  cart_item_id uuid NOT NULL REFERENCES cart_items(id) ON DELETE CASCADE,
+  event_activity_id uuid NOT NULL REFERENCES event_activities(id) ON DELETE CASCADE,
+  time_slot_id uuid REFERENCES time_slots(id) ON DELETE CASCADE
+);
+
+ALTER TABLE cart_item_activities ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "Anyone can manage their cart item activities"
+  ON cart_item_activities FOR ALL
+  USING (true);

--- a/supabase/migrations/20250902001000_update_reserve_pass_with_stock_check.sql
+++ b/supabase/migrations/20250902001000_update_reserve_pass_with_stock_check.sql
@@ -1,0 +1,85 @@
+-- Update reserve_pass_with_stock_check to handle multiple activities
+CREATE OR REPLACE FUNCTION reserve_pass_with_stock_check(
+  session_id text,
+  pass_id uuid,
+  activities jsonb DEFAULT '[]'::jsonb,
+  quantity integer DEFAULT 1,
+  attendee_first_name text DEFAULT NULL,
+  attendee_last_name text DEFAULT NULL,
+  attendee_birth_year integer DEFAULT NULL,
+  access_conditions_ack boolean DEFAULT false,
+  product_type text DEFAULT 'event_pass',
+  product_id uuid DEFAULT NULL
+)
+RETURNS void AS $$
+DECLARE
+  remaining integer;
+  cart_item_uuid uuid;
+  act RECORD;
+BEGIN
+  -- Lock and check pass stock
+  IF pass_id IS NOT NULL THEN
+    PERFORM 1 FROM passes WHERE id = pass_id FOR UPDATE;
+    SELECT get_pass_remaining_stock(pass_id) INTO remaining;
+    IF remaining < quantity THEN
+      RAISE EXCEPTION 'insufficient_stock';
+    END IF;
+  END IF;
+
+  -- Verify stock for each activity/time slot
+  FOR act IN
+    SELECT (value->>'event_activity_id')::uuid AS event_activity_id,
+           (value->>'time_slot_id')::uuid AS time_slot_id
+    FROM jsonb_array_elements(activities)
+  LOOP
+    PERFORM 1 FROM event_activities WHERE id = act.event_activity_id FOR UPDATE;
+    SELECT get_event_activity_remaining_stock(act.event_activity_id) INTO remaining;
+    IF remaining < quantity THEN
+      RAISE EXCEPTION 'insufficient_activity_stock';
+    END IF;
+    IF act.time_slot_id IS NOT NULL THEN
+      PERFORM 1 FROM time_slots WHERE id = act.time_slot_id FOR UPDATE;
+      SELECT get_slot_remaining_capacity(act.time_slot_id) INTO remaining;
+      IF remaining < quantity THEN
+        RAISE EXCEPTION 'insufficient_slot_capacity';
+      END IF;
+    END IF;
+  END LOOP;
+
+  -- Insert cart item
+  INSERT INTO cart_items(
+    session_id,
+    pass_id,
+    time_slot_id,
+    quantity,
+    attendee_first_name,
+    attendee_last_name,
+    attendee_birth_year,
+    access_conditions_ack,
+    product_type,
+    product_id
+  ) VALUES (
+    session_id,
+    pass_id,
+    NULL,
+    quantity,
+    attendee_first_name,
+    attendee_last_name,
+    attendee_birth_year,
+    access_conditions_ack,
+    product_type,
+    product_id
+  )
+  RETURNING id INTO cart_item_uuid;
+
+  -- Insert activities
+  FOR act IN
+    SELECT (value->>'event_activity_id')::uuid AS event_activity_id,
+           (value->>'time_slot_id')::uuid AS time_slot_id
+    FROM jsonb_array_elements(activities)
+  LOOP
+    INSERT INTO cart_item_activities(cart_item_id, event_activity_id, time_slot_id)
+    VALUES (cart_item_uuid, act.event_activity_id, act.time_slot_id);
+  END LOOP;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;


### PR DESCRIPTION
## Summary
- support `cart_item_activities` table and activity-aware reservation RPC
- allow adding passes with multiple activities to cart
- create reservations for each cart item activity during checkout

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b3274ac5b4832bbc012009542edf61