### PR TITLE
chore: document setup workflow and integrate prettier

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,22 +3,40 @@
 Ce document définit les règles à suivre pour contribuer au projet. **Chaque collaborateur doit le lire avant toute contribution.**
 
 ## Environnement
+
 - Utiliser Node.js 18 ou version supérieure.
+- Exécuter `./setup.sh` une fois pour installer les dépendances, appliquer les migrations et configurer les secrets (`SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_SECRET`, `WEBHOOK_SECRET`).
+- Pour les relances sur un conteneur mis en cache, utiliser `./maintenance.sh` pour mettre à jour les dépendances et exécuter les migrations.
+- Définir les variables d'environnement nécessaires à l'exécution (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`).
 - Utiliser `npm` pour l'installation et l'exécution des scripts.
 - Ne jamais committer de fichiers `.env` ou d'autres secrets.
 
+## Commandes
+
+- Installer les dépendances : `npm install`
+- Lancer le serveur de développement : `npm run dev`
+- Construire l'application : `npm run build`
+- Lancer les tests : `npm test`
+- Lancer le lint : `npm run lint`
+- Générer la couverture : `npm run test:coverage`
+- Formater le code : `npm run format`
+
 ## Git & Workflow
+
 - Créer une branche depuis `main` pour chaque fonctionnalité ou correctif.
-- Écrire des messages de commit clairs à l'impératif.
+- Nommer les branches de façon descriptive (ex. `feature/xyz`).
+- Écrire des messages de commit clairs à l'impératif en suivant la convention [Conventional Commits](https://www.conventionalcommits.org/).
 - Pousser des commits atomiques et logiques.
 - Ouvrir une Pull Request dès qu'une contribution est prête à être revue.
 
 ## Hooks Git
+
 - `pre-commit` : `npm run lint && npm test && lint-staged`
 - `commit-msg` : `npx commitlint --edit "$1"`
 
 ## Qualité & Style
-- Respecter les configurations ESLint et TypeScript existantes.
+
+- Respecter les configurations ESLint, Prettier et TypeScript existantes.
 - Lancer `npm run lint` et `npm test` avant de soumettre des changements.
 - Préférer un code lisible, typé et sans warnings.
 - TypeScript doit utiliser le mode `strict`.
@@ -27,18 +45,24 @@ Ce document définit les règles à suivre pour contribuer au projet. **Chaque c
 - L'usage de `any` est interdit sans justification explicite.
 
 ## Sécurité
+
 - Ne jamais exposer de secrets, mots de passe ou clés d'API dans le dépôt.
+- Les variables `VITE_SUPABASE_URL` et `VITE_SUPABASE_ANON_KEY` sont requises au runtime.
+- Les secrets (`SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_SECRET`, `WEBHOOK_SECRET`) doivent être fournis via `setup.sh`.
 - Vérifier les dépendances et maintenir le projet à jour.
 
 ## UI/UX
+
 - Privilégier un design accessible et responsive.
 - Réutiliser les composants existants et suivre les conventions de style.
 
 ## Documentation
+
 - Mettre à jour la documentation (README, architecture, etc.) lors de l'ajout de fonctionnalités.
 - Ajouter des commentaires aux parties complexes du code.
 
 ## Definition of Done
+
 - Les tests et le lint passent (`npm test`, `npm run lint`).
 - La fonctionnalité est documentée et testée.
 - La Pull Request est relue et reçoit au moins une approbation.

--- a/README.md
+++ b/README.md
@@ -4,14 +4,13 @@
 
 ## Prérequis
 
-* [Node.js](https://nodejs.org/) version 18 ou supérieure
-* [npm](https://www.npmjs.com/)
-* [Supabase CLI](https://supabase.com/docs/reference/cli/installation)
-* Compte Supabase avec base de données
-* Fichier `.env` avec les variables :
-
-  * `VITE_SUPABASE_URL`
-  * `VITE_SUPABASE_ANON_KEY`
+- [Node.js](https://nodejs.org/) version 18 ou supérieure
+- [npm](https://www.npmjs.com/)
+- [Supabase CLI](https://supabase.com/docs/reference/cli/installation)
+- Compte Supabase avec base de données
+- Fichier `.env` avec les variables :
+  - `VITE_SUPABASE_URL`
+  - `VITE_SUPABASE_ANON_KEY`
 
 ## Installation
 
@@ -21,11 +20,13 @@
    git clone <url>
    cd billeterie-maido
    ```
+
 2. Installer les dépendances :
 
    ```bash
    npm install
    ```
+
 3. Créer un fichier `.env` à la racine et y définir les variables décrites ci-dessus.
 
 ## Gestion des variables sensibles
@@ -34,6 +35,8 @@ Les clés API, jetons et autres secrets doivent être fournis via des variables 
 
 - Le fichier `.env` est ignoré par Git et ne doit être utilisé qu'en développement local.
 - En production, configurez les variables d'environnement directement dans votre plateforme d'hébergement.
+- `VITE_SUPABASE_URL` et `VITE_SUPABASE_ANON_KEY` sont nécessaires au runtime et doivent rester accessibles après le déploiement.
+- Les secrets sensibles (`SUPABASE_SERVICE_ROLE_KEY`, `STRIPE_SECRET`, `WEBHOOK_SECRET`) sont configurés via `setup.sh` et ne sont pas conservés dans l'environnement.
 - Le hook de pré-commit exécute [`git-secrets`](https://github.com/awslabs/git-secrets) pour éviter les fuites accidentelles. Installez l'outil puis lancez `git secrets --install` avant de contribuer.
 
 ## Structure du projet
@@ -51,33 +54,37 @@ Les clés API, jetons et autres secrets doivent être fournis via des variables 
 
 ## Développement
 
-* Lancer le serveur de développement :
+- Lancer le serveur de développement :
 
   ```bash
   npm run dev
   ```
-* L'application est disponible sur [http://localhost:5173](http://localhost:5173).
+
+- L'application est disponible sur [http://localhost:5173](http://localhost:5173).
 
 ## Tests et Lint
 
-* Exécuter la suite de tests :
+- Exécuter la suite de tests :
 
   ```bash
   npm test
   ```
-* Exécuter les tests UI/UX et accessibilité :
+
+- Exécuter les tests UI/UX et accessibilité :
 
   ```bash
   npm run test:ui
   ```
 
   Chaque modification visuelle doit mettre à jour ces tests.
-* Générer le rapport de couverture :
+
+- Générer le rapport de couverture :
 
   ```bash
   npm run test:coverage
   ```
-* Vérifier la qualité du code avec ESLint :
+
+- Vérifier la qualité du code avec ESLint :
 
   ```bash
   npm run lint
@@ -90,11 +97,13 @@ Les clés API, jetons et autres secrets doivent être fournis via des variables 
    ```bash
    npm run build
    ```
+
 2. Prévisualiser la version production :
 
    ```bash
    npm run preview
    ```
+
 3. Déployer le contenu du dossier `dist/` sur la plateforme de votre choix et y configurer les variables d'environnement Supabase.
 
 ## Configuration Supabase
@@ -109,8 +118,10 @@ SUPABASE_SERVICE_ROLE_KEY=<clé> STRIPE_SECRET=<clé> WEBHOOK_SECRET=<clé> ./se
 
 Ce script lit les variables d'environnement fournies et les enregistre via `supabase secrets set`.
 
-* Les migrations SQL se trouvent dans le dossier `supabase/migrations`.
-* Pour appliquer les migrations en local :
+Pour mettre à jour un environnement déjà configuré (dépendances, migrations), exécutez `./maintenance.sh`.
+
+- Les migrations SQL se trouvent dans le dossier `supabase/migrations`.
+- Pour appliquer les migrations en local :
 
   ```bash
   supabase db reset
@@ -121,17 +132,21 @@ Ce script lit les variables d'environnement fournies et les enregistre via `supa
   ```bash
   supabase migration up
   ```
-* Pour créer une nouvelle migration :
+
+- Pour créer une nouvelle migration :
 
   ```bash
   supabase migration new <nom_de_migration>
   ```
-* Les variables d'environnement Supabase doivent être définies dans le fichier `.env` :
+
+- Les variables d'environnement Supabase doivent être définies dans le fichier `.env` :
 
   ```env
   VITE_SUPABASE_URL="https://votre-projet.supabase.co"
-VITE_SUPABASE_ANON_KEY="votre_clef_anon"
-```
+  VITE_SUPABASE_ANON_KEY="votre_clef_anon"
+  ```
+
+````
 
 ### Tâches planifiées
 
@@ -201,7 +216,7 @@ ALTER TABLE cart_items
   ADD COLUMN IF NOT EXISTS attendee_last_name text,
   ADD COLUMN IF NOT EXISTS attendee_birth_year integer,
   ADD COLUMN IF NOT EXISTS access_conditions_ack boolean DEFAULT false;
-```
+````
 
 ### Page d’accueil et événements
 
@@ -219,6 +234,7 @@ La page d’accueil affiche d’abord les « Événements en cours » (ventes ou
    ```
 
    Cette requête garantit que l'entrée de `public.users` correspond à `auth.uid()` avec `role = 'admin'`.
+
 3. La policy `"Admins can manage events"` s'appuie sur cette table pour vérifier le rôle administrateur.
    Si votre application préfère utiliser un claim JWT pour stocker le rôle, adaptez la policy en conséquence et
    assurez‑vous que le token contient `{"role": "admin"}`.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,11 +3,16 @@ import globals from 'globals';
 import reactHooks from 'eslint-plugin-react-hooks';
 import reactRefresh from 'eslint-plugin-react-refresh';
 import tseslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
 
 export default tseslint.config(
   { ignores: ['dist'] },
   {
-    extends: [js.configs.recommended, ...tseslint.configs.recommended],
+    extends: [
+      js.configs.recommended,
+      ...tseslint.configs.recommended,
+      prettier,
+    ],
     files: ['**/*.{ts,tsx}'],
     languageOptions: {
       ecmaVersion: 2020,
@@ -26,5 +31,5 @@ export default tseslint.config(
       'no-console': ['error', { allow: ['warn', 'error'] }],
       '@typescript-eslint/no-explicit-any': 'error',
     },
-  }
+  },
 );

--- a/maintenance.sh
+++ b/maintenance.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+npm install
+
+if command -v supabase >/dev/null; then
+  supabase migration up
+fi

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,6 +41,7 @@
         "@vitest/ui": "^3.2.4",
         "autoprefixer": "^10.4.18",
         "eslint": "^9.9.1",
+        "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react-hooks": "^5.1.0-rc.0",
         "eslint-plugin-react-refresh": "^0.4.11",
         "globals": "^15.9.0",
@@ -49,6 +50,7 @@
         "jsdom": "^23.0.1",
         "lint-staged": "^16.1.5",
         "postcss": "^8.4.35",
+        "prettier": "^3.6.2",
         "tailwindcss": "^3.4.1",
         "typescript": "^5.5.3",
         "typescript-eslint": "^8.3.0",
@@ -4863,6 +4865,22 @@
         }
       }
     },
+    "node_modules/eslint-config-prettier": {
+      "version": "10.1.8",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+      "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "eslint-config-prettier": "bin/cli.js"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint-config-prettier"
+      },
+      "peerDependencies": {
+        "eslint": ">=7.0.0"
+      }
+    },
     "node_modules/eslint-plugin-react-hooks": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
@@ -8777,6 +8795,22 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "test": "npx vitest run",
     "test:ui": "npx vitest --ui",
     "test:coverage": "npx vitest --coverage",
-    "prepare": "husky"
+    "prepare": "husky",
+    "format": "prettier --write ."
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.8",
@@ -47,6 +48,7 @@
     "@vitest/ui": "^3.2.4",
     "autoprefixer": "^10.4.18",
     "eslint": "^9.9.1",
+    "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^5.1.0-rc.0",
     "eslint-plugin-react-refresh": "^0.4.11",
     "globals": "^15.9.0",
@@ -55,6 +57,7 @@
     "jsdom": "^23.0.1",
     "lint-staged": "^16.1.5",
     "postcss": "^8.4.35",
+    "prettier": "^3.6.2",
     "tailwindcss": "^3.4.1",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.3.0",
@@ -62,6 +65,10 @@
     "vitest": "^3.2.4"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "eslint --fix"
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ],
+    "*.{json,md,css}": "prettier --write"
   }
 }

--- a/setup.sh
+++ b/setup.sh
@@ -1,11 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+npm install
+
+if command -v supabase >/dev/null; then
+  supabase migration up
+fi
+
 : "${SUPABASE_SERVICE_ROLE_KEY:?Missing SUPABASE_SERVICE_ROLE_KEY}"
 : "${STRIPE_SECRET:?Missing STRIPE_SECRET}"
 : "${WEBHOOK_SECRET:?Missing WEBHOOK_SECRET}"
 
-cat <<SECRETS | supabase secrets set --env-file -
+cat <<'SECRETS' | supabase secrets set --env-file -
 SUPABASE_SERVICE_ROLE_KEY=${SUPABASE_SERVICE_ROLE_KEY}
 STRIPE_SECRET=${STRIPE_SECRET}
 WEBHOOK_SECRET=${WEBHOOK_SECRET}


### PR DESCRIPTION
## Summary
- expand AGENTS instructions with build/test commands, secret guidance and Prettier policy
- clarify README on runtime env vars vs Supabase secrets and mention maintenance script
- add maintenance script, enhance setup script and integrate Prettier config

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3530238cc832bad2d10b9fcf458a8