### PR TITLE
test: ensure act imports and await state updates

### DIFF
--- a/src/__tests__/PassManagement.modal.test.tsx
+++ b/src/__tests__/PassManagement.modal.test.tsx
@@ -3,7 +3,7 @@ import { describe, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import PassManagement from '../pages/admin/PassManagement';
 import { render, screen, waitFor } from '../test/utils';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 
 describe('PassManagement add/edit modal', () => {
   it('renders a scrollable dialog for long content', async () => {

--- a/src/components/__tests__/Layout.test.tsx
+++ b/src/components/__tests__/Layout.test.tsx
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, waitFor } from '@testing-library/react';
-import { act } from 'react-dom/test-utils';
+import { render, screen, waitFor, act } from '@testing-library/react';
 import Layout from '../Layout';
 
 // Mock auth to return an admin user for Admin link rendering

--- a/src/components/admin/__tests__/MarkdownEditor.test.tsx
+++ b/src/components/admin/__tests__/MarkdownEditor.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { render, screen, waitFor } from '../../../test/utils';
-import { act } from 'react-dom/test-utils';
+import { act } from '@testing-library/react';
 import MarkdownEditor from '../MarkdownEditor';
 
 function Wrapper() {

--- a/src/pages/__tests__/EventDetails.test.tsx
+++ b/src/pages/__tests__/EventDetails.test.tsx
@@ -68,13 +68,21 @@ describe('EventDetails Page', () => {
           event_activities: [
             {
               id: 'activity1',
-              activity: { name: 'Activity 1', description: 'activity desc', icon: '🎉' },
+              activity: {
+                name: 'Activity 1',
+                description: 'activity desc',
+                icon: '🎉',
+              },
               stock_limit: null,
               requires_time_slot: false,
             },
             {
               id: 'activity2',
-              activity: { name: 'Activity 2', description: 'activity2 desc', icon: '🎯' },
+              activity: {
+                name: 'Activity 2',
+                description: 'activity2 desc',
+                icon: '🎯',
+              },
               stock_limit: null,
               requires_time_slot: false,
             },
@@ -93,7 +101,9 @@ describe('EventDetails Page', () => {
     render(<EventDetails />);
 
     fireEvent.click(screen.getByRole('button', { name: /ajouter au panier/i }));
-    const modalButton = screen.getAllByRole('button', { name: /ajouter au panier/i })[1];
+    const modalButton = screen.getAllByRole('button', {
+      name: /ajouter au panier/i,
+    })[1];
     fireEvent.click(modalButton);
 
     await waitFor(() => {
@@ -107,17 +117,19 @@ describe('EventDetails Page', () => {
         1,
         undefined,
         undefined,
-        expect.anything()
+        expect.anything(),
       );
       expect(refresh).toHaveBeenCalled();
     });
 
     await waitFor(() => {
-      expect(screen.queryByText(/configurer votre achat/i)).not.toBeInTheDocument();
+      expect(
+        screen.queryByText(/configurer votre achat/i),
+      ).not.toBeInTheDocument();
     });
   });
 
-  it('hides last name field for baby poney passes', () => {
+  it('hides last name field for baby poney passes', async () => {
     vi.mocked(useEventDetails).mockReturnValue({
       event: {
         id: 'event',
@@ -148,8 +160,12 @@ describe('EventDetails Page', () => {
 
     fireEvent.click(screen.getByRole('button', { name: /ajouter au panier/i }));
 
-    expect(screen.queryByPlaceholderText(/^Nom$/i)).not.toBeInTheDocument();
-    expect(screen.getByPlaceholderText(/prénom/i)).toBeInTheDocument();
-    expect(screen.getByPlaceholderText(/année de naissance/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText(/^Nom$/i)).not.toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/prénom/i)).toBeInTheDocument();
+      expect(
+        screen.getByPlaceholderText(/année de naissance/i),
+      ).toBeInTheDocument();
+    });
   });
 });

--- a/src/pages/__tests__/EventFAQ.test.tsx
+++ b/src/pages/__tests__/EventFAQ.test.tsx
@@ -18,7 +18,12 @@ describe('EventFAQ Page', () => {
   });
 
   it('shows spinner and loading text when loading', () => {
-    mockedUseFaq.mockReturnValue({ event: null, faqs: [], loading: true, error: null });
+    mockedUseFaq.mockReturnValue({
+      event: null,
+      faqs: [],
+      loading: true,
+      error: null,
+    });
 
     const { container } = render(<EventFAQ />);
 
@@ -27,14 +32,19 @@ describe('EventFAQ Page', () => {
   });
 
   it('shows not found message when no event', () => {
-    mockedUseFaq.mockReturnValue({ event: null, faqs: [], loading: false, error: null });
+    mockedUseFaq.mockReturnValue({
+      event: null,
+      faqs: [],
+      loading: false,
+      error: null,
+    });
 
     render(<EventFAQ />);
 
     expect(screen.getByText(/faq introuvable/i)).toBeInTheDocument();
   });
 
-  it('renders event name and FAQ content', () => {
+  it('renders event name and FAQ content', async () => {
     mockedUseFaq.mockReturnValue({
       event: { id: '1', name: 'Event' },
       faqs: [{ question: 'Q', answer: 'A' }],
@@ -48,16 +58,23 @@ describe('EventFAQ Page', () => {
     const question = screen.getByText('Q');
     expect(question).toBeInTheDocument();
     fireEvent.click(question);
-    expect(screen.getByText('A')).toBeInTheDocument();
+    await waitFor(() => expect(screen.getByText('A')).toBeInTheDocument());
   });
 
   it('displays error toast when request fails', async () => {
-    mockedUseFaq.mockReturnValue({ event: null, faqs: [], loading: false, error: new Error('fail') });
+    mockedUseFaq.mockReturnValue({
+      event: null,
+      faqs: [],
+      loading: false,
+      error: new Error('fail'),
+    });
 
     render(<EventFAQ />);
 
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith('Erreur lors du chargement de la FAQ');
+      expect(toast.error).toHaveBeenCalledWith(
+        'Erreur lors du chargement de la FAQ',
+      );
     });
     expect(screen.getByText(/faq introuvable/i)).toBeInTheDocument();
   });


### PR DESCRIPTION
## Summary
- import act from `@testing-library/react` in UI tests
- wait for state updates after interactive events

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4c1d6edc8832ba18938779399c8c1