### PR TITLE
test: stub env with booleans

### DIFF
--- a/src/pages/admin/__tests__/EventManagement.test.tsx
+++ b/src/pages/admin/__tests__/EventManagement.test.tsx
@@ -3,7 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { render, screen, waitFor, act } from '../../../test/utils';
 import EventManagement from '../EventManagement';
 
-// Mock the supabase calls to return resolved data immediately  
+// Mock the supabase calls to return resolved data immediately
 vi.mock('../../../lib/supabase', async () => {
   const actual = await vi.importActual('../../../lib/supabase');
   return {
@@ -11,9 +11,9 @@ vi.mock('../../../lib/supabase', async () => {
     supabase: {
       from: vi.fn(() => ({
         select: vi.fn(() => ({
-          order: vi.fn(() => Promise.resolve({ data: [], error: null }))
-        }))
-      }))
+          order: vi.fn(() => Promise.resolve({ data: [], error: null })),
+        })),
+      })),
     },
     isSupabaseConfigured: vi.fn(() => true),
   };
@@ -24,32 +24,38 @@ describe('EventManagement', () => {
     render(<EventManagement />);
 
     await waitFor(() => {
-      expect(screen.getByRole('heading', { name: /gestion des événements/i })).toBeInTheDocument();
+      expect(
+        screen.getByRole('heading', { name: /gestion des événements/i }),
+      ).toBeInTheDocument();
     });
-    expect(screen.getByRole('button', { name: /nouvel événement/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /nouvel événement/i }),
+    ).toBeInTheDocument();
   });
 
   it('should open create modal when clicking add button', async () => {
     const user = userEvent.setup();
     render(<EventManagement />);
 
-    const button = await screen.findByRole('button', { name: /nouvel événement/i });
+    const button = await screen.findByRole('button', {
+      name: /nouvel événement/i,
+    });
     await act(async () => {
       await user.click(button);
     });
 
     await waitFor(() => {
       expect(
-        screen.getByRole('heading', { name: /nouvel événement/i })
+        screen.getByRole('heading', { name: /nouvel événement/i }),
       ).toBeInTheDocument();
     });
   });
 
   it('should not output debug logs in production mode', async () => {
-    vi.stubEnv('DEV', 'false');
-    vi.stubEnv('PROD', 'true');
-    vi.stubEnv('MODE', 'production');
-    vi.stubEnv('VITE_DEBUG', 'true');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
+    vi.stubEnv('MODE', 'production'); // reste une chaîne
+    vi.stubEnv('VITE_DEBUG', true);
 
     const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -60,7 +66,9 @@ describe('EventManagement', () => {
     });
 
     expect(logSpy).not.toHaveBeenCalled();
-    expect(screen.queryByText(/DEBUG EventManagement/i)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/DEBUG EventManagement/i),
+    ).not.toBeInTheDocument();
 
     logSpy.mockRestore();
     vi.unstubAllEnvs();


### PR DESCRIPTION
## Summary
- ensure EventManagement tests use boolean flags when stubbing environment variables

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d591ea50832b9908e7344ecc4ae7