### PR TITLE
feat(payment): integrate Stripe checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ Pour mettre à jour un environnement déjà configuré (dépendances, migrations
   supabase migration new <nom_de_migration>
   ```
 
+### Paiement Stripe
+
+Le processus de paiement s'appuie sur **Stripe Checkout**. La fonction Edge
+`create-checkout-session` génère un Payment Intent et redirige l'utilisateur vers
+la page hébergée par Stripe. Une fois le paiement confirmé, le webhook
+`stripe-webhook` crée les réservations correspondantes dans la base.
+
+Déployez les fonctions nécessaires via la CLI :
+
+```bash
+supabase functions deploy create-checkout-session
+supabase functions deploy stripe-webhook --no-verify-jwt
+```
+
+Les variables `STRIPE_SECRET` et `WEBHOOK_SECRET` doivent être définies pour que
+ces fonctions fonctionnent correctement.
+
 - Les variables d'environnement Supabase doivent être définies dans le fichier `.env` :
 
   ```env

--- a/src/pages/__tests__/Cart.test.tsx
+++ b/src/pages/__tests__/Cart.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, afterAll } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen, waitFor } from '../../test/utils';
 import Cart from '../Cart';
 
@@ -7,17 +7,13 @@ vi.mock('../../lib/cart', () => ({
   getCartItems: vi.fn(() => Promise.resolve([])),
   removeFromCart: vi.fn(() => Promise.resolve(true)),
   calculateCartTotal: vi.fn(() => 0),
+  clearCart: vi.fn(() => Promise.resolve(true)),
 }));
-
-vi.stubEnv('VITE_TEST_DELAY_MS', '0');
-afterAll(() => {
-  vi.unstubAllEnvs();
-});
 
 describe('Cart Page', () => {
   it('should render empty cart message when no items', async () => {
     render(<Cart />);
-    
+
     await waitFor(() => {
       expect(screen.getByText(/votre panier est vide/i)).toBeInTheDocument();
     });
@@ -25,7 +21,7 @@ describe('Cart Page', () => {
 
   it('should render cart header', async () => {
     render(<Cart />);
-    
+
     await waitFor(() => {
       expect(screen.getByText(/mon panier/i)).toBeInTheDocument();
     });
@@ -33,7 +29,7 @@ describe('Cart Page', () => {
 
   it('should render navigation link', async () => {
     render(<Cart />);
-    
+
     await waitFor(() => {
       expect(screen.getByText(/continuer mes achats/i)).toBeInTheDocument();
     });
@@ -41,7 +37,7 @@ describe('Cart Page', () => {
 
   it('should render cart items when present', async () => {
     const { getCartItems, calculateCartTotal } = await import('../../lib/cart');
-    
+
     vi.mocked(getCartItems).mockResolvedValue([
       {
         id: '1',
@@ -49,15 +45,15 @@ describe('Cart Page', () => {
           id: '1',
           name: 'Test Pass',
           price: 25,
-          description: 'Test description'
+          description: 'Test description',
         },
-        quantity: 1
-      }
+        quantity: 1,
+      },
     ]);
     vi.mocked(calculateCartTotal).mockReturnValue(25);
-    
+
     render(<Cart />);
-    
+
     await waitFor(() => {
       expect(screen.getByText('Test Pass')).toBeInTheDocument();
       expect(screen.getByText('25€')).toBeInTheDocument();

--- a/supabase/functions/create-checkout-session/index.test.ts
+++ b/supabase/functions/create-checkout-session/index.test.ts
@@ -1,0 +1,63 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let handler: (req: Request) => Promise<Response>;
+
+const createSessionMock = vi.fn();
+const stripeMock = { checkout: { sessions: { create: createSessionMock } } };
+
+vi.mock('https://esm.sh/stripe@13?target=deno', () => ({
+  default: vi.fn(() => stripeMock),
+}));
+
+vi.mock('https://deno.land/std@0.224.0/http/server.ts', () => ({
+  serve: (cb: (req: Request) => Promise<Response>) => {
+    handler = cb;
+  },
+}));
+
+describe('create-checkout-session edge function', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.STRIPE_SECRET = 'sk_test';
+    (
+      globalThis as unknown as {
+        Deno: { env: { get: (n: string) => string | undefined } };
+      }
+    ).Deno = {
+      env: { get: (name: string) => process.env[name] },
+    };
+    createSessionMock.mockResolvedValue({ url: 'https://stripe.test/session' });
+    await import('./index.ts');
+  });
+
+  it('returns 405 for non POST', async () => {
+    const res = await handler(new Request('http://localhost')); // GET by default
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 400 for invalid payload', async () => {
+    const res = await handler(
+      new Request('http://localhost', { method: 'POST', body: '{}' }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('creates session and returns url', async () => {
+    const body = {
+      cartItems: [{ pass: { id: '1', name: 'Test', price: 10 }, quantity: 1 }],
+      customer: { email: 'test@example.com' },
+    };
+    const res = await handler(
+      new Request('http://localhost', {
+        method: 'POST',
+        body: JSON.stringify(body),
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(createSessionMock).toHaveBeenCalled();
+    await expect(res.json()).resolves.toEqual({
+      url: 'https://stripe.test/session',
+    });
+  });
+});

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -1,0 +1,77 @@
+import Stripe from 'https://esm.sh/stripe@13?target=deno';
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+
+function getEnv(name: string): string {
+  const value = Deno.env.get(name);
+  if (!value) {
+    throw new Error(`Missing env var ${name}`);
+  }
+  return value;
+}
+
+const stripe = new Stripe(getEnv('STRIPE_SECRET'), {
+  apiVersion: '2023-10-16',
+});
+
+interface CartItem {
+  pass: { id: string; name: string; price: number };
+  eventActivity?: { id: string };
+  timeSlot?: { id: string };
+  quantity: number;
+}
+
+interface Customer {
+  email: string;
+  [key: string]: unknown;
+}
+
+serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+    });
+  }
+
+  try {
+    const { cartItems, customer } = (await req.json()) as {
+      cartItems?: CartItem[];
+      customer?: Customer;
+    };
+
+    if (!cartItems || cartItems.length === 0 || !customer?.email) {
+      return new Response(JSON.stringify({ error: 'Invalid payload' }), {
+        status: 400,
+      });
+    }
+
+    const origin = new URL(req.url).origin;
+
+    const session = await stripe.checkout.sessions.create({
+      mode: 'payment',
+      customer_email: customer.email,
+      line_items: cartItems.map((item) => ({
+        price_data: {
+          currency: 'eur',
+          product_data: { name: item.pass.name },
+          unit_amount: Math.round(item.pass.price * 100),
+        },
+        quantity: item.quantity || 1,
+      })),
+      success_url: `${origin}/cart?success=true`,
+      cancel_url: `${origin}/cart?canceled=true`,
+      metadata: {
+        cart: JSON.stringify(cartItems),
+        customer: JSON.stringify(customer),
+      },
+    });
+
+    return new Response(JSON.stringify({ url: session.url }), {
+      status: 200,
+    });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    return new Response(JSON.stringify({ error: message }), {
+      status: 500,
+    });
+  }
+});

--- a/supabase/functions/stripe-webhook/index.test.ts
+++ b/supabase/functions/stripe-webhook/index.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+let handler: (req: Request) => Promise<Response>;
+
+const insertMock = vi.fn();
+const fromMock = vi.fn(() => ({ insert: insertMock }));
+const supabaseClient = { from: fromMock };
+
+const constructEventMock = vi.fn();
+const stripeMock = { webhooks: { constructEvent: constructEventMock } };
+
+vi.mock('https://esm.sh/@supabase/supabase-js@2', () => ({
+  createClient: vi.fn(() => supabaseClient),
+}));
+
+vi.mock('https://esm.sh/stripe@13?target=deno', () => ({
+  default: vi.fn(() => stripeMock),
+}));
+
+vi.mock('https://deno.land/std@0.224.0/http/server.ts', () => ({
+  serve: (cb: (req: Request) => Promise<Response>) => {
+    handler = cb;
+  },
+}));
+
+describe('stripe-webhook edge function', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.STRIPE_SECRET = 'sk_test';
+    process.env.SUPABASE_URL = 'https://example.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
+    process.env.WEBHOOK_SECRET = 'whsec';
+    (
+      globalThis as unknown as {
+        Deno: { env: { get: (name: string) => string | undefined } };
+      }
+    ).Deno = {
+      env: { get: (name: string) => process.env[name] },
+    };
+  });
+
+  it('returns 400 on invalid signature', async () => {
+    constructEventMock.mockImplementation(() => {
+      throw new Error('bad signature');
+    });
+    await import('./index.ts');
+    const res = await handler(
+      new Request('http://localhost', {
+        method: 'POST',
+        headers: { 'Stripe-Signature': 'sig' },
+        body: '{}',
+      }),
+    );
+    expect(res.status).toBe(400);
+  });
+
+  it('inserts reservations on checkout completion', async () => {
+    constructEventMock.mockReturnValue({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          metadata: {
+            cart: JSON.stringify([{ pass: { id: '1' }, quantity: 1 }]),
+            customer: JSON.stringify({ email: 'a@b.c' }),
+          },
+        },
+      },
+    });
+    insertMock.mockResolvedValue({ error: null });
+    await import('./index.ts');
+    const res = await handler(
+      new Request('http://localhost', {
+        method: 'POST',
+        headers: { 'Stripe-Signature': 'sig' },
+        body: '{}',
+      }),
+    );
+    expect(res.status).toBe(200);
+    expect(insertMock).toHaveBeenCalled();
+  });
+});

--- a/supabase/functions/stripe-webhook/index.ts
+++ b/supabase/functions/stripe-webhook/index.ts
@@ -1,0 +1,77 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import Stripe from 'https://esm.sh/stripe@13?target=deno';
+import { serve } from 'https://deno.land/std@0.224.0/http/server.ts';
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2';
+
+function getEnv(name: string): string {
+  const value = Deno.env.get(name);
+  if (!value) throw new Error(`Missing env var ${name}`);
+  return value;
+}
+
+const stripe = new Stripe(getEnv('STRIPE_SECRET'), {
+  apiVersion: '2023-10-16',
+});
+
+const supabase = createClient(
+  getEnv('SUPABASE_URL'),
+  getEnv('SUPABASE_SERVICE_ROLE_KEY'),
+);
+
+serve(async (req: Request) => {
+  if (req.method !== 'POST') {
+    return new Response(JSON.stringify({ error: 'Method not allowed' }), {
+      status: 405,
+    });
+  }
+
+  const signature = req.headers.get('Stripe-Signature') ?? '';
+  const body = await req.text();
+
+  let event: any;
+  try {
+    event = stripe.webhooks.constructEvent(
+      body,
+      signature,
+      getEnv('WEBHOOK_SECRET'),
+    );
+  } catch {
+    return new Response(JSON.stringify({ error: 'Invalid signature' }), {
+      status: 400,
+    });
+  }
+
+  if (event.type === 'checkout.session.completed') {
+    const session = event.data.object as any;
+    try {
+      const cartItems = JSON.parse(session.metadata?.cart ?? '[]') as Array<{
+        pass: { id: string };
+        eventActivity?: { id: string };
+        timeSlot?: { id: string };
+        quantity: number;
+      }>;
+      const customer = JSON.parse(session.metadata?.customer ?? '{}') as {
+        email?: string;
+      };
+
+      for (const item of cartItems) {
+        for (let i = 0; i < (item.quantity || 1); i++) {
+          const { error } = await supabase.from('reservations').insert({
+            client_email: customer.email,
+            pass_id: item.pass.id,
+            event_activity_id: item.eventActivity?.id ?? null,
+            time_slot_id: item.timeSlot?.id ?? null,
+            payment_status: 'paid',
+          });
+          if (error) throw error;
+        }
+      }
+    } catch (err) {
+      return new Response(JSON.stringify({ error: (err as Error).message }), {
+        status: 500,
+      });
+    }
+  }
+
+  return new Response(JSON.stringify({ received: true }), { status: 200 });
+});


### PR DESCRIPTION
## Summary
- replace fake payment with Stripe Checkout session
- handle success/cancel flow and clear cart
- add Stripe webhook to finalize reservations
- document Stripe setup and add edge function tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b3a9e5a844832ba69e2a59b8b81591