### PR TITLE
ci: guard SARIF upload when file is absent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
 
       # Publish results to the Security tab
       - name: Upload SARIF
-        if: always()
+        if: always() && hashFiles('semgrep.sarif') != ''
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif


### PR DESCRIPTION
## Summary
- ensure SARIF upload runs only when semgrep report exists to avoid path errors

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4ae110bec832b87aab3df9633be77