### PR TITLE
ci: avoid unknown npm config warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      npm_config_http_proxy: ""
     steps:
       - uses: actions/checkout@v4
 
@@ -28,7 +30,7 @@ jobs:
           cache-dependency-path: package-lock.json
 
       - run: npm ci --no-audit --no-fund
-      - run: npm run lint --max-warnings=0
+      - run: npm run lint -- --max-warnings=0
       - run: npm test -- --silent
       - run: npm run build
         if: github.event_name == 'push'


### PR DESCRIPTION
## Summary
- unset unsupported `npm_config_http_proxy` in CI workflow
- fix npm lint invocation to pass `--max-warnings` to eslint

## Testing
- `npm_config_http_proxy= npm ci --no-audit --no-fund`
- `npm_config_http_proxy= npm run lint -- --max-warnings=0`
- `npm_config_http_proxy= npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b6b7801c832bb3b625685481205a