### PR TITLE
chore: enforce zero lint warnings

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -25,7 +25,7 @@ export default tseslint.config(
     rules: {
       ...reactHooks.configs.recommended.rules,
       'react-refresh/only-export-components': [
-        'warn',
+        'error',
         { allowConstantExport: true },
       ],
       'no-console': ['error', { allow: ['warn', 'error'] }],

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint .",
+    "lint": "eslint --max-warnings=0 .",
     "preview": "vite preview",
     "test": "npx vitest run",
     "test:ui": "npx vitest --ui",


### PR DESCRIPTION
## Summary
- fail lint when warnings are present
- escalate `react-refresh/only-export-components` to an error

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b855bfe0832ba22c270581fc2f89