### PR TITLE
fix: adjust admin dashboard revenue query

### DIFF
--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -23,7 +23,7 @@ export default function AdminDashboard() {
     totalEvents: 0,
     totalReservations: 0,
     totalRevenue: 0,
-    activeEvents: 0
+    activeEvents: 0,
   });
   const [loading, setLoading] = useState(true);
 
@@ -53,17 +53,15 @@ export default function AdminDashboard() {
         .eq('payment_status', 'paid');
 
       // Calculer le chiffre d'affaires (approximatif)
-      const { data: reservations, error: revenueError } = await supabase
+      const { data, error: revenueError } = await supabase
         .from('reservations')
-        .select<ReservationWithPass>(`
-          passes!inner (
-            price
-          )
-        `)
+        .select('passes!inner(price)')
         .eq('payment_status', 'paid');
 
+      const reservations = (data ?? []) as ReservationWithPass[];
+
       let revenue = 0;
-      if (!revenueError && reservations) {
+      if (!revenueError) {
         revenue = reservations.reduce((total, reservation) => {
           return total + (reservation.passes?.price || 0);
         }, 0);
@@ -73,7 +71,7 @@ export default function AdminDashboard() {
         totalEvents: eventCount || 0,
         totalReservations: reservationCount || 0,
         totalRevenue: revenue,
-        activeEvents: activeEventCount || 0
+        activeEvents: activeEventCount || 0,
       });
     } catch (err) {
       logger.error('Erreur chargement statistiques', { error: err });
@@ -90,7 +88,7 @@ export default function AdminDashboard() {
       icon: Calendar,
       color: 'bg-blue-500',
       bgColor: 'bg-blue-50',
-      textColor: 'text-blue-700'
+      textColor: 'text-blue-700',
     },
     {
       title: 'Événements Actifs',
@@ -98,7 +96,7 @@ export default function AdminDashboard() {
       icon: Activity,
       color: 'bg-green-500',
       bgColor: 'bg-green-50',
-      textColor: 'text-green-700'
+      textColor: 'text-green-700',
     },
     {
       title: 'Réservations',
@@ -106,16 +104,16 @@ export default function AdminDashboard() {
       icon: Users,
       color: 'bg-purple-500',
       bgColor: 'bg-purple-50',
-      textColor: 'text-purple-700'
+      textColor: 'text-purple-700',
     },
     {
-      title: 'Chiffre d\'affaires',
+      title: "Chiffre d'affaires",
       value: `${stats.totalRevenue.toFixed(2)}€`,
       icon: Euro,
       color: 'bg-yellow-500',
       bgColor: 'bg-yellow-50',
-      textColor: 'text-yellow-700'
-    }
+      textColor: 'text-yellow-700',
+    },
   ];
 
   if (loading) {
@@ -130,7 +128,9 @@ export default function AdminDashboard() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Tableau de Bord</h1>
-        <p className="text-gray-600">Vue d'ensemble de votre activité événementielle</p>
+        <p className="text-gray-600">
+          Vue d'ensemble de votre activité événementielle
+        </p>
       </div>
 
       {/* Statistiques */}
@@ -159,21 +159,34 @@ export default function AdminDashboard() {
 
       {/* Actions rapides */}
       <div className="bg-white rounded-lg shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Actions Rapides</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          Actions Rapides
+        </h2>
         <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-          <Link to="/admin/events" className="p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors text-left block">
+          <Link
+            to="/admin/events"
+            className="p-4 border border-gray-200 rounded-lg hover:border-blue-300 hover:bg-blue-50 transition-colors text-left block"
+          >
             <Calendar className="h-6 w-6 text-blue-600 mb-2" />
             <h3 className="font-medium text-gray-900">Créer un Événement</h3>
-            <p className="text-sm text-gray-600">Configurer un nouvel événement</p>
+            <p className="text-sm text-gray-600">
+              Configurer un nouvel événement
+            </p>
           </Link>
-          
-          <Link to="/admin/reservations" className="p-4 border border-gray-200 rounded-lg hover:border-green-300 hover:bg-green-50 transition-colors text-left block">
+
+          <Link
+            to="/admin/reservations"
+            className="p-4 border border-gray-200 rounded-lg hover:border-green-300 hover:bg-green-50 transition-colors text-left block"
+          >
             <Users className="h-6 w-6 text-green-600 mb-2" />
             <h3 className="font-medium text-gray-900">Voir les Réservations</h3>
             <p className="text-sm text-gray-600">Gérer les inscriptions</p>
           </Link>
-          
-          <Link to="/admin/reports" className="p-4 border border-gray-200 rounded-lg hover:border-purple-300 hover:bg-purple-50 transition-colors text-left block">
+
+          <Link
+            to="/admin/reports"
+            className="p-4 border border-gray-200 rounded-lg hover:border-purple-300 hover:bg-purple-50 transition-colors text-left block"
+          >
             <TrendingUp className="h-6 w-6 text-purple-600 mb-2" />
             <h3 className="font-medium text-gray-900">Rapports</h3>
             <p className="text-sm text-gray-600">Analyser les performances</p>
@@ -183,7 +196,9 @@ export default function AdminDashboard() {
 
       {/* Événements récents */}
       <div className="bg-white rounded-lg shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Activité Récente</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          Activité Récente
+        </h2>
         <div className="text-center py-8 text-gray-500">
           <Activity className="h-12 w-12 mx-auto mb-4 text-gray-300" />
           <p>Aucune activité récente à afficher</p>


### PR DESCRIPTION
## Summary
- simplify supabase select when fetching passes for paid reservations
- handle null data and compute revenue safely

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d990deec832bbde6ddef88a548a0