### PR TITLE
ci: schedule weekly dependency audit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  schedule:
+    - cron: '0 0 * * 0'
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -37,9 +39,8 @@ jobs:
 
       - name: Audit dependencies
         if: github.event_name == 'push'
-        run: npm audit --production --audit-level=moderate
+        run: npm audit --production --audit-level=high
         continue-on-error: true
-
       # Static analysis (no Semgrep account required)
       - name: Static analysis with Semgrep
         uses: returntocorp/semgrep-action@v1
@@ -54,3 +55,20 @@ jobs:
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif
+
+  audit:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'schedule'
+    env:
+      npm_config_http_proxy: ""
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: npm
+          cache-dependency-path: package-lock.json
+
+      - run: npm ci --no-audit --no-fund
+      - run: npm audit --audit-level=high


### PR DESCRIPTION
## Summary
- add weekly scheduled workflow to run `npm audit` with high severity threshold
- raise `npm audit` step in CI to `--audit-level=high`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4b9abba6c832b861ffc97f4d1d74c