### PR TITLE
test: set toast spy return values in Settings

### DIFF
--- a/src/pages/admin/__tests__/Settings.test.tsx
+++ b/src/pages/admin/__tests__/Settings.test.tsx
@@ -23,8 +23,8 @@ import Settings from '../Settings';
 describe('Settings Page', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.spyOn(toast, 'success').mockImplementation(() => {});
-    vi.spyOn(toast, 'error').mockImplementation(() => {});
+    vi.spyOn(toast, 'success').mockImplementation(() => 'ok');
+    vi.spyOn(toast, 'error').mockImplementation(() => 'err');
     return vi.mocked(getCurrentUser).mockResolvedValue({
       id: 'u1',
       email: 'admin@example.com',


### PR DESCRIPTION
## Summary
- ensure toast success/error spies return values in Settings tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d886d588832b9974b5137ecd63fe