### PR TITLE
refactor: remove unnecessary React imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { Toaster } from 'react-hot-toast';
 
@@ -60,7 +59,10 @@ export default function App() {
             <Route index element={<AdminDashboard />} />
             <Route path="users" element={<UserManagement />} />
             <Route path="events" element={<EventManagement />} />
-            <Route path="activity-variants" element={<ActivityVariantsManagement />} />
+            <Route
+              path="activity-variants"
+              element={<ActivityVariantsManagement />}
+            />
             <Route path="activities" element={<ActivityManagement />} />
             <Route path="passes" element={<PassManagement />} />
             <Route path="time-slots" element={<TimeSlotManagement />} />

--- a/src/__tests__/PassManagement.modal.test.tsx
+++ b/src/__tests__/PassManagement.modal.test.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { describe, it, expect, vi } from 'vitest';
 import userEvent from '@testing-library/user-event';
 import PassManagement from '../pages/admin/PassManagement';

--- a/src/components/AdminLogin.tsx
+++ b/src/components/AdminLogin.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { Lock, Mail, Eye, EyeOff } from 'lucide-react';
 import { signInWithEmail } from '../lib/auth';
 import type { User } from '../lib/auth';
@@ -16,9 +16,9 @@ export default function AdminLogin({ onLogin }: AdminLoginProps) {
   const [loading, setLoading] = useState(false);
   const showDemoInfo = import.meta.env.VITE_SHOW_TEST_CREDENTIALS === 'true';
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    
+
     if (!email || !password) {
       return;
     }
@@ -26,11 +26,13 @@ export default function AdminLogin({ onLogin }: AdminLoginProps) {
     try {
       setLoading(true);
       const user = await signInWithEmail(email, password);
-      
+
       if (user && user.role === 'admin') {
         onLogin(user);
       } else if (user) {
-        alert('Accès refusé. Seuls les administrateurs peuvent accéder au dashboard.');
+        alert(
+          'Accès refusé. Seuls les administrateurs peuvent accéder au dashboard.',
+        );
       }
     } catch (err) {
       logger.error('Erreur connexion', { error: err });
@@ -55,9 +57,15 @@ export default function AdminLogin({ onLogin }: AdminLoginProps) {
           </p>
         </div>
 
-        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm p-8 space-y-6">
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-lg shadow-sm p-8 space-y-6"
+        >
           <div>
-            <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Adresse email
             </label>
             <div className="relative">
@@ -75,7 +83,10 @@ export default function AdminLogin({ onLogin }: AdminLoginProps) {
           </div>
 
           <div>
-            <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Mot de passe
             </label>
             <div className="relative">
@@ -94,7 +105,11 @@ export default function AdminLogin({ onLogin }: AdminLoginProps) {
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute right-3 top-1/2 transform -translate-y-1/2 text-gray-400 hover:text-gray-600"
               >
-                {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                {showPassword ? (
+                  <EyeOff className="h-5 w-5" />
+                ) : (
+                  <Eye className="h-5 w-5" />
+                )}
               </button>
             </div>
           </div>
@@ -117,7 +132,8 @@ export default function AdminLogin({ onLogin }: AdminLoginProps) {
         {showDemoInfo && (
           <div className="bg-blue-50 rounded-lg p-4 text-center">
             <p className="text-sm text-blue-800">
-              Environnement de démonstration : les identifiants de test sont fournis sur demande.
+              Environnement de démonstration : les identifiants de test sont
+              fournis sur demande.
             </p>
           </div>
         )}

--- a/src/components/CheckoutForm.tsx
+++ b/src/components/CheckoutForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { User, Mail, Phone, MapPin } from 'lucide-react';
 
 interface CheckoutFormProps {
@@ -24,22 +24,27 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
     phone: '',
     address: '',
     city: '',
-    postalCode: ''
+    postalCode: '',
   });
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
     onSubmit(formData);
   };
 
   return (
     <div className="bg-white rounded-lg shadow-sm p-6">
-      <h2 className="text-lg font-semibold text-gray-900 mb-6">Informations de Facturation</h2>
-      
+      <h2 className="text-lg font-semibold text-gray-900 mb-6">
+        Informations de Facturation
+      </h2>
+
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label htmlFor="firstName" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="firstName"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Prénom *
             </label>
             <div className="relative">
@@ -48,7 +53,9 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
                 id="firstName"
                 type="text"
                 value={formData.firstName}
-                onChange={(e) => setFormData({ ...formData, firstName: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, firstName: e.target.value })
+                }
                 className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
               />
@@ -56,14 +63,19 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
           </div>
 
           <div>
-            <label htmlFor="lastName" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="lastName"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Nom *
             </label>
             <input
               id="lastName"
               type="text"
               value={formData.lastName}
-              onChange={(e) => setFormData({ ...formData, lastName: e.target.value })}
+              onChange={(e) =>
+                setFormData({ ...formData, lastName: e.target.value })
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               required
             />
@@ -71,7 +83,10 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
         </div>
 
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-1">
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
             Adresse email *
           </label>
           <div className="relative">
@@ -80,7 +95,9 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
               id="email"
               type="email"
               value={formData.email}
-              onChange={(e) => setFormData({ ...formData, email: e.target.value })}
+              onChange={(e) =>
+                setFormData({ ...formData, email: e.target.value })
+              }
               className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               required
             />
@@ -88,7 +105,10 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
         </div>
 
         <div>
-          <label htmlFor="phone" className="block text-sm font-medium text-gray-700 mb-1">
+          <label
+            htmlFor="phone"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
             Téléphone *
           </label>
           <div className="relative">
@@ -97,7 +117,9 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
               id="phone"
               type="tel"
               value={formData.phone}
-              onChange={(e) => setFormData({ ...formData, phone: e.target.value })}
+              onChange={(e) =>
+                setFormData({ ...formData, phone: e.target.value })
+              }
               className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="0692 XX XX XX"
               required
@@ -106,7 +128,10 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
         </div>
 
         <div>
-          <label htmlFor="address" className="block text-sm font-medium text-gray-700 mb-1">
+          <label
+            htmlFor="address"
+            className="block text-sm font-medium text-gray-700 mb-1"
+          >
             Adresse *
           </label>
           <div className="relative">
@@ -115,7 +140,9 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
               id="address"
               type="text"
               value={formData.address}
-              onChange={(e) => setFormData({ ...formData, address: e.target.value })}
+              onChange={(e) =>
+                setFormData({ ...formData, address: e.target.value })
+              }
               className="w-full pl-10 pr-4 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               required
             />
@@ -124,28 +151,38 @@ export default function CheckoutForm({ onSubmit, loading }: CheckoutFormProps) {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label htmlFor="city" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="city"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Ville *
             </label>
             <input
               id="city"
               type="text"
               value={formData.city}
-              onChange={(e) => setFormData({ ...formData, city: e.target.value })}
+              onChange={(e) =>
+                setFormData({ ...formData, city: e.target.value })
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               required
             />
           </div>
 
           <div>
-            <label htmlFor="postalCode" className="block text-sm font-medium text-gray-700 mb-1">
+            <label
+              htmlFor="postalCode"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
               Code postal *
             </label>
             <input
               id="postalCode"
               type="text"
               value={formData.postalCode}
-              onChange={(e) => setFormData({ ...formData, postalCode: e.target.value })}
+              onChange={(e) =>
+                setFormData({ ...formData, postalCode: e.target.value })
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               pattern="[0-9]{5}"
               placeholder="97400"

--- a/src/components/ConfirmationModal.tsx
+++ b/src/components/ConfirmationModal.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { CheckCircle, X, Download, Mail } from 'lucide-react';
 import QRCode from 'qrcode';
 import { logger } from '../lib/logger';
@@ -26,17 +26,17 @@ export default function ConfirmationModal({
   passName,
   price,
   timeSlot,
-  activityName
+  activityName,
 }: ConfirmationModalProps) {
   const [qrDataUrl, setQrDataUrl] = useState('');
 
   useEffect(() => {
     let mounted = true;
     QRCode.toDataURL(reservationNumber)
-      .then(url => {
+      .then((url) => {
         if (mounted) setQrDataUrl(url);
       })
-      .catch(err => logger.error('Erreur génération QR', { error: err }));
+      .catch((err) => logger.error('Erreur génération QR', { error: err }));
     return () => {
       mounted = false;
     };
@@ -94,7 +94,9 @@ Présentez ce billet à l'entrée de l'événement.
 
           <div className="space-y-4 mb-6">
             <div className="bg-gray-50 rounded-lg p-4">
-              <div className="text-sm text-gray-600 mb-1">Numéro de réservation</div>
+              <div className="text-sm text-gray-600 mb-1">
+                Numéro de réservation
+              </div>
               <div className="font-mono text-lg font-semibold text-gray-900">
                 {reservationNumber}
               </div>
@@ -136,10 +138,13 @@ Présentez ce billet à l'entrée de l'événement.
                   <div className="flex justify-between">
                     <span className="text-gray-600">Horaire:</span>
                     <span className="font-medium">
-                      {new Date(timeSlot.slot_time).toLocaleTimeString('fr-FR', { 
-                        hour: '2-digit', 
-                        minute: '2-digit' 
-                      })}
+                      {new Date(timeSlot.slot_time).toLocaleTimeString(
+                        'fr-FR',
+                        {
+                          hour: '2-digit',
+                          minute: '2-digit',
+                        },
+                      )}
                     </span>
                   </div>
                 </>
@@ -155,7 +160,7 @@ Présentez ce billet à l'entrée de l'événement.
               <Download className="h-4 w-4" />
               Télécharger le Billet
             </button>
-            
+
             <div className="text-center">
               <div className="flex items-center justify-center gap-2 text-sm text-gray-600 mb-2">
                 <Mail className="h-4 w-4" />

--- a/src/components/FAQAccordion.tsx
+++ b/src/components/FAQAccordion.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Disclosure } from '@headlessui/react';
 import { ChevronUp } from 'lucide-react';
 import MarkdownRenderer from './MarkdownRenderer';
@@ -15,7 +14,9 @@ interface FAQAccordionProps {
 export default function FAQAccordion({ faqs }: FAQAccordionProps) {
   if (!faqs || faqs.length === 0) {
     return (
-      <p className="text-gray-600">Aucune question n'est disponible pour cet événement.</p>
+      <p className="text-gray-600">
+        Aucune question n'est disponible pour cet événement.
+      </p>
     );
   }
 

--- a/src/components/MarkdownRenderer.tsx
+++ b/src/components/MarkdownRenderer.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import rehypeSanitize from 'rehype-sanitize';
@@ -10,7 +9,10 @@ interface MarkdownRendererProps {
   className?: string;
 }
 
-export default function MarkdownRenderer({ content, className }: MarkdownRendererProps) {
+export default function MarkdownRenderer({
+  content,
+  className,
+}: MarkdownRendererProps) {
   if (!content || content.trim() === '') {
     return <p className={className}>Aucune information définie</p>;
   }
@@ -18,7 +20,10 @@ export default function MarkdownRenderer({ content, className }: MarkdownRendere
   try {
     return (
       <div className={className || 'prose max-w-none'}>
-        <ReactMarkdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeSanitize]}>
+        <ReactMarkdown
+          remarkPlugins={[remarkGfm]}
+          rehypePlugins={[rehypeSanitize]}
+        >
           {content}
         </ReactMarkdown>
       </div>

--- a/src/components/ProviderLogin.tsx
+++ b/src/components/ProviderLogin.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { Lock, Mail, Eye, EyeOff } from 'lucide-react';
 import { signInWithEmail } from '../lib/auth';
 import type { User } from '../lib/auth';
@@ -8,7 +8,13 @@ interface ProviderLoginProps {
   onLogin: (user: User) => void;
 }
 
-const ALLOWED: User['role'][] = ['pony_provider', 'archery_provider', 'luge_provider', 'atlm_collaborator', 'admin'];
+const ALLOWED: User['role'][] = [
+  'pony_provider',
+  'archery_provider',
+  'luge_provider',
+  'atlm_collaborator',
+  'admin',
+];
 
 export default function ProviderLogin({ onLogin }: ProviderLoginProps) {
   const [email, setEmail] = useState('');
@@ -16,7 +22,7 @@ export default function ProviderLogin({ onLogin }: ProviderLoginProps) {
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     if (!email || !password) return;
     setLoading(true);
@@ -39,12 +45,21 @@ export default function ProviderLogin({ onLogin }: ProviderLoginProps) {
           <div className="bg-blue-100 rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
             <Lock className="h-8 w-8 text-blue-600" />
           </div>
-          <h2 className="text-3xl font-bold text-gray-900 mb-2">Espace Prestataire</h2>
-          <p className="text-gray-600">Connectez-vous pour valider les inscriptions</p>
+          <h2 className="text-3xl font-bold text-gray-900 mb-2">
+            Espace Prestataire
+          </h2>
+          <p className="text-gray-600">
+            Connectez-vous pour valider les inscriptions
+          </p>
         </div>
-        <form onSubmit={handleSubmit} className="bg-white rounded-lg shadow-sm p-8 space-y-6">
+        <form
+          onSubmit={handleSubmit}
+          className="bg-white rounded-lg shadow-sm p-8 space-y-6"
+        >
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Adresse email</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Adresse email
+            </label>
             <div className="relative">
               <Mail className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
               <input
@@ -58,7 +73,9 @@ export default function ProviderLogin({ onLogin }: ProviderLoginProps) {
             </div>
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Mot de passe</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Mot de passe
+            </label>
             <div className="relative">
               <Lock className="absolute left-3 top-1/2 -translate-y-1/2 h-5 w-5 text-gray-400" />
               <input
@@ -74,7 +91,11 @@ export default function ProviderLogin({ onLogin }: ProviderLoginProps) {
                 onClick={() => setShowPassword(!showPassword)}
                 className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
               >
-                {showPassword ? <EyeOff className="h-5 w-5" /> : <Eye className="h-5 w-5" />}
+                {showPassword ? (
+                  <EyeOff className="h-5 w-5" />
+                ) : (
+                  <Eye className="h-5 w-5" />
+                )}
               </button>
             </div>
           </div>
@@ -90,4 +111,3 @@ export default function ProviderLogin({ onLogin }: ProviderLoginProps) {
     </div>
   );
 }
-

--- a/src/components/admin/AnimationsManager.tsx
+++ b/src/components/admin/AnimationsManager.tsx
@@ -1,6 +1,16 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type FormEvent } from 'react';
 import { supabase } from '../../lib/supabase';
-import { X, Plus, Edit, Trash2, Clock, MapPin, Users, Eye, EyeOff } from 'lucide-react';
+import {
+  X,
+  Plus,
+  Edit,
+  Trash2,
+  Clock,
+  MapPin,
+  Users,
+  Eye,
+  EyeOff,
+} from 'lucide-react';
 import { format } from 'date-fns';
 import { fr } from 'date-fns/locale';
 import { toast } from 'react-hot-toast';
@@ -28,11 +38,16 @@ interface AnimationsManagerProps {
   onClose: () => void;
 }
 
-export default function AnimationsManager({ event, onClose }: AnimationsManagerProps) {
+export default function AnimationsManager({
+  event,
+  onClose,
+}: AnimationsManagerProps) {
   const [animations, setAnimations] = useState<Animation[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateForm, setShowCreateForm] = useState(false);
-  const [editingAnimation, setEditingAnimation] = useState<Animation | null>(null);
+  const [editingAnimation, setEditingAnimation] = useState<Animation | null>(
+    null,
+  );
 
   const loadAnimations = useCallback(async () => {
     try {
@@ -48,7 +63,11 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
     } catch (err) {
       logger.error('Erreur chargement animations', {
         error: err,
-        query: { table: 'event_animations', action: 'select', eventId: event.id }
+        query: {
+          table: 'event_animations',
+          action: 'select',
+          eventId: event.id,
+        },
       });
       toast.error('Erreur lors du chargement des animations');
     } finally {
@@ -61,7 +80,8 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
   }, [loadAnimations]);
 
   const handleDeleteAnimation = async (animationId: string) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer cette animation ?')) return;
+    if (!confirm('Êtes-vous sûr de vouloir supprimer cette animation ?'))
+      return;
 
     try {
       const { error } = await supabase
@@ -76,7 +96,7 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
     } catch (err) {
       logger.error('Erreur suppression animation', {
         error: err,
-        query: { table: 'event_animations', action: 'delete', id: animationId }
+        query: { table: 'event_animations', action: 'delete', id: animationId },
       });
       toast.error('Erreur lors de la suppression');
     }
@@ -91,7 +111,9 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
 
       if (error) throw error;
 
-      toast.success(`Animation ${!animation.is_active ? 'activée' : 'désactivée'}`);
+      toast.success(
+        `Animation ${!animation.is_active ? 'activée' : 'désactivée'}`,
+      );
       loadAnimations();
     } catch (err) {
       logger.error('Erreur changement statut animation', {
@@ -100,8 +122,8 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
           table: 'event_animations',
           action: 'update',
           id: animation.id,
-          is_active: !animation.is_active
-        }
+          is_active: !animation.is_active,
+        },
       });
       toast.error('Erreur lors du changement de statut');
     }
@@ -125,11 +147,16 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center justify-between">
               <div>
-                <h2 id="animations-manager-title" className="text-xl font-semibold text-gray-900 flex items-center gap-2">
+                <h2
+                  id="animations-manager-title"
+                  className="text-xl font-semibold text-gray-900 flex items-center gap-2"
+                >
                   🎭 Animations - {event.name}
                 </h2>
                 <p className="text-gray-600">
-                  {format(new Date(event.event_date), 'EEEE d MMMM yyyy', { locale: fr })}
+                  {format(new Date(event.event_date), 'EEEE d MMMM yyyy', {
+                    locale: fr,
+                  })}
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -140,13 +167,16 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
                   <Plus className="h-4 w-4" />
                   Nouvelle Animation
                 </button>
-                <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                <button
+                  onClick={onClose}
+                  className="text-gray-400 hover:text-gray-600"
+                >
                   <X className="h-6 w-6" />
                 </button>
               </div>
             </div>
           </div>
-          
+
           <div className="p-6 overflow-y-auto max-h-[calc(90vh-140px)]">
             {loading ? (
               <div className="flex items-center justify-center h-32">
@@ -155,9 +185,12 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
             ) : animations.length === 0 ? (
               <div className="text-center py-12">
                 <div className="text-6xl mb-4">🎭</div>
-                <h3 className="text-lg font-medium text-gray-900 mb-2">Aucune animation</h3>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                  Aucune animation
+                </h3>
                 <p className="text-gray-600 mb-4">
-                  Créez votre première animation pour enrichir l'expérience de vos participants.
+                  Créez votre première animation pour enrichir l'expérience de
+                  vos participants.
                 </p>
                 <button
                   onClick={() => setShowCreateForm(true)}
@@ -169,22 +202,31 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
             ) : (
               <div className="space-y-4">
                 {animations.map((animation) => (
-                  <div key={animation.id} className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors">
+                  <div
+                    key={animation.id}
+                    className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors"
+                  >
                     <div className="flex items-start justify-between">
                       <div className="flex-1">
                         <div className="flex items-center gap-3 mb-2">
-                          <h3 className="text-lg font-semibold text-gray-900">{animation.name}</h3>
-                          <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                            animation.is_active 
-                              ? 'bg-green-100 text-green-800' 
-                              : 'bg-gray-100 text-gray-800'
-                          }`}>
+                          <h3 className="text-lg font-semibold text-gray-900">
+                            {animation.name}
+                          </h3>
+                          <span
+                            className={`px-2 py-1 rounded-full text-xs font-medium ${
+                              animation.is_active
+                                ? 'bg-green-100 text-green-800'
+                                : 'bg-gray-100 text-gray-800'
+                            }`}
+                          >
                             {animation.is_active ? 'Active' : 'Inactive'}
                           </span>
                         </div>
-                        
-                        <p className="text-gray-600 mb-3">{animation.description}</p>
-                        
+
+                        <p className="text-gray-600 mb-3">
+                          {animation.description}
+                        </p>
+
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm text-gray-500">
                           <div className="flex items-center gap-2">
                             <MapPin className="h-4 w-4" />
@@ -193,18 +235,21 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
                           <div className="flex items-center gap-2">
                             <Clock className="h-4 w-4" />
                             <span>
-                              {format(new Date(animation.start_time), 'HH:mm')} - {format(new Date(animation.end_time), 'HH:mm')}
+                              {format(new Date(animation.start_time), 'HH:mm')}{' '}
+                              - {format(new Date(animation.end_time), 'HH:mm')}
                             </span>
                           </div>
                           <div className="flex items-center gap-2">
                             <Users className="h-4 w-4" />
                             <span>
-                              {animation.capacity === null ? 'Capacité illimitée' : `${animation.capacity} places`}
+                              {animation.capacity === null
+                                ? 'Capacité illimitée'
+                                : `${animation.capacity} places`}
                             </span>
                           </div>
                         </div>
                       </div>
-                      
+
                       <div className="flex items-center gap-2 ml-4">
                         <button
                           onClick={() => toggleAnimationStatus(animation)}
@@ -215,9 +260,13 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
                           }`}
                           title={animation.is_active ? 'Désactiver' : 'Activer'}
                         >
-                          {animation.is_active ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+                          {animation.is_active ? (
+                            <EyeOff className="h-4 w-4" />
+                          ) : (
+                            <Eye className="h-4 w-4" />
+                          )}
                         </button>
-                        
+
                         <button
                           onClick={() => setEditingAnimation(animation)}
                           className="p-2 text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded-md transition-colors"
@@ -225,7 +274,7 @@ export default function AnimationsManager({ event, onClose }: AnimationsManagerP
                         >
                           <Edit className="h-4 w-4" />
                         </button>
-                        
+
                         <button
                           onClick={() => handleDeleteAnimation(animation.id)}
                           className="p-2 text-red-600 hover:text-red-700 hover:bg-red-50 rounded-md transition-colors"
@@ -265,34 +314,43 @@ function AnimationForm({ event, animation, onClose }: AnimationFormProps) {
     name: animation?.name || '',
     description: animation?.description || '',
     location: animation?.location || '',
-    start_time: animation?.start_time ? format(new Date(animation.start_time), 'HH:mm') : '10:00',
-    end_time: animation?.end_time ? format(new Date(animation.end_time), 'HH:mm') : '11:00',
+    start_time: animation?.start_time
+      ? format(new Date(animation.start_time), 'HH:mm')
+      : '10:00',
+    end_time: animation?.end_time
+      ? format(new Date(animation.end_time), 'HH:mm')
+      : '11:00',
     capacity: animation?.capacity || null,
-    is_active: animation?.is_active ?? true
+    is_active: animation?.is_active ?? true,
   });
   const [saving, setSaving] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    
-    if (!formData.name || !formData.location || !formData.start_time || !formData.end_time) {
+
+    if (
+      !formData.name ||
+      !formData.location ||
+      !formData.start_time ||
+      !formData.end_time
+    ) {
       toast.error('Veuillez remplir tous les champs obligatoires');
       return;
     }
 
     if (formData.start_time >= formData.end_time) {
-      toast.error('L\'heure de fin doit être après l\'heure de début');
+      toast.error("L'heure de fin doit être après l'heure de début");
       return;
     }
 
     try {
       setSaving(true);
-      
+
       // Construire les dates complètes avec la date de l'événement
       const eventDate = format(new Date(event.event_date), 'yyyy-MM-dd');
       const startDateTime = new Date(`${eventDate}T${formData.start_time}:00`);
       const endDateTime = new Date(`${eventDate}T${formData.end_time}:00`);
-      
+
       const animationData = {
         event_id: event.id,
         name: formData.name,
@@ -301,7 +359,7 @@ function AnimationForm({ event, animation, onClose }: AnimationFormProps) {
         start_time: startDateTime.toISOString(),
         end_time: endDateTime.toISOString(),
         capacity: formData.capacity,
-        is_active: formData.is_active
+        is_active: formData.is_active,
       };
 
       if (animation) {
@@ -328,8 +386,8 @@ function AnimationForm({ event, animation, onClose }: AnimationFormProps) {
         query: {
           table: 'event_animations',
           action: animation ? 'update' : 'insert',
-          animationId: animation?.id
-        }
+          animationId: animation?.id,
+        },
       });
       toast.error('Erreur lors de la sauvegarde');
     } finally {
@@ -347,131 +405,155 @@ function AnimationForm({ event, animation, onClose }: AnimationFormProps) {
         aria-labelledby="animation-form-title"
       >
         <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-          <h3 id="animation-form-title" className="text-lg font-semibold text-gray-900">
-              {animation ? "Modifier l'Animation" : 'Créer une Animation'}
+          <h3
+            id="animation-form-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            {animation ? "Modifier l'Animation" : 'Créer une Animation'}
           </h3>
-          <button onClick={onClose} aria-label="Fermer le modal" className="text-gray-400 hover:text-gray-600">
+          <button
+            onClick={onClose}
+            aria-label="Fermer le modal"
+            className="text-gray-400 hover:text-gray-600"
+          >
             <X className="h-5 w-5" />
           </button>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4 p-6 overflow-y-auto">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Nom de l'animation *
+            </label>
+            <input
+              type="text"
+              value={formData.name}
+              onChange={(e) =>
+                setFormData({ ...formData, name: e.target.value })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Ex: Spectacle de magie"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description
+            </label>
+            <textarea
+              value={formData.description}
+              onChange={(e) =>
+                setFormData({ ...formData, description: e.target.value })
+              }
+              rows={3}
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Description de l'animation..."
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Lieu *
+            </label>
+            <input
+              type="text"
+              value={formData.location}
+              onChange={(e) =>
+                setFormData({ ...formData, location: e.target.value })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Ex: Scène principale"
+              required
+            />
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Nom de l'animation *
+                Heure de début *
               </label>
               <input
-                type="text"
-                value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                type="time"
+                value={formData.start_time}
+                onChange={(e) =>
+                  setFormData({ ...formData, start_time: e.target.value })
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-                placeholder="Ex: Spectacle de magie"
                 required
               />
             </div>
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Description
-              </label>
-              <textarea
-                value={formData.description}
-                onChange={(e) => setFormData({ ...formData, description: e.target.value })}
-                rows={3}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-                placeholder="Description de l'animation..."
-              />
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Lieu *
+                Heure de fin *
               </label>
               <input
-                type="text"
-                value={formData.location}
-                onChange={(e) => setFormData({ ...formData, location: e.target.value })}
+                type="time"
+                value={formData.end_time}
+                onChange={(e) =>
+                  setFormData({ ...formData, end_time: e.target.value })
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-                placeholder="Ex: Scène principale"
                 required
               />
             </div>
+          </div>
 
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Heure de début *
-                </label>
-                <input
-                  type="time"
-                  value={formData.start_time}
-                  onChange={(e) => setFormData({ ...formData, start_time: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-                  required
-                />
-              </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Capacité (optionnel)
+            </label>
+            <input
+              type="number"
+              min="1"
+              value={formData.capacity || ''}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  capacity: e.target.value ? parseInt(e.target.value) : null,
+                })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
+              placeholder="Laisser vide pour capacité illimitée"
+            />
+          </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Heure de fin *
-                </label>
-                <input
-                  type="time"
-                  value={formData.end_time}
-                  onChange={(e) => setFormData({ ...formData, end_time: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-                  required
-                />
-              </div>
-            </div>
+          <div className="flex items-center gap-3">
+            <input
+              type="checkbox"
+              id="is_active"
+              checked={formData.is_active}
+              onChange={(e) =>
+                setFormData({ ...formData, is_active: e.target.checked })
+              }
+              className="h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 rounded"
+            />
+            <label
+              htmlFor="is_active"
+              className="text-sm font-medium text-gray-700"
+            >
+              Animation active (visible au public)
+            </label>
+          </div>
 
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Capacité (optionnel)
-              </label>
-              <input
-                type="number"
-                min="1"
-                value={formData.capacity || ''}
-                onChange={(e) => setFormData({ 
-                  ...formData, 
-                  capacity: e.target.value ? parseInt(e.target.value) : null 
-                })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-purple-500 focus:border-purple-500"
-                placeholder="Laisser vide pour capacité illimitée"
-              />
-            </div>
-
-            <div className="flex items-center gap-3">
-              <input
-                type="checkbox"
-                id="is_active"
-                checked={formData.is_active}
-                onChange={(e) => setFormData({ ...formData, is_active: e.target.checked })}
-                className="h-4 w-4 text-purple-600 focus:ring-purple-500 border-gray-300 rounded"
-              />
-              <label htmlFor="is_active" className="text-sm font-medium text-gray-700">
-                Animation active (visible au public)
-              </label>
-            </div>
-
-            <div className="flex gap-3 pt-4">
-              <button
-                type="button"
-                onClick={onClose}
-                className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-900 px-4 py-2 rounded-md font-medium transition-colors"
-              >
-                Annuler
-              </button>
-              <button
-                type="submit"
-                disabled={saving}
-                className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:bg-purple-400 text-white px-4 py-2 rounded-md font-medium transition-colors"
-              >
-                {saving ? 'Sauvegarde...' : (animation ? 'Modifier' : 'Créer')}
-              </button>
-            </div>
-          </form>
+          <div className="flex gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-900 px-4 py-2 rounded-md font-medium transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={saving}
+              className="flex-1 bg-purple-600 hover:bg-purple-700 disabled:bg-purple-400 text-white px-4 py-2 rounded-md font-medium transition-colors"
+            >
+              {saving ? 'Sauvegarde...' : animation ? 'Modifier' : 'Créer'}
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/src/components/admin/EventActivitiesManager.tsx
+++ b/src/components/admin/EventActivitiesManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type FormEvent } from 'react';
 import { supabase } from '../../lib/supabase';
 import { X, Plus, Settings, Clock, Users, Target, Trash2 } from 'lucide-react';
 import { format } from 'date-fns';
@@ -35,25 +35,34 @@ interface EventActivitiesManagerProps {
   onClose: () => void;
 }
 
-export default function EventActivitiesManager({ event, onClose }: EventActivitiesManagerProps) {
+export default function EventActivitiesManager({
+  event,
+  onClose,
+}: EventActivitiesManagerProps) {
   const [eventActivities, setEventActivities] = useState<EventActivity[]>([]);
-  const [availableActivities, setAvailableActivities] = useState<Activity[]>([]);
+  const [availableActivities, setAvailableActivities] = useState<Activity[]>(
+    [],
+  );
   const [loading, setLoading] = useState(true);
   const [showAddModal, setShowAddModal] = useState(false);
-  const [showTimeSlotsModal, setShowTimeSlotsModal] = useState<EventActivity | null>(null);
+  const [showTimeSlotsModal, setShowTimeSlotsModal] =
+    useState<EventActivity | null>(null);
 
   const loadData = useCallback(async (): Promise<void> => {
     try {
       setLoading(true);
-      
+
       // Charger les activités de l'événement
-      const { data: eventActivitiesData, error: eventActivitiesError } = await supabase
-        .from('event_activities')
-        .select(`
+      const { data: eventActivitiesData, error: eventActivitiesError } =
+        await supabase
+          .from('event_activities')
+          .select(
+            `
           *,
           activities (*)
-        `)
-        .eq('event_id', event.id);
+        `,
+          )
+          .eq('event_id', event.id);
 
       if (eventActivitiesError) throw eventActivitiesError;
 
@@ -70,15 +79,16 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
             .select('capacity')
             .eq('event_activity_id', ea.id);
 
-          const totalCapacity = slotsData?.reduce((sum, slot) => sum + slot.capacity, 0) || 0;
+          const totalCapacity =
+            slotsData?.reduce((sum, slot) => sum + slot.capacity, 0) || 0;
 
           return {
             ...ea,
             activity: ea.activities,
             time_slots_count: count || 0,
-            total_capacity: totalCapacity
+            total_capacity: totalCapacity,
           };
-        })
+        }),
       );
 
       setEventActivities(enrichedEventActivities);
@@ -104,7 +114,12 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
   }, [loadData]);
 
   const handleRemoveActivity = async (eventActivityId: string) => {
-    if (!confirm('Êtes-vous sûr de vouloir retirer cette activité de l\'événement ?')) return;
+    if (
+      !confirm(
+        "Êtes-vous sûr de vouloir retirer cette activité de l'événement ?",
+      )
+    )
+      return;
 
     try {
       const { error } = await supabase
@@ -113,8 +128,8 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
         .eq('id', eventActivityId);
 
       if (error) throw error;
-      
-      toast.success('Activité retirée de l\'événement');
+
+      toast.success("Activité retirée de l'événement");
       loadData();
     } catch (err) {
       logger.error('Erreur suppression activité', { error: err });
@@ -149,12 +164,17 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center justify-between">
               <div>
-                <h2 id="event-activities-title" className="text-xl font-semibold text-gray-900 flex items-center gap-2">
+                <h2
+                  id="event-activities-title"
+                  className="text-xl font-semibold text-gray-900 flex items-center gap-2"
+                >
                   <Settings className="h-6 w-6 text-green-600" />
                   Activités - {event.name}
                 </h2>
                 <p className="text-gray-600">
-                  {format(new Date(event.event_date), 'EEEE d MMMM yyyy', { locale: fr })}
+                  {format(new Date(event.event_date), 'EEEE d MMMM yyyy', {
+                    locale: fr,
+                  })}
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -165,20 +185,26 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
                   <Plus className="h-4 w-4" />
                   Ajouter Activité
                 </button>
-                <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                <button
+                  onClick={onClose}
+                  className="text-gray-400 hover:text-gray-600"
+                >
                   <X className="h-6 w-6" />
                 </button>
               </div>
             </div>
           </div>
-          
+
           <div className="p-6 overflow-y-auto max-h-[calc(90vh-140px)]">
             {eventActivities.length === 0 ? (
               <div className="text-center py-12">
                 <Target className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">Aucune activité</h3>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                  Aucune activité
+                </h3>
                 <p className="text-gray-600 mb-4">
-                  Ajoutez des activités à votre événement pour permettre aux participants de réserver.
+                  Ajoutez des activités à votre événement pour permettre aux
+                  participants de réserver.
                 </p>
                 <button
                   onClick={() => setShowAddModal(true)}
@@ -190,10 +216,15 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
             ) : (
               <div className="space-y-4">
                 {eventActivities.map((eventActivity) => (
-                  <div key={eventActivity.id} className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors">
+                  <div
+                    key={eventActivity.id}
+                    className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors"
+                  >
                     <div className="flex items-start justify-between">
                       <div className="flex items-start gap-4 flex-1">
-                        <span className="text-3xl">{eventActivity.activity.icon}</span>
+                        <span className="text-3xl">
+                          {eventActivity.activity.icon}
+                        </span>
                         <div className="flex-1">
                           <h3 className="text-lg font-semibold text-gray-900 mb-1">
                             {eventActivity.activity.name}
@@ -201,38 +232,46 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
                           <p className="text-gray-600 text-sm mb-3">
                             {eventActivity.activity.description}
                           </p>
-                          
+
                           <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
                             <div className="flex items-center gap-2 text-gray-500">
                               <Users className="h-4 w-4" />
                               <span>
-                                Stock: {eventActivity.stock_limit === null ? 'Illimité' : eventActivity.stock_limit}
+                                Stock:{' '}
+                                {eventActivity.stock_limit === null
+                                  ? 'Illimité'
+                                  : eventActivity.stock_limit}
                                 {eventActivity.requires_time_slot &&
                                   (eventActivity.total_capacity ?? 0) > 0 && (
                                     <span className="text-blue-600 ml-1">
-                                      (calculé: {eventActivity.total_capacity ?? 0})
+                                      (calculé:{' '}
+                                      {eventActivity.total_capacity ?? 0})
                                     </span>
                                   )}
                               </span>
                             </div>
-                            
+
                             <div className="flex items-center gap-2 text-gray-500">
                               <Clock className="h-4 w-4" />
                               <span>
-                                {eventActivity.requires_time_slot ? 'Avec créneaux' : 'Sans créneaux'}
+                                {eventActivity.requires_time_slot
+                                  ? 'Avec créneaux'
+                                  : 'Sans créneaux'}
                               </span>
                             </div>
-                            
+
                             {eventActivity.requires_time_slot && (
                               <div className="flex items-center gap-2 text-gray-500">
                                 <Target className="h-4 w-4" />
-                                <span>{eventActivity.time_slots_count} créneau(x)</span>
+                                <span>
+                                  {eventActivity.time_slots_count} créneau(x)
+                                </span>
                               </div>
                             )}
                           </div>
                         </div>
                       </div>
-                      
+
                       <div className="flex items-center gap-2 ml-4">
                         {eventActivity.requires_time_slot && (
                           <button
@@ -243,7 +282,7 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
                             Créneaux ({eventActivity.time_slots_count})
                           </button>
                         )}
-                        
+
                         <button
                           onClick={() => handleRemoveActivity(eventActivity.id)}
                           className="p-2 text-red-600 hover:text-red-700 hover:bg-red-50 rounded-md transition-colors"
@@ -265,7 +304,7 @@ export default function EventActivitiesManager({ event, onClose }: EventActiviti
         <AddActivityModal
           event={event}
           availableActivities={availableActivities}
-          existingActivityIds={eventActivities.map(ea => ea.activity_id)}
+          existingActivityIds={eventActivities.map((ea) => ea.activity_id)}
           onClose={() => setShowAddModal(false)}
           onSave={() => {
             setShowAddModal(false);
@@ -293,19 +332,25 @@ interface AddActivityModalProps {
   onSave: () => void;
 }
 
-function AddActivityModal({ event, availableActivities, existingActivityIds, onClose, onSave }: AddActivityModalProps) {
+function AddActivityModal({
+  event,
+  availableActivities,
+  existingActivityIds,
+  onClose,
+  onSave,
+}: AddActivityModalProps) {
   const [selectedActivityId, setSelectedActivityId] = useState('');
   const [stockLimit, setStockLimit] = useState<number | null>(null);
   const [requiresTimeSlot, setRequiresTimeSlot] = useState(false);
   const [saving, setSaving] = useState(false);
 
   const availableOptions = availableActivities.filter(
-    activity => !existingActivityIds.includes(activity.id)
+    (activity) => !existingActivityIds.includes(activity.id),
   );
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    
+
     if (!selectedActivityId) {
       toast.error('Veuillez sélectionner une activité');
       return;
@@ -313,23 +358,21 @@ function AddActivityModal({ event, availableActivities, existingActivityIds, onC
 
     try {
       setSaving(true);
-      
-      const { error } = await supabase
-        .from('event_activities')
-        .insert({
-          event_id: event.id,
-          activity_id: selectedActivityId,
-          stock_limit: stockLimit,
-          requires_time_slot: requiresTimeSlot
-        });
+
+      const { error } = await supabase.from('event_activities').insert({
+        event_id: event.id,
+        activity_id: selectedActivityId,
+        stock_limit: stockLimit,
+        requires_time_slot: requiresTimeSlot,
+      });
 
       if (error) throw error;
-      
-      toast.success('Activité ajoutée à l\'événement');
+
+      toast.success("Activité ajoutée à l'événement");
       onSave();
     } catch (err) {
       logger.error('Erreur ajout activité', { error: err });
-      toast.error('Erreur lors de l\'ajout');
+      toast.error("Erreur lors de l'ajout");
     } finally {
       setSaving(false);
     }
@@ -345,10 +388,17 @@ function AddActivityModal({ event, availableActivities, existingActivityIds, onC
         aria-labelledby="add-activity-title"
       >
         <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-          <h3 id="add-activity-title" className="text-lg font-semibold text-gray-900">
-              Ajouter une Activité
+          <h3
+            id="add-activity-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            Ajouter une Activité
           </h3>
-          <button onClick={onClose} aria-label="Fermer le modal" className="text-gray-400 hover:text-gray-600">
+          <button
+            onClick={onClose}
+            aria-label="Fermer le modal"
+            className="text-gray-400 hover:text-gray-600"
+          >
             <X className="h-5 w-5" />
           </button>
         </div>
@@ -358,7 +408,8 @@ function AddActivityModal({ event, availableActivities, existingActivityIds, onC
             <div className="text-center py-8">
               <Target className="h-12 w-12 text-gray-400 mx-auto mb-4" />
               <p className="text-gray-600">
-                Toutes les activités disponibles ont déjà été ajoutées à cet événement.
+                Toutes les activités disponibles ont déjà été ajoutées à cet
+                événement.
               </p>
               <button
                 onClick={onClose}
@@ -369,79 +420,90 @@ function AddActivityModal({ event, availableActivities, existingActivityIds, onC
             </div>
           </div>
         ) : (
-          <form onSubmit={handleSubmit} className="space-y-4 p-6 overflow-y-auto">
+          <form
+            onSubmit={handleSubmit}
+            className="space-y-4 p-6 overflow-y-auto"
+          >
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
                 Activité *
               </label>
-                <select
-                  value={selectedActivityId}
-                  onChange={(e) => setSelectedActivityId(e.target.value)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-green-500"
-                  required
-                >
-                  <option value="">Sélectionner une activité</option>
-                  {availableOptions.map((activity) => (
-                    <option key={activity.id} value={activity.id}>
-                      {activity.icon} {activity.name}
-                    </option>
-                  ))}
-                </select>
-              </div>
+              <select
+                value={selectedActivityId}
+                onChange={(e) => setSelectedActivityId(e.target.value)}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                required
+              >
+                <option value="">Sélectionner une activité</option>
+                {availableOptions.map((activity) => (
+                  <option key={activity.id} value={activity.id}>
+                    {activity.icon} {activity.name}
+                  </option>
+                ))}
+              </select>
+            </div>
 
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Stock limite (optionnel)
-                </label>
-                <input
-                  type="number"
-                  min="1"
-                  value={stockLimit || ''}
-                  onChange={(e) => setStockLimit(e.target.value ? parseInt(e.target.value) : null)}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-green-500"
-                  placeholder="Laisser vide pour stock illimité"
-                />
-              </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Stock limite (optionnel)
+              </label>
+              <input
+                type="number"
+                min="1"
+                value={stockLimit || ''}
+                onChange={(e) =>
+                  setStockLimit(
+                    e.target.value ? parseInt(e.target.value) : null,
+                  )
+                }
+                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-green-500 focus:border-green-500"
+                placeholder="Laisser vide pour stock illimité"
+              />
+            </div>
 
-              <div className="flex items-center gap-3">
-                <input
-                  type="checkbox"
-                  id="requires_time_slot"
-                  checked={requiresTimeSlot}
-                  onChange={(e) => setRequiresTimeSlot(e.target.checked)}
-                  className="h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded"
-                />
-                <label htmlFor="requires_time_slot" className="text-sm font-medium text-gray-700">
-                  Nécessite des créneaux horaires
-                </label>
-              </div>
+            <div className="flex items-center gap-3">
+              <input
+                type="checkbox"
+                id="requires_time_slot"
+                checked={requiresTimeSlot}
+                onChange={(e) => setRequiresTimeSlot(e.target.checked)}
+                className="h-4 w-4 text-green-600 focus:ring-green-500 border-gray-300 rounded"
+              />
+              <label
+                htmlFor="requires_time_slot"
+                className="text-sm font-medium text-gray-700"
+              >
+                Nécessite des créneaux horaires
+              </label>
+            </div>
 
-              {requiresTimeSlot && (
-                <div className="p-3 bg-blue-50 rounded-md">
-                  <p className="text-sm text-blue-800">
-                    Le stock sera calculé automatiquement selon la capacité des créneaux créés.
-                  </p>
-                </div>
-              )}
-
-              <div className="flex gap-3 pt-4">
-                <button
-                  type="button"
-                  onClick={onClose}
-                  className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-900 px-4 py-2 rounded-md font-medium transition-colors"
-                >
-                  Annuler
-                </button>
-                <button
-                  type="submit"
-                  disabled={saving}
-                  className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-green-400 text-white px-4 py-2 rounded-md font-medium transition-colors"
-                >
-                  {saving ? 'Ajout...' : 'Ajouter'}
-                </button>
+            {requiresTimeSlot && (
+              <div className="p-3 bg-blue-50 rounded-md">
+                <p className="text-sm text-blue-800">
+                  Le stock sera calculé automatiquement selon la capacité des
+                  créneaux créés.
+                </p>
               </div>
-            </form>
-          )}
+            )}
+
+            <div className="flex gap-3 pt-4">
+              <button
+                type="button"
+                onClick={onClose}
+                className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-900 px-4 py-2 rounded-md font-medium transition-colors"
+              >
+                Annuler
+              </button>
+              <button
+                type="submit"
+                disabled={saving}
+                className="flex-1 bg-green-600 hover:bg-green-700 disabled:bg-green-400 text-white px-4 py-2 rounded-md font-medium transition-colors"
+              >
+                {saving ? 'Ajout...' : 'Ajouter'}
+              </button>
+            </div>
+          </form>
+        )}
       </div>
     </div>
   );

--- a/src/components/admin/EventForm.tsx
+++ b/src/components/admin/EventForm.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect, type ChangeEvent, type FormEvent } from 'react';
 import { supabase } from '../../lib/supabase';
 import { toast } from 'react-hot-toast';
 import { X } from 'lucide-react';
@@ -43,15 +43,27 @@ export default function EventForm({ event, onClose }: EventFormProps) {
     if (event) {
       setFormData({
         name: event.name,
-        event_date: event.event_date ? new Date(event.event_date).toISOString().substring(0, 10) : '',
-        sales_opening_date: event.sales_opening_date ? new Date(event.sales_opening_date).toISOString().substring(0, 16) : '',
-        sales_closing_date: event.sales_closing_date ? new Date(event.sales_closing_date).toISOString().substring(0, 16) : '',
+        event_date: event.event_date
+          ? new Date(event.event_date).toISOString().substring(0, 10)
+          : '',
+        sales_opening_date: event.sales_opening_date
+          ? new Date(event.sales_opening_date).toISOString().substring(0, 16)
+          : '',
+        sales_closing_date: event.sales_closing_date
+          ? new Date(event.sales_closing_date).toISOString().substring(0, 16)
+          : '',
         status: event.status,
         cgv_content: event.cgv_content || '',
         key_info_content: event.key_info_content || '',
         has_animations: event.has_animations || false,
       });
-      setFaqs(event.faqs.map(f => ({ id: crypto.randomUUID(), question: f.question, answer: f.answer })));
+      setFaqs(
+        event.faqs.map((f) => ({
+          id: crypto.randomUUID(),
+          question: f.question,
+          answer: f.answer,
+        })),
+      );
     } else {
       // Reset for new event
       setFormData({
@@ -68,22 +80,24 @@ export default function EventForm({ event, onClose }: EventFormProps) {
     }
   }, [event]);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
+  const handleChange = (
+    e: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
+  ) => {
     const { name, value, type } = e.target;
 
     if (type === 'checkbox') {
-        const { checked } = e.target as HTMLInputElement;
-        setFormData(prev => ({ ...prev, [name]: checked }));
+      const { checked } = e.target as HTMLInputElement;
+      setFormData((prev) => ({ ...prev, [name]: checked }));
     } else {
-        setFormData(prev => ({ ...prev, [name]: value }));
+      setFormData((prev) => ({ ...prev, [name]: value }));
     }
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setLoading(true);
 
-    if (faqs.some(f => !f.question.trim() || f.answer.trim().length < 20)) {
+    if (faqs.some((f) => !f.question.trim() || f.answer.trim().length < 20)) {
       toast.error('Toutes les questions doivent avoir une réponse valide.');
       setLoading(false);
       return;
@@ -145,7 +159,7 @@ export default function EventForm({ event, onClose }: EventFormProps) {
               question: f.question,
               answer: f.answer,
               position: index,
-            }))
+            })),
           );
           if (faqError) throw faqError;
         }
@@ -173,10 +187,16 @@ export default function EventForm({ event, onClose }: EventFormProps) {
       >
         <div className="p-6 border-b border-gray-200">
           <div className="flex items-center justify-between">
-            <h2 id="event-form-title" className="text-xl font-semibold text-gray-900">
+            <h2
+              id="event-form-title"
+              className="text-xl font-semibold text-gray-900"
+            >
               {event ? "Modifier l'événement" : 'Nouvel Événement'}
             </h2>
-            <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600"
+            >
               <X className="h-6 w-6" />
             </button>
           </div>
@@ -185,28 +205,91 @@ export default function EventForm({ event, onClose }: EventFormProps) {
         <form onSubmit={handleSubmit} className="p-6 space-y-6 overflow-y-auto">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
             <div>
-              <label htmlFor="name" className="block text-sm font-medium text-gray-700 mb-1">Nom de l'événement</label>
-              <input type="text" name="name" id="name" value={formData.name} onChange={handleChange} required className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" />
+              <label
+                htmlFor="name"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Nom de l'événement
+              </label>
+              <input
+                type="text"
+                name="name"
+                id="name"
+                value={formData.name}
+                onChange={handleChange}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+              />
             </div>
 
             <div>
-              <label htmlFor="event_date" className="block text-sm font-medium text-gray-700 mb-1">Date de l'événement</label>
-              <input type="date" name="event_date" id="event_date" value={formData.event_date} onChange={handleChange} required className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" />
+              <label
+                htmlFor="event_date"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Date de l'événement
+              </label>
+              <input
+                type="date"
+                name="event_date"
+                id="event_date"
+                value={formData.event_date}
+                onChange={handleChange}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+              />
             </div>
 
             <div>
-              <label htmlFor="sales_opening_date" className="block text-sm font-medium text-gray-700 mb-1">Ouverture des ventes</label>
-              <input type="datetime-local" name="sales_opening_date" id="sales_opening_date" value={formData.sales_opening_date} onChange={handleChange} required className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" />
+              <label
+                htmlFor="sales_opening_date"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Ouverture des ventes
+              </label>
+              <input
+                type="datetime-local"
+                name="sales_opening_date"
+                id="sales_opening_date"
+                value={formData.sales_opening_date}
+                onChange={handleChange}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+              />
             </div>
 
             <div>
-              <label htmlFor="sales_closing_date" className="block text-sm font-medium text-gray-700 mb-1">Fermeture des ventes</label>
-              <input type="datetime-local" name="sales_closing_date" id="sales_closing_date" value={formData.sales_closing_date} onChange={handleChange} required className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500" />
+              <label
+                htmlFor="sales_closing_date"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Fermeture des ventes
+              </label>
+              <input
+                type="datetime-local"
+                name="sales_closing_date"
+                id="sales_closing_date"
+                value={formData.sales_closing_date}
+                onChange={handleChange}
+                required
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+              />
             </div>
 
             <div>
-              <label htmlFor="status" className="block text-sm font-medium text-gray-700 mb-1">Statut</label>
-              <select name="status" id="status" value={formData.status} onChange={handleChange} className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500">
+              <label
+                htmlFor="status"
+                className="block text-sm font-medium text-gray-700 mb-1"
+              >
+                Statut
+              </label>
+              <select
+                name="status"
+                id="status"
+                value={formData.status}
+                onChange={handleChange}
+                className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+              >
                 <option value="draft">Brouillon</option>
                 <option value="published">Publié</option>
                 <option value="finished">Terminé</option>
@@ -214,18 +297,21 @@ export default function EventForm({ event, onClose }: EventFormProps) {
               </select>
             </div>
 
-             <div className="flex items-center">
-                <input
-                    type="checkbox"
-                    name="has_animations"
-                    id="has_animations"
-                    checked={formData.has_animations}
-                    onChange={handleChange}
-                    className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
-                />
-                <label htmlFor="has_animations" className="ml-2 block text-sm text-gray-900">
-                    Activer les animations pour cet événement
-                </label>
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                name="has_animations"
+                id="has_animations"
+                checked={formData.has_animations}
+                onChange={handleChange}
+                className="h-4 w-4 text-blue-600 border-gray-300 rounded focus:ring-blue-500"
+              />
+              <label
+                htmlFor="has_animations"
+                className="ml-2 block text-sm text-gray-900"
+              >
+                Activer les animations pour cet événement
+              </label>
             </div>
           </div>
 
@@ -234,7 +320,9 @@ export default function EventForm({ event, onClose }: EventFormProps) {
               id="key_info_content"
               label="Informations clés"
               value={formData.key_info_content}
-              onChange={(value) => setFormData(prev => ({ ...prev, key_info_content: value }))}
+              onChange={(value) =>
+                setFormData((prev) => ({ ...prev, key_info_content: value }))
+              }
               rows={4}
             />
           </div>
@@ -244,7 +332,9 @@ export default function EventForm({ event, onClose }: EventFormProps) {
               id="cgv_content"
               label="Conditions Générales de Vente (CGV)"
               value={formData.cgv_content}
-              onChange={(value) => setFormData(prev => ({ ...prev, cgv_content: value }))}
+              onChange={(value) =>
+                setFormData((prev) => ({ ...prev, cgv_content: value }))
+              }
               rows={6}
             />
           </div>
@@ -254,10 +344,18 @@ export default function EventForm({ event, onClose }: EventFormProps) {
           </div>
 
           <div className="flex justify-end items-center p-6 bg-gray-50 border-t border-gray-200">
-            <button type="button" onClick={onClose} className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
+            >
               Annuler
             </button>
-            <button type="submit" disabled={loading} className="ml-3 px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:bg-blue-300">
+            <button
+              type="submit"
+              disabled={loading}
+              className="ml-3 px-4 py-2 text-sm font-medium text-white bg-blue-600 border border-transparent rounded-md shadow-sm hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:bg-blue-300"
+            >
               {loading ? 'Sauvegarde...' : 'Sauvegarder'}
             </button>
           </div>

--- a/src/components/admin/FAQEditor.tsx
+++ b/src/components/admin/FAQEditor.tsx
@@ -1,6 +1,17 @@
-import React from 'react';
-import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, DragEndEvent } from '@dnd-kit/core';
-import { arrayMove, SortableContext, useSortable, verticalListSortingStrategy } from '@dnd-kit/sortable';
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  arrayMove,
+  SortableContext,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
 import { CSS } from '@dnd-kit/utilities';
 import { GripVertical, Trash2, Plus } from 'lucide-react';
 import MarkdownEditor from './MarkdownEditor';
@@ -16,22 +27,42 @@ interface FAQEditorProps {
   onChange: (items: FAQFormItem[]) => void;
 }
 
-function SortableFAQItem({ item, onChange, onRemove }: { item: FAQFormItem; onChange: (item: FAQFormItem) => void; onRemove: () => void; }) {
-  const { attributes, listeners, setNodeRef, transform, transition } = useSortable({ id: item.id });
+function SortableFAQItem({
+  item,
+  onChange,
+  onRemove,
+}: {
+  item: FAQFormItem;
+  onChange: (item: FAQFormItem) => void;
+  onRemove: () => void;
+}) {
+  const { attributes, listeners, setNodeRef, transform, transition } =
+    useSortable({ id: item.id });
   const style = { transform: CSS.Transform.toString(transform), transition };
 
   const questionError = !item.question.trim();
   const answerError = item.answer.trim().length < 20;
 
   return (
-    <div ref={setNodeRef} style={style} className="border rounded-md p-4 bg-white">
+    <div
+      ref={setNodeRef}
+      style={style}
+      className="border rounded-md p-4 bg-white"
+    >
       <div className="flex items-start gap-2">
-        <button type="button" {...attributes} {...listeners} className="cursor-move pt-2 text-gray-400">
+        <button
+          type="button"
+          {...attributes}
+          {...listeners}
+          className="cursor-move pt-2 text-gray-400"
+        >
           <GripVertical className="h-5 w-5" />
         </button>
         <div className="flex-1 space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Question</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Question
+            </label>
             <input
               type="text"
               value={item.question}
@@ -39,7 +70,9 @@ function SortableFAQItem({ item, onChange, onRemove }: { item: FAQFormItem; onCh
               className="w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
             />
             {questionError && (
-              <p className="mt-1 text-sm text-red-600">La question ne peut pas être vide</p>
+              <p className="mt-1 text-sm text-red-600">
+                La question ne peut pas être vide
+              </p>
             )}
           </div>
           <MarkdownEditor
@@ -49,7 +82,9 @@ function SortableFAQItem({ item, onChange, onRemove }: { item: FAQFormItem; onCh
             rows={4}
           />
           {answerError && (
-            <p className="mt-1 text-sm text-red-600">La réponse doit contenir au moins 20 caractères</p>
+            <p className="mt-1 text-sm text-red-600">
+              La réponse doit contenir au moins 20 caractères
+            </p>
           )}
         </div>
         <button
@@ -81,10 +116,7 @@ export default function FAQEditor({ value, onChange }: FAQEditorProps) {
   };
 
   const addItem = () => {
-    onChange([
-      ...value,
-      { id: crypto.randomUUID(), question: '', answer: '' },
-    ]);
+    onChange([...value, { id: crypto.randomUUID(), question: '', answer: '' }]);
   };
 
   const removeItem = (id: string) => {
@@ -93,9 +125,18 @@ export default function FAQEditor({ value, onChange }: FAQEditorProps) {
 
   return (
     <div>
-      <label className="block text-sm font-medium text-gray-700 mb-2">FAQ</label>
-      <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={handleDragEnd}>
-        <SortableContext items={value.map((i) => i.id)} strategy={verticalListSortingStrategy}>
+      <label className="block text-sm font-medium text-gray-700 mb-2">
+        FAQ
+      </label>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={value.map((i) => i.id)}
+          strategy={verticalListSortingStrategy}
+        >
           <div className="space-y-4">
             {value.map((item) => (
               <SortableFAQItem
@@ -119,4 +160,3 @@ export default function FAQEditor({ value, onChange }: FAQEditorProps) {
     </div>
   );
 }
-

--- a/src/components/admin/MarkdownEditor.tsx
+++ b/src/components/admin/MarkdownEditor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type ChangeEvent } from 'react';
 import MarkdownRenderer from '../MarkdownRenderer';
 
 interface MarkdownEditorProps {
@@ -9,10 +9,16 @@ interface MarkdownEditorProps {
   id?: string;
 }
 
-export default function MarkdownEditor({ value, onChange, label, rows = 6, id }: MarkdownEditorProps) {
+export default function MarkdownEditor({
+  value,
+  onChange,
+  label,
+  rows = 6,
+  id,
+}: MarkdownEditorProps) {
   const [error, setError] = useState<string | null>(null);
 
-  const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+  const handleChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
     const newValue = e.target.value;
     onChange(newValue);
     if (!newValue.trim()) {
@@ -24,7 +30,12 @@ export default function MarkdownEditor({ value, onChange, label, rows = 6, id }:
 
   return (
     <div>
-      <label htmlFor={id} className="block text-sm font-medium text-gray-700 mb-1">{label}</label>
+      <label
+        htmlFor={id}
+        className="block text-sm font-medium text-gray-700 mb-1"
+      >
+        {label}
+      </label>
       <textarea
         id={id}
         value={value}
@@ -34,7 +45,9 @@ export default function MarkdownEditor({ value, onChange, label, rows = 6, id }:
       />
       {error && <p className="mt-1 text-sm text-red-600">{error}</p>}
       <div className="mt-4">
-        <p className="text-sm font-medium text-gray-700 mb-1">Prévisualisation</p>
+        <p className="text-sm font-medium text-gray-700 mb-1">
+          Prévisualisation
+        </p>
         <div className="border border-gray-200 rounded-md p-3">
           <MarkdownRenderer content={value} />
         </div>

--- a/src/components/admin/TimeSlotsManager.tsx
+++ b/src/components/admin/TimeSlotsManager.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, type FormEvent } from 'react';
 import { supabase } from '../../lib/supabase';
 import { X, Plus, Trash2, Clock, Users } from 'lucide-react';
 import { format, addMinutes, startOfDay } from 'date-fns';
@@ -33,7 +33,11 @@ interface TimeSlotsManagerProps {
   onClose: () => void;
 }
 
-export default function TimeSlotsManager({ eventActivity, event, onClose }: TimeSlotsManagerProps) {
+export default function TimeSlotsManager({
+  eventActivity,
+  event,
+  onClose,
+}: TimeSlotsManagerProps) {
   const [timeSlots, setTimeSlots] = useState<TimeSlot[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateForm, setShowCreateForm] = useState(false);
@@ -52,14 +56,16 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
       // Calculer la capacité restante pour chaque créneau
       const slotsWithCapacity = await Promise.all(
         (data || []).map(async (slot) => {
-          const { data: capacityData } = await supabase
-            .rpc('get_slot_remaining_capacity', { slot_uuid: slot.id });
+          const { data: capacityData } = await supabase.rpc(
+            'get_slot_remaining_capacity',
+            { slot_uuid: slot.id },
+          );
 
           return {
             ...slot,
-            remaining_capacity: capacityData || 0
+            remaining_capacity: capacityData || 0,
           };
-        })
+        }),
       );
 
       setTimeSlots(slotsWithCapacity);
@@ -85,7 +91,7 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
         .eq('id', slotId);
 
       if (error) throw error;
-      
+
       toast.success('Créneau supprimé');
       loadTimeSlots();
     } catch (err) {
@@ -121,12 +127,20 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center justify-between">
               <div>
-                <h2 id="time-slots-title" className="text-xl font-semibold text-gray-900 flex items-center gap-2">
-                  <span className="text-2xl">{eventActivity.activity.icon}</span>
+                <h2
+                  id="time-slots-title"
+                  className="text-xl font-semibold text-gray-900 flex items-center gap-2"
+                >
+                  <span className="text-2xl">
+                    {eventActivity.activity.icon}
+                  </span>
                   Créneaux - {eventActivity.activity.name}
                 </h2>
                 <p className="text-gray-600">
-                  {event.name} • {format(new Date(event.event_date), 'EEEE d MMMM yyyy', { locale: fr })}
+                  {event.name} •{' '}
+                  {format(new Date(event.event_date), 'EEEE d MMMM yyyy', {
+                    locale: fr,
+                  })}
                 </p>
               </div>
               <div className="flex items-center gap-2">
@@ -137,20 +151,26 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
                   <Plus className="h-4 w-4" />
                   Créer Créneaux
                 </button>
-                <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+                <button
+                  onClick={onClose}
+                  className="text-gray-400 hover:text-gray-600"
+                >
                   <X className="h-6 w-6" />
                 </button>
               </div>
             </div>
           </div>
-          
+
           <div className="p-6 overflow-y-auto max-h-[calc(90vh-140px)]">
             {timeSlots.length === 0 ? (
               <div className="text-center py-12">
                 <Clock className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-                <h3 className="text-lg font-medium text-gray-900 mb-2">Aucun créneau</h3>
+                <h3 className="text-lg font-medium text-gray-900 mb-2">
+                  Aucun créneau
+                </h3>
                 <p className="text-gray-600 mb-4">
-                  Créez des créneaux horaires pour permettre aux participants de réserver cette activité.
+                  Créez des créneaux horaires pour permettre aux participants de
+                  réserver cette activité.
                 </p>
                 <button
                   onClick={() => setShowCreateForm(true)}
@@ -164,19 +184,26 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
                 <div className="bg-blue-50 rounded-lg p-4 mb-6">
                   <div className="flex items-center gap-2 text-blue-800 mb-2">
                     <Users className="h-5 w-5" />
-                    <span className="font-medium">Capacité totale calculée</span>
+                    <span className="font-medium">
+                      Capacité totale calculée
+                    </span>
                   </div>
                   <div className="text-2xl font-bold text-blue-900">
-                    {timeSlots.reduce((sum, slot) => sum + slot.capacity, 0)} places
+                    {timeSlots.reduce((sum, slot) => sum + slot.capacity, 0)}{' '}
+                    places
                   </div>
                   <p className="text-sm text-blue-700 mt-1">
-                    Cette valeur sera automatiquement synchronisée avec le stock de l'activité
+                    Cette valeur sera automatiquement synchronisée avec le stock
+                    de l'activité
                   </p>
                 </div>
 
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
                   {timeSlots.map((slot) => (
-                    <div key={slot.id} className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors">
+                    <div
+                      key={slot.id}
+                      className="border border-gray-200 rounded-lg p-4 hover:bg-gray-50 transition-colors"
+                    >
                       <div className="flex items-center justify-between mb-3">
                         <div className="font-medium text-gray-900">
                           {format(new Date(slot.slot_time), 'HH:mm')}
@@ -188,23 +215,27 @@ export default function TimeSlotsManager({ eventActivity, event, onClose }: Time
                           <Trash2 className="h-4 w-4" />
                         </button>
                       </div>
-                      
+
                       <div className="flex items-center gap-2 text-sm text-gray-600 mb-2">
                         <Users className="h-4 w-4" />
-                        <span>{slot.capacity - (slot.remaining_capacity || 0)}/{slot.capacity} participants</span>
+                        <span>
+                          {slot.capacity - (slot.remaining_capacity || 0)}/
+                          {slot.capacity} participants
+                        </span>
                       </div>
-                      
+
                       <div className="w-full bg-gray-200 rounded-full h-2">
-                        <div 
+                        <div
                           className={`h-2 rounded-full transition-all ${
-                            (slot.remaining_capacity || 0) === 0 
+                            (slot.remaining_capacity || 0) === 0
                               ? 'bg-red-500'
-                              : (slot.remaining_capacity || 0) <= slot.capacity * 0.25
-                              ? 'bg-orange-500'
-                              : 'bg-green-500'
+                              : (slot.remaining_capacity || 0) <=
+                                  slot.capacity * 0.25
+                                ? 'bg-orange-500'
+                                : 'bg-green-500'
                           }`}
-                          style={{ 
-                            width: `${((slot.capacity - (slot.remaining_capacity || 0)) / slot.capacity) * 100}%` 
+                          style={{
+                            width: `${((slot.capacity - (slot.remaining_capacity || 0)) / slot.capacity) * 100}%`,
                           }}
                         ></div>
                       </div>
@@ -234,45 +265,53 @@ interface CreateTimeSlotsFormProps {
   onClose: () => void;
 }
 
-function CreateTimeSlotsForm({ eventActivity, event, onClose }: CreateTimeSlotsFormProps) {
+function CreateTimeSlotsForm({
+  eventActivity,
+  event,
+  onClose,
+}: CreateTimeSlotsFormProps) {
   const [formData, setFormData] = useState({
     startTime: '09:00',
     endTime: '17:00',
     slotDuration: 30,
     capacity: 15,
-    breakDuration: 0
+    breakDuration: 0,
   });
   const [creating, setCreating] = useState(false);
 
   const calculateSlots = () => {
     const eventDate = startOfDay(new Date(event.event_date));
-    const startDateTime = new Date(`${format(eventDate, 'yyyy-MM-dd')}T${formData.startTime}`);
-    const endDateTime = new Date(`${format(eventDate, 'yyyy-MM-dd')}T${formData.endTime}`);
-    
+    const startDateTime = new Date(
+      `${format(eventDate, 'yyyy-MM-dd')}T${formData.startTime}`,
+    );
+    const endDateTime = new Date(
+      `${format(eventDate, 'yyyy-MM-dd')}T${formData.endTime}`,
+    );
+
     const slots = [];
     let currentTime = startDateTime;
-    
+
     while (currentTime < endDateTime) {
       const nextTime = addMinutes(currentTime, formData.slotDuration);
       if (nextTime <= endDateTime) {
         slots.push({
           start: new Date(currentTime),
-          end: nextTime
+          end: nextTime,
         });
         currentTime = addMinutes(nextTime, formData.breakDuration);
       } else {
         break;
       }
     }
-    
+
     return slots;
   };
 
   const previewSlots = calculateSlots();
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    
+
     if (previewSlots.length === 0) {
       toast.error('Aucun créneau à créer avec ces paramètres');
       return;
@@ -280,19 +319,17 @@ function CreateTimeSlotsForm({ eventActivity, event, onClose }: CreateTimeSlotsF
 
     try {
       setCreating(true);
-      
-      const slotsToCreate = previewSlots.map(slot => ({
+
+      const slotsToCreate = previewSlots.map((slot) => ({
         event_activity_id: eventActivity.id,
         slot_time: slot.start.toISOString(),
-        capacity: formData.capacity
+        capacity: formData.capacity,
       }));
 
-      const { error } = await supabase
-        .from('time_slots')
-        .insert(slotsToCreate);
+      const { error } = await supabase.from('time_slots').insert(slotsToCreate);
 
       if (error) throw error;
-      
+
       toast.success(`${slotsToCreate.length} créneaux créés avec succès`);
       onClose();
     } catch (err) {
@@ -313,71 +350,33 @@ function CreateTimeSlotsForm({ eventActivity, event, onClose }: CreateTimeSlotsF
         aria-labelledby="create-slots-title"
       >
         <div className="p-6 border-b border-gray-200 flex items-center justify-between">
-          <h3 id="create-slots-title" className="text-lg font-semibold text-gray-900">
-              Créer des Créneaux
+          <h3
+            id="create-slots-title"
+            className="text-lg font-semibold text-gray-900"
+          >
+            Créer des Créneaux
           </h3>
-          <button onClick={onClose} aria-label="Fermer le modal" className="text-gray-400 hover:text-gray-600">
+          <button
+            onClick={onClose}
+            aria-label="Fermer le modal"
+            className="text-gray-400 hover:text-gray-600"
+          >
             <X className="h-5 w-5" />
           </button>
         </div>
 
         <form onSubmit={handleSubmit} className="space-y-4 p-6 overflow-y-auto">
-            <div className="grid grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Heure de début
-                </label>
-                <input
-                  type="time"
-                  value={formData.startTime}
-                  onChange={(e) => setFormData({ ...formData, startTime: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  required
-                />
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Heure de fin
-                </label>
-                <input
-                  type="time"
-                  value={formData.endTime}
-                  onChange={(e) => setFormData({ ...formData, endTime: e.target.value })}
-                  className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  required
-                />
-              </div>
-            </div>
-
+          <div className="grid grid-cols-2 gap-4">
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Durée par créneau (minutes)
-              </label>
-              <select
-                value={formData.slotDuration}
-                onChange={(e) => setFormData({ ...formData, slotDuration: parseInt(e.target.value) })}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              >
-                <option value={15}>15 minutes</option>
-                <option value={30}>30 minutes</option>
-                <option value={45}>45 minutes</option>
-                <option value={60}>1 heure</option>
-                <option value={90}>1h30</option>
-                <option value={120}>2 heures</option>
-              </select>
-            </div>
-
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Capacité par créneau
+                Heure de début
               </label>
               <input
-                type="number"
-                min="1"
-                max="100"
-                value={formData.capacity}
-                onChange={(e) => setFormData({ ...formData, capacity: parseInt(e.target.value) })}
+                type="time"
+                value={formData.startTime}
+                onChange={(e) =>
+                  setFormData({ ...formData, startTime: e.target.value })
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
               />
@@ -385,49 +384,113 @@ function CreateTimeSlotsForm({ eventActivity, event, onClose }: CreateTimeSlotsF
 
             <div>
               <label className="block text-sm font-medium text-gray-700 mb-1">
-                Pause entre créneaux (minutes)
+                Heure de fin
               </label>
-              <select
-                value={formData.breakDuration}
-                onChange={(e) => setFormData({ ...formData, breakDuration: parseInt(e.target.value) })}
+              <input
+                type="time"
+                value={formData.endTime}
+                onChange={(e) =>
+                  setFormData({ ...formData, endTime: e.target.value })
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              >
-                <option value={0}>Aucune pause</option>
-                <option value={5}>5 minutes</option>
-                <option value={10}>10 minutes</option>
-                <option value={15}>15 minutes</option>
-                <option value={30}>30 minutes</option>
-              </select>
+                required
+              />
             </div>
+          </div>
 
-            {/* Prévisualisation */}
-            <div className="bg-gray-50 rounded-lg p-4">
-              <h4 className="font-medium text-gray-900 mb-2">Prévisualisation</h4>
-              <div className="text-sm text-gray-600 mb-2">
-                <strong>{previewSlots.length}</strong> créneaux seront créés
-              </div>
-              <div className="text-sm text-blue-600">
-                Capacité totale: <strong>{previewSlots.length * formData.capacity}</strong> places
-              </div>
-            </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Durée par créneau (minutes)
+            </label>
+            <select
+              value={formData.slotDuration}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  slotDuration: parseInt(e.target.value),
+                })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value={15}>15 minutes</option>
+              <option value={30}>30 minutes</option>
+              <option value={45}>45 minutes</option>
+              <option value={60}>1 heure</option>
+              <option value={90}>1h30</option>
+              <option value={120}>2 heures</option>
+            </select>
+          </div>
 
-            <div className="flex gap-3 pt-4">
-              <button
-                type="button"
-                onClick={onClose}
-                className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-900 px-4 py-2 rounded-md font-medium transition-colors"
-              >
-                Annuler
-              </button>
-              <button
-                type="submit"
-                disabled={creating || previewSlots.length === 0}
-                className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-md font-medium transition-colors"
-              >
-                {creating ? 'Création...' : `Créer ${previewSlots.length} créneaux`}
-              </button>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Capacité par créneau
+            </label>
+            <input
+              type="number"
+              min="1"
+              max="100"
+              value={formData.capacity}
+              onChange={(e) =>
+                setFormData({ ...formData, capacity: parseInt(e.target.value) })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+              required
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Pause entre créneaux (minutes)
+            </label>
+            <select
+              value={formData.breakDuration}
+              onChange={(e) =>
+                setFormData({
+                  ...formData,
+                  breakDuration: parseInt(e.target.value),
+                })
+              }
+              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+            >
+              <option value={0}>Aucune pause</option>
+              <option value={5}>5 minutes</option>
+              <option value={10}>10 minutes</option>
+              <option value={15}>15 minutes</option>
+              <option value={30}>30 minutes</option>
+            </select>
+          </div>
+
+          {/* Prévisualisation */}
+          <div className="bg-gray-50 rounded-lg p-4">
+            <h4 className="font-medium text-gray-900 mb-2">Prévisualisation</h4>
+            <div className="text-sm text-gray-600 mb-2">
+              <strong>{previewSlots.length}</strong> créneaux seront créés
             </div>
-          </form>
+            <div className="text-sm text-blue-600">
+              Capacité totale:{' '}
+              <strong>{previewSlots.length * formData.capacity}</strong> places
+            </div>
+          </div>
+
+          <div className="flex gap-3 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-gray-200 hover:bg-gray-300 text-gray-900 px-4 py-2 rounded-md font-medium transition-colors"
+            >
+              Annuler
+            </button>
+            <button
+              type="submit"
+              disabled={creating || previewSlots.length === 0}
+              className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-md font-medium transition-colors"
+            >
+              {creating
+                ? 'Création...'
+                : `Créer ${previewSlots.length} créneaux`}
+            </button>
+          </div>
+        </form>
       </div>
     </div>
   );

--- a/src/components/admin/__tests__/MarkdownEditor.test.tsx
+++ b/src/components/admin/__tests__/MarkdownEditor.test.tsx
@@ -1,12 +1,12 @@
 import { describe, it, expect } from 'vitest';
 import userEvent from '@testing-library/user-event';
-import React from 'react';
 import { render, screen, waitFor } from '../../../test/utils';
+import { useState } from 'react';
 import { act } from '@testing-library/react';
 import MarkdownEditor from '../MarkdownEditor';
 
 function Wrapper() {
-  const [value, setValue] = React.useState('');
+  const [value, setValue] = useState('');
   return (
     <MarkdownEditor
       label="Description"

--- a/src/components/validation/ReservationValidationForm.tsx
+++ b/src/components/validation/ReservationValidationForm.tsx
@@ -1,6 +1,9 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { CheckCircle, QrCode, XCircle } from 'lucide-react';
-import { validateReservation, type ValidationActivity } from '../../lib/validation';
+import {
+  validateReservation,
+  type ValidationActivity,
+} from '../../lib/validation';
 import { toast } from 'react-hot-toast';
 
 interface Props {
@@ -9,13 +12,17 @@ interface Props {
   help?: string;
 }
 
-export default function ReservationValidationForm({ activity, title, help }: Props) {
+export default function ReservationValidationForm({
+  activity,
+  title,
+  help,
+}: Props) {
   const [code, setCode] = useState('');
   const [status, setStatus] = useState<'idle' | 'success' | 'error'>('idle');
   const [message, setMessage] = useState<string>('');
   const [loading, setLoading] = useState(false);
 
-  const onSubmit = async (e: React.FormEvent) => {
+  const onSubmit = async (e: FormEvent) => {
     e.preventDefault();
     setLoading(true);
     setStatus('idle');
@@ -57,7 +64,10 @@ export default function ReservationValidationForm({ activity, title, help }: Pro
             value={code}
             onChange={(e) => setCode(e.target.value)}
           />
-          <p className="text-xs text-gray-500 mt-1">Un lecteur code-barres/QR agit comme un clavier: cliquez dans le champ et scannez.</p>
+          <p className="text-xs text-gray-500 mt-1">
+            Un lecteur code-barres/QR agit comme un clavier: cliquez dans le
+            champ et scannez.
+          </p>
         </div>
         <button
           type="submit"
@@ -68,12 +78,17 @@ export default function ReservationValidationForm({ activity, title, help }: Pro
         </button>
       </form>
       {status !== 'idle' && (
-        <div className={`mt-4 flex items-center gap-2 ${status === 'success' ? 'text-green-700' : 'text-red-700'}`}>
-          {status === 'success' ? <CheckCircle className="h-5 w-5" /> : <XCircle className="h-5 w-5" />}
+        <div
+          className={`mt-4 flex items-center gap-2 ${status === 'success' ? 'text-green-700' : 'text-red-700'}`}
+        >
+          {status === 'success' ? (
+            <CheckCircle className="h-5 w-5" />
+          ) : (
+            <XCircle className="h-5 w-5" />
+          )}
           <span className="text-sm">{message}</span>
         </div>
       )}
     </div>
   );
 }
-

--- a/src/pages/EventCGV.tsx
+++ b/src/pages/EventCGV.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { supabase } from '../lib/supabase';
 import { ArrowLeft, FileText } from 'lucide-react';
@@ -59,8 +59,12 @@ export default function EventCGV() {
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <FileText className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">CGV introuvables</h2>
-          <p className="text-gray-600">Les conditions générales de cet événement ne sont pas disponibles.</p>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            CGV introuvables
+          </h2>
+          <p className="text-gray-600">
+            Les conditions générales de cet événement ne sont pas disponibles.
+          </p>
         </div>
       </div>
     );
@@ -70,7 +74,7 @@ export default function EventCGV() {
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       {/* Navigation */}
       <div className="mb-8">
-        <Link 
+        <Link
           to={`/event/${eventId}`}
           className="inline-flex items-center gap-2 text-blue-600 hover:text-blue-700 font-medium"
         >
@@ -83,7 +87,9 @@ export default function EventCGV() {
       <div className="bg-white rounded-lg shadow-sm p-8 mb-8">
         <div className="flex items-center gap-3 mb-4">
           <FileText className="h-8 w-8 text-blue-600" />
-          <h1 className="text-3xl font-bold text-gray-900">Conditions Générales de Vente</h1>
+          <h1 className="text-3xl font-bold text-gray-900">
+            Conditions Générales de Vente
+          </h1>
         </div>
         <p className="text-xl text-gray-600">{event.name}</p>
       </div>
@@ -102,7 +108,8 @@ export default function EventCGV() {
           Questions sur les conditions ?
         </h2>
         <p className="text-gray-600 mb-4">
-          Pour toute question concernant ces conditions générales de vente, contactez-nous.
+          Pour toute question concernant ces conditions générales de vente,
+          contactez-nous.
         </p>
         <a
           href="mailto:legal@billetevent.com"

--- a/src/pages/EventDetails.tsx
+++ b/src/pages/EventDetails.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { addToCart } from '../lib/cart';
 import { Calendar, Info, Plus, Minus } from 'lucide-react';
@@ -10,13 +10,16 @@ import { toast } from 'react-hot-toast';
 
 export default function EventDetails() {
   const { eventId } = useParams<{ eventId: string }>();
-  const { event, passes, loading, refresh, loadTimeSlotsForActivity } = useEventDetails(eventId);
+  const { event, passes, loading, refresh, loadTimeSlotsForActivity } =
+    useEventDetails(eventId);
   const [showPurchaseModal, setShowPurchaseModal] = useState(false);
   const [selectedPass, setSelectedPass] = useState<Pass | null>(null);
   const [selectedQuantity, setSelectedQuantity] = useState(1);
 
   // Type de pass (utilise pass_type si fourni, sinon heuristique sur le nom)
-  const classifyPassType = (p: Pass): 'moins_8' | 'plus_8' | 'luge_seule' | 'baby_poney' | 'other' => {
+  const classifyPassType = (
+    p: Pass,
+  ): 'moins_8' | 'plus_8' | 'luge_seule' | 'baby_poney' | 'other' => {
     if (p.pass_type) return p.pass_type;
     const n = (p.name || '').toLowerCase();
     if (/baby/.test(n) && /poney/.test(n)) return 'baby_poney';
@@ -42,10 +45,17 @@ export default function EventDetails() {
   };
 
   const handlePurchase = async (
-    selectedSlots: { [key: number]: { [activityId: string]: string | undefined } },
+    selectedSlots: {
+      [key: number]: { [activityId: string]: string | undefined };
+    },
     attendees: {
-      [key: number]: { firstName?: string; lastName?: string; birthYear?: string; ack?: boolean };
-    }
+      [key: number]: {
+        firstName?: string;
+        lastName?: string;
+        birthYear?: string;
+        ack?: boolean;
+      };
+    },
   ) => {
     if (!selectedPass) return;
     for (let i = 0; i < selectedQuantity; i++) {
@@ -66,7 +76,7 @@ export default function EventDetails() {
         1,
         undefined,
         undefined,
-        attendee
+        attendee,
       );
       if (!success) {
         toast.error(`Erreur lors de l'ajout du pass ${i + 1}`);
@@ -95,8 +105,12 @@ export default function EventDetails() {
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <Calendar className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">Événement introuvable</h2>
-          <p className="text-gray-600">Cet événement n'existe pas ou n'est plus disponible.</p>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            Événement introuvable
+          </h2>
+          <p className="text-gray-600">
+            Cet événement n'existe pas ou n'est plus disponible.
+          </p>
         </div>
       </div>
     );
@@ -109,7 +123,9 @@ export default function EventDetails() {
         <div className="flex items-center gap-3 mb-4">
           <Calendar className="h-6 w-6 text-blue-600" />
           <span className="text-lg font-medium text-blue-600">
-            {format(new Date(event.event_date), 'EEEE d MMMM yyyy', { locale: fr })}
+            {format(new Date(event.event_date), 'EEEE d MMMM yyyy', {
+              locale: fr,
+            })}
           </span>
         </div>
 
@@ -119,8 +135,13 @@ export default function EventDetails() {
           <div className="flex items-start gap-3">
             <Info className="h-6 w-6 text-blue-600 mt-0.5" />
             <div>
-              <h2 className="font-semibold text-blue-900 mb-2">Informations Clés</h2>
-              <MarkdownRenderer className="text-blue-800" content={event.key_info_content} />
+              <h2 className="font-semibold text-blue-900 mb-2">
+                Informations Clés
+              </h2>
+              <MarkdownRenderer
+                className="text-blue-800"
+                content={event.key_info_content}
+              />
             </div>
           </div>
         </div>
@@ -132,33 +153,43 @@ export default function EventDetails() {
 
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           {passes.map((pass) => (
-            <div key={pass.id} className="border border-gray-200 rounded-lg p-6 hover:border-blue-300 transition-colors">
+            <div
+              key={pass.id}
+              className="border border-gray-200 rounded-lg p-6 hover:border-blue-300 transition-colors"
+            >
               <div className="flex justify-between items-start mb-4">
-                <h3 className="text-xl font-semibold text-gray-900">{pass.name}</h3>
+                <h3 className="text-xl font-semibold text-gray-900">
+                  {pass.name}
+                </h3>
                 <div className="text-right">
-                  <div className="text-2xl font-bold text-blue-600">{pass.price}€</div>
+                  <div className="text-2xl font-bold text-blue-600">
+                    {pass.price}€
+                  </div>
                   <div className="text-sm text-gray-500">
                     {pass.initial_stock === null
                       ? 'Stock illimité'
                       : pass.remaining_stock === 0
-                      ? 'Épuisé'
-                      : `${pass.remaining_stock} restant(s)`}
+                        ? 'Épuisé'
+                        : `${pass.remaining_stock} restant(s)`}
                   </div>
                 </div>
               </div>
 
               <p className="text-gray-600 mb-6">{pass.description}</p>
-              {typeof pass.guaranteed_runs === 'number' && pass.guaranteed_runs > 0 && (
-                <div className="mb-4 text-xs font-medium text-green-700 bg-green-50 border border-green-200 inline-block px-2 py-1 rounded">
-                  Garantie {pass.guaranteed_runs} tour{pass.guaranteed_runs > 1 ? 's' : ''}
-                </div>
-              )}
+              {typeof pass.guaranteed_runs === 'number' &&
+                pass.guaranteed_runs > 0 && (
+                  <div className="mb-4 text-xs font-medium text-green-700 bg-green-50 border border-green-200 inline-block px-2 py-1 rounded">
+                    Garantie {pass.guaranteed_runs} tour
+                    {pass.guaranteed_runs > 1 ? 's' : ''}
+                  </div>
+                )}
 
               <button
                 onClick={() => handleAddToCart(pass)}
                 disabled={
                   pass.remaining_stock === 0 ||
-                  (classifyPassType(pass) === 'luge_seule' && !isLugeOnlyAvailable)
+                  (classifyPassType(pass) === 'luge_seule' &&
+                    !isLugeOnlyAvailable)
                 }
                 className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white px-4 py-2 rounded-md font-medium transition-colors"
               >
@@ -193,10 +224,21 @@ interface PurchaseModalProps {
   quantity: number;
   onQuantityChange: (quantity: number) => void;
   onPurchase: (
-    selectedSlots: { [key: number]: { [activityId: string]: string | undefined } },
-    attendees: { [key: number]: { firstName?: string; lastName?: string; birthYear?: string; ack?: boolean } }
+    selectedSlots: {
+      [key: number]: { [activityId: string]: string | undefined };
+    },
+    attendees: {
+      [key: number]: {
+        firstName?: string;
+        lastName?: string;
+        birthYear?: string;
+        ack?: boolean;
+      };
+    },
   ) => void;
-  loadTimeSlots: (eventActivityId: string) => Promise<import('../lib/types').TimeSlot[]>;
+  loadTimeSlots: (
+    eventActivityId: string,
+  ) => Promise<import('../lib/types').TimeSlot[]>;
   conditionsMarkdown?: string;
   onClose: () => void;
 }
@@ -210,9 +252,23 @@ function PurchaseModal({
   conditionsMarkdown,
   onClose,
 }: PurchaseModalProps) {
-  const [slotsByActivity, setSlotsByActivity] = useState<Record<string, import('../lib/types').TimeSlot[]>>({});
-  const [selectedSlots, setSelectedSlots] = useState<Record<number, Record<string, string | undefined>>>({});
-  const [attendees, setAttendees] = useState<Record<number, { firstName?: string; lastName?: string; birthYear?: string; ack?: boolean }>>({});
+  const [slotsByActivity, setSlotsByActivity] = useState<
+    Record<string, import('../lib/types').TimeSlot[]>
+  >({});
+  const [selectedSlots, setSelectedSlots] = useState<
+    Record<number, Record<string, string | undefined>>
+  >({});
+  const [attendees, setAttendees] = useState<
+    Record<
+      number,
+      {
+        firstName?: string;
+        lastName?: string;
+        birthYear?: string;
+        ack?: boolean;
+      }
+    >
+  >({});
 
   const ensureSlotsLoaded = async (eventActivityId: string) => {
     if (!slotsByActivity[eventActivityId]) {
@@ -228,7 +284,7 @@ function PurchaseModal({
           return !!selectedSlots[i]?.[ea.id];
         }
         return true;
-      })
+      }),
     );
   }, [quantity, pass.event_activities, selectedSlots]);
 
@@ -242,7 +298,10 @@ function PurchaseModal({
             <h3 className="text-lg font-semibold text-gray-900">
               Configurer votre achat : {pass.name}
             </h3>
-            <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600"
+            >
               ✕
             </button>
           </div>
@@ -251,7 +310,9 @@ function PurchaseModal({
         <div className="p-6 overflow-y-auto max-h-[60vh]">
           {/* Sélection de quantité */}
           <div className="mb-6">
-            <label className="block text-sm font-medium text-gray-700 mb-2">Quantité</label>
+            <label className="block text-sm font-medium text-gray-700 mb-2">
+              Quantité
+            </label>
             <div className="flex items-center gap-3">
               <button
                 onClick={() => onQuantityChange(Math.max(1, quantity - 1))}
@@ -272,14 +333,23 @@ function PurchaseModal({
           {/* Créneaux pour chaque pass et activité */}
           <div className="space-y-4">
             {Array.from({ length: quantity }, (_, index) => (
-              <div key={index} className="border border-gray-200 rounded-lg p-4">
-                <h4 className="font-medium text-gray-900 mb-3">Pass #{index + 1}</h4>
+              <div
+                key={index}
+                className="border border-gray-200 rounded-lg p-4"
+              >
+                <h4 className="font-medium text-gray-900 mb-3">
+                  Pass #{index + 1}
+                </h4>
 
                 {pass.event_activities.map((eventActivity) => (
                   <div key={eventActivity.id} className="mb-3">
                     <div className="flex items-center gap-3 mb-2">
-                      <span className="text-xl">{eventActivity.activity.icon}</span>
-                      <div className="font-medium">{eventActivity.activity.name}</div>
+                      <span className="text-xl">
+                        {eventActivity.activity.icon}
+                      </span>
+                      <div className="font-medium">
+                        {eventActivity.activity.name}
+                      </div>
                     </div>
                     {eventActivity.requires_time_slot && (
                       <select
@@ -288,7 +358,10 @@ function PurchaseModal({
                         onChange={(e) =>
                           setSelectedSlots((prev) => ({
                             ...prev,
-                            [index]: { ...(prev[index] || {}), [eventActivity.id]: e.target.value },
+                            [index]: {
+                              ...(prev[index] || {}),
+                              [eventActivity.id]: e.target.value,
+                            },
                           }))
                         }
                         onFocus={() => ensureSlotsLoaded(eventActivity.id)}
@@ -296,25 +369,36 @@ function PurchaseModal({
                         <option value="" disabled>
                           Choisir un créneau
                         </option>
-                        {(slotsByActivity[eventActivity.id] || []).map((slot) => (
-                          <option key={slot.id} value={slot.id}>
-                            {format(new Date(slot.slot_time), 'HH:mm — d MMM yyyy', { locale: fr })}
-                          </option>
-                        ))}
+                        {(slotsByActivity[eventActivity.id] || []).map(
+                          (slot) => (
+                            <option key={slot.id} value={slot.id}>
+                              {format(
+                                new Date(slot.slot_time),
+                                'HH:mm — d MMM yyyy',
+                                { locale: fr },
+                              )}
+                            </option>
+                          ),
+                        )}
                       </select>
                     )}
                   </div>
                 ))}
 
                 {/* Informations participant */}
-                <div className={`mt-4 grid grid-cols-1 gap-3 ${isBabyPoney ? 'md:grid-cols-2' : 'md:grid-cols-3'}`}>
+                <div
+                  className={`mt-4 grid grid-cols-1 gap-3 ${isBabyPoney ? 'md:grid-cols-2' : 'md:grid-cols-3'}`}
+                >
                   <input
                     type="text"
                     placeholder="Prénom"
                     className="px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={attendees[index]?.firstName || ''}
                     onChange={(e) =>
-                      setAttendees((prev) => ({ ...prev, [index]: { ...prev[index], firstName: e.target.value } }))
+                      setAttendees((prev) => ({
+                        ...prev,
+                        [index]: { ...prev[index], firstName: e.target.value },
+                      }))
                     }
                   />
                   {!isBabyPoney && (
@@ -324,7 +408,10 @@ function PurchaseModal({
                       className="px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                       value={attendees[index]?.lastName || ''}
                       onChange={(e) =>
-                        setAttendees((prev) => ({ ...prev, [index]: { ...prev[index], lastName: e.target.value } }))
+                        setAttendees((prev) => ({
+                          ...prev,
+                          [index]: { ...prev[index], lastName: e.target.value },
+                        }))
                       }
                     />
                   )}
@@ -334,7 +421,10 @@ function PurchaseModal({
                     className="px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                     value={attendees[index]?.birthYear || ''}
                     onChange={(e) =>
-                      setAttendees((prev) => ({ ...prev, [index]: { ...prev[index], birthYear: e.target.value } }))
+                      setAttendees((prev) => ({
+                        ...prev,
+                        [index]: { ...prev[index], birthYear: e.target.value },
+                      }))
                     }
                   />
                 </div>
@@ -347,16 +437,23 @@ function PurchaseModal({
             <div className="mt-6 bg-blue-50 border border-blue-100 rounded-md p-4">
               <div className="flex items-start gap-2 mb-2">
                 <Info className="h-5 w-5 text-blue-600 mt-0.5" />
-                <span className="font-medium text-blue-900">Conditions d'accès</span>
+                <span className="font-medium text-blue-900">
+                  Conditions d'accès
+                </span>
               </div>
-              <MarkdownRenderer className="text-sm text-blue-900" content={conditionsMarkdown} />
+              <MarkdownRenderer
+                className="text-sm text-blue-900"
+                content={conditionsMarkdown}
+              />
             </div>
           )}
         </div>
 
         <div className="p-6 border-t border-gray-200">
           <div className="flex items-center justify-between mb-4">
-            <div className="text-lg font-semibold">Total: {(pass.price * quantity).toFixed(2)}€</div>
+            <div className="text-lg font-semibold">
+              Total: {(pass.price * quantity).toFixed(2)}€
+            </div>
           </div>
 
           <div className="flex gap-3">

--- a/src/pages/EventFAQ.tsx
+++ b/src/pages/EventFAQ.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import { useEffect } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { ArrowLeft, HelpCircle } from 'lucide-react';
 import FAQAccordion from '../components/FAQAccordion';
@@ -31,8 +31,12 @@ export default function EventFAQ() {
       <div className="min-h-screen bg-gray-50 flex items-center justify-center">
         <div className="text-center">
           <HelpCircle className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-          <h2 className="text-xl font-semibold text-gray-900 mb-2">FAQ introuvable</h2>
-          <p className="text-gray-600">La FAQ de cet événement n'est pas disponible.</p>
+          <h2 className="text-xl font-semibold text-gray-900 mb-2">
+            FAQ introuvable
+          </h2>
+          <p className="text-gray-600">
+            La FAQ de cet événement n'est pas disponible.
+          </p>
         </div>
       </div>
     );

--- a/src/pages/FindTicket.tsx
+++ b/src/pages/FindTicket.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState, type FormEvent } from 'react';
 import { Search, Mail, Shield, CheckCircle } from 'lucide-react';
 import { requestReservationEmail } from '../lib/requestReservationEmail';
 import { toast } from 'react-hot-toast';
@@ -10,9 +10,9 @@ export default function FindTicket() {
   const [found, setFound] = useState(false);
   const [captchaVerified, setCaptchaVerified] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    
+
     if (!email) {
       toast.error('Veuillez saisir votre adresse e-mail');
       return;
@@ -25,7 +25,7 @@ export default function FindTicket() {
 
     try {
       setLoading(true);
-      
+
       // Demander au serveur d'envoyer l'e-mail (sans exposer la table)
       const res = await requestReservationEmail({ email });
 
@@ -40,7 +40,7 @@ export default function FindTicket() {
       toast.error(
         err instanceof Error
           ? err.message
-          : 'Une erreur est survenue lors de la recherche'
+          : 'Une erreur est survenue lors de la recherche',
       );
     } finally {
       setLoading(false);
@@ -66,7 +66,8 @@ export default function FindTicket() {
           Retrouver mon Billet
         </h1>
         <p className="text-gray-600">
-          Saisissez votre adresse e-mail pour recevoir à nouveau votre confirmation de réservation.
+          Saisissez votre adresse e-mail pour recevoir à nouveau votre
+          confirmation de réservation.
         </p>
       </div>
 
@@ -75,7 +76,10 @@ export default function FindTicket() {
         <div className="bg-white rounded-lg shadow-sm p-8">
           <form onSubmit={handleSubmit} noValidate>
             <div className="mb-6">
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700 mb-2">
+              <label
+                htmlFor="email"
+                className="block text-sm font-medium text-gray-700 mb-2"
+              >
                 Adresse e-mail
               </label>
               <div className="relative">
@@ -102,18 +106,30 @@ export default function FindTicket() {
                     onClick={handleCaptchaClick}
                     className="flex items-center gap-2 hover:bg-gray-100 p-1 rounded transition-colors"
                   >
-                    <div className={`w-6 h-6 border-2 rounded-sm flex items-center justify-center transition-colors ${
-                      captchaVerified 
-                        ? 'border-green-500 bg-green-500' 
-                        : 'border-gray-300 hover:border-gray-400'
-                    }`}>
+                    <div
+                      className={`w-6 h-6 border-2 rounded-sm flex items-center justify-center transition-colors ${
+                        captchaVerified
+                          ? 'border-green-500 bg-green-500'
+                          : 'border-gray-300 hover:border-gray-400'
+                      }`}
+                    >
                       {captchaVerified && (
-                        <svg className="w-4 h-4 text-white" fill="currentColor" viewBox="0 0 20 20">
-                          <path fillRule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clipRule="evenodd" />
+                        <svg
+                          className="w-4 h-4 text-white"
+                          fill="currentColor"
+                          viewBox="0 0 20 20"
+                        >
+                          <path
+                            fillRule="evenodd"
+                            d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z"
+                            clipRule="evenodd"
+                          />
                         </svg>
                       )}
                     </div>
-                    <span className="text-sm text-gray-700">Je ne suis pas un robot</span>
+                    <span className="text-sm text-gray-700">
+                      Je ne suis pas un robot
+                    </span>
                   </button>
                 </div>
                 <div className="text-xs text-gray-500">reCAPTCHA</div>
@@ -148,8 +164,9 @@ export default function FindTicket() {
                   Sécurité et Confidentialité
                 </h3>
                 <p className="text-sm text-blue-800">
-                  Votre adresse e-mail est utilisée uniquement pour retrouver vos réservations. 
-                  Aucune donnée personnelle n'est stockée ou partagée.
+                  Votre adresse e-mail est utilisée uniquement pour retrouver
+                  vos réservations. Aucune donnée personnelle n'est stockée ou
+                  partagée.
                 </p>
               </div>
             </div>
@@ -161,23 +178,24 @@ export default function FindTicket() {
           <div className="bg-green-100 rounded-full p-4 w-16 h-16 mx-auto mb-4 flex items-center justify-center">
             <CheckCircle className="h-8 w-8 text-green-600" />
           </div>
-          
+
           <h2 className="text-xl font-semibold text-gray-900 mb-2">
             E-mail envoyé avec succès !
           </h2>
-          
+
           <p className="text-gray-600 mb-6">
             Votre confirmation de réservation a été renvoyée à l'adresse :<br />
             <strong>{email}</strong>
           </p>
-          
+
           <div className="bg-gray-50 rounded-lg p-4 mb-6">
             <p className="text-sm text-gray-700">
-              <strong>Vérifiez votre boîte de réception</strong> ainsi que votre dossier spam/courriers indésirables. 
-              L'e-mail peut mettre quelques minutes à arriver.
+              <strong>Vérifiez votre boîte de réception</strong> ainsi que votre
+              dossier spam/courriers indésirables. L'e-mail peut mettre quelques
+              minutes à arriver.
             </p>
           </div>
-          
+
           <button
             onClick={() => {
               setFound(false);
@@ -197,7 +215,10 @@ export default function FindTicket() {
         </h3>
         <p className="text-sm text-gray-600">
           Contactez notre support à{' '}
-          <a href="mailto:support@billetevent.com" className="text-blue-600 hover:text-blue-700">
+          <a
+            href="mailto:support@billetevent.com"
+            className="text-blue-600 hover:text-blue-700"
+          >
             support@billetevent.com
           </a>
         </p>

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { getCurrentUser } from '../lib/auth';
 import type { User } from '../lib/auth';
 import { supabase } from '../lib/supabase';
@@ -46,7 +46,9 @@ export default function Profile() {
       <div className="max-w-2xl mx-auto px-4 py-12 text-center">
         <Shield className="w-10 h-10 text-gray-400 mx-auto mb-3" />
         <h1 className="text-2xl font-bold">Profil</h1>
-        <p className="text-gray-600 mt-2">Veuillez vous connecter pour consulter vos commandes.</p>
+        <p className="text-gray-600 mt-2">
+          Veuillez vous connecter pour consulter vos commandes.
+        </p>
       </div>
     );
   }
@@ -69,7 +71,9 @@ export default function Profile() {
         {loading ? (
           <div className="p-6">Chargement...</div>
         ) : reservations.length === 0 ? (
-          <div className="p-6 text-sm text-gray-600">Aucune réservation trouvée.</div>
+          <div className="p-6 text-sm text-gray-600">
+            Aucune réservation trouvée.
+          </div>
         ) : (
           <ul className="divide-y divide-gray-200">
             {reservations.map((r) => (
@@ -77,11 +81,17 @@ export default function Profile() {
                 <div className="flex items-center justify-between">
                   <div>
                     <div className="font-medium">{r.reservation_number}</div>
-                    <div className="text-sm text-gray-500">{new Date(r.created_at).toLocaleString()}</div>
+                    <div className="text-sm text-gray-500">
+                      {new Date(r.created_at).toLocaleString()}
+                    </div>
                   </div>
-                  <span className={`text-xs px-2 py-1 rounded-full ${
-                    r.payment_status === 'paid' ? 'bg-green-100 text-green-700' : 'bg-yellow-100 text-yellow-700'
-                  }`}>
+                  <span
+                    className={`text-xs px-2 py-1 rounded-full ${
+                      r.payment_status === 'paid'
+                        ? 'bg-green-100 text-green-700'
+                        : 'bg-yellow-100 text-yellow-700'
+                    }`}
+                  >
                     {r.payment_status}
                   </span>
                 </div>
@@ -93,4 +103,3 @@ export default function Profile() {
     </div>
   );
 }
-

--- a/src/pages/admin/ActivityManagement.tsx
+++ b/src/pages/admin/ActivityManagement.tsx
@@ -1,11 +1,22 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
 import { supabase } from '../../lib/supabase';
-import { Activity, Plus, Edit, Trash2, X, Image as ImageIcon } from 'lucide-react';
+import {
+  Activity,
+  Plus,
+  Edit,
+  Trash2,
+  X,
+  Image as ImageIcon,
+} from 'lucide-react';
 import { toast } from 'react-hot-toast';
 import MarkdownRenderer from '../../components/MarkdownRenderer';
 import MarkdownEditor from '../../components/admin/MarkdownEditor';
 import { logger } from '../../lib/logger';
-import { processAndUploadPublicImage, deletePublicImage, validateImageFile } from '../../lib/upload';
+import {
+  processAndUploadPublicImage,
+  deletePublicImage,
+  validateImageFile,
+} from '../../lib/upload';
 
 interface ActivityType {
   id: string;
@@ -25,7 +36,9 @@ export default function ActivityManagement() {
   const [activities, setActivities] = useState<ActivityType[]>([]);
   const [loading, setLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
-  const [editingActivity, setEditingActivity] = useState<ActivityType | null>(null);
+  const [editingActivity, setEditingActivity] = useState<ActivityType | null>(
+    null,
+  );
 
   const loadActivities = useCallback(async () => {
     try {
@@ -50,7 +63,12 @@ export default function ActivityManagement() {
   }, [loadActivities]);
 
   const handleDeleteActivity = async (activityId: string) => {
-    if (!confirm("Êtes-vous sûr de vouloir supprimer cette activité ? Cette action est irréversible et affectera tous les événements qui l'utilisent.")) return;
+    if (
+      !confirm(
+        "Êtes-vous sûr de vouloir supprimer cette activité ? Cette action est irréversible et affectera tous les événements qui l'utilisent.",
+      )
+    )
+      return;
 
     try {
       const { error } = await supabase
@@ -59,7 +77,7 @@ export default function ActivityManagement() {
         .eq('id', activityId);
 
       if (error) throw error;
-      
+
       toast.success('Activité supprimée avec succès');
       loadActivities();
     } catch (err) {
@@ -80,10 +98,14 @@ export default function ActivityManagement() {
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Gestion des Activités</h1>
-          <p className="text-gray-600">Créez et gérez les types d'activités disponibles</p>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Gestion des Activités
+          </h1>
+          <p className="text-gray-600">
+            Créez et gérez les types d'activités disponibles
+          </p>
         </div>
-        <button 
+        <button
           onClick={() => setShowCreateModal(true)}
           className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-colors flex items-center gap-2"
         >
@@ -95,18 +117,26 @@ export default function ActivityManagement() {
       {/* Statistiques */}
       <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
         <div className="bg-white rounded-lg shadow-sm p-4">
-          <div className="text-2xl font-bold text-gray-900">{activities.length}</div>
+          <div className="text-2xl font-bold text-gray-900">
+            {activities.length}
+          </div>
           <div className="text-sm text-gray-600">Total Activités</div>
         </div>
         <div className="bg-white rounded-lg shadow-sm p-4">
           <div className="text-2xl font-bold text-blue-600">
-            {activities.filter(a => a.name.toLowerCase().includes('poney')).length}
+            {
+              activities.filter((a) => a.name.toLowerCase().includes('poney'))
+                .length
+            }
           </div>
           <div className="text-sm text-gray-600">Activités Poney</div>
         </div>
         <div className="bg-white rounded-lg shadow-sm p-4">
           <div className="text-2xl font-bold text-green-600">
-            {activities.filter(a => a.name.toLowerCase().includes('tir')).length}
+            {
+              activities.filter((a) => a.name.toLowerCase().includes('tir'))
+                .length
+            }
           </div>
           <div className="text-sm text-gray-600">Activités Tir</div>
         </div>
@@ -115,32 +145,49 @@ export default function ActivityManagement() {
       {/* Liste des activités */}
       <div className="bg-white rounded-lg shadow-sm overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Activités ({activities.length})</h2>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Activités ({activities.length})
+          </h2>
         </div>
 
         {activities.length === 0 ? (
           <div className="p-12 text-center">
             <Activity className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 mb-2">Aucune activité</h3>
-            <p className="text-gray-600">Créez votre première activité pour commencer.</p>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              Aucune activité
+            </h3>
+            <p className="text-gray-600">
+              Créez votre première activité pour commencer.
+            </p>
           </div>
         ) : (
           <div className="divide-y divide-gray-200">
             {activities.map((activity) => (
-              <div key={activity.id} className="p-6 hover:bg-gray-50 transition-colors">
+              <div
+                key={activity.id}
+                className="p-6 hover:bg-gray-50 transition-colors"
+              >
                 <div className="flex items-center justify-between">
                   <div className="flex items-center gap-4">
                     <div className="text-3xl">{activity.icon}</div>
                     <div>
-                      <h3 className="text-lg font-semibold text-gray-900">{activity.name}</h3>
-                      <MarkdownRenderer content={activity.description} className="text-gray-600" />
+                      <h3 className="text-lg font-semibold text-gray-900">
+                        {activity.name}
+                      </h3>
+                      <MarkdownRenderer
+                        content={activity.description}
+                        className="text-gray-600"
+                      />
                       <div className="text-xs text-gray-500 mt-1">
-                        Parc: {activity.is_parc_product ? 'Activé' : 'Désactivé'}
-                        {activity.parc_category ? ` • Catégorie: ${activity.parc_category}` : ''}
+                        Parc:{' '}
+                        {activity.is_parc_product ? 'Activé' : 'Désactivé'}
+                        {activity.parc_category
+                          ? ` • Catégorie: ${activity.parc_category}`
+                          : ''}
                       </div>
                     </div>
                   </div>
-                  
+
                   <div className="flex items-center gap-2">
                     <button
                       onClick={() => setEditingActivity(activity)}
@@ -148,7 +195,7 @@ export default function ActivityManagement() {
                     >
                       <Edit className="h-4 w-4" />
                     </button>
-                    
+
                     <button
                       onClick={() => handleDeleteActivity(activity.id)}
                       className="p-2 text-red-600 hover:text-red-700 hover:bg-red-50 rounded-md transition-colors"
@@ -188,7 +235,11 @@ interface ActivityFormModalProps {
   onSave: () => void;
 }
 
-function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps) {
+function ActivityFormModal({
+  activity,
+  onClose,
+  onSave,
+}: ActivityFormModalProps) {
   const [formData, setFormData] = useState({
     name: activity?.name || '',
     description: activity?.description || '',
@@ -200,14 +251,18 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
     parc_requires_time_slot: activity?.parc_requires_time_slot ?? false,
   });
   const [imageFile, setImageFile] = useState<File | null>(null);
-  const [imagePreview, setImagePreview] = useState<string | null>(activity?.parc_image_url || null);
-  const [originalImageUrl] = useState<string | null>(activity?.parc_image_url || null);
+  const [imagePreview, setImagePreview] = useState<string | null>(
+    activity?.parc_image_url || null,
+  );
+  const [originalImageUrl] = useState<string | null>(
+    activity?.parc_image_url || null,
+  );
   const [deleteOnSave, setDeleteOnSave] = useState<boolean>(false);
   const [saving, setSaving] = useState(false);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    
+
     if (!formData.name.trim()) {
       toast.error('Le nom est obligatoire');
       return;
@@ -215,20 +270,25 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
 
     try {
       setSaving(true);
-      
+
       if (activity) {
         // Mise à jour
         let parc_image_url: string | null | undefined = undefined;
         if (imageFile) {
           try {
-            const uploaded = await processAndUploadPublicImage('activities', imageFile, 'activities', {
-              minWidth: 1200,
-              minHeight: 600,
-              maxWidth: 1600,
-              maxHeight: 900,
-              mimeType: 'image/jpeg',
-              quality: 0.85,
-            });
+            const uploaded = await processAndUploadPublicImage(
+              'activities',
+              imageFile,
+              'activities',
+              {
+                minWidth: 1200,
+                minHeight: 600,
+                maxWidth: 1600,
+                maxHeight: 900,
+                mimeType: 'image/jpeg',
+                quality: 0.85,
+              },
+            );
             if (!uploaded) throw new Error("Échec de l'upload");
             parc_image_url = uploaded.publicUrl;
             if (originalImageUrl) {
@@ -265,14 +325,19 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
         let parc_image_url: string | null | undefined = undefined;
         if (imageFile) {
           try {
-            const uploaded = await processAndUploadPublicImage('activities', imageFile, 'activities', {
-              minWidth: 1200,
-              minHeight: 600,
-              maxWidth: 1600,
-              maxHeight: 900,
-              mimeType: 'image/jpeg',
-              quality: 0.85,
-            });
+            const uploaded = await processAndUploadPublicImage(
+              'activities',
+              imageFile,
+              'activities',
+              {
+                minWidth: 1200,
+                minHeight: 600,
+                maxWidth: 1600,
+                maxHeight: 900,
+                mimeType: 'image/jpeg',
+                quality: 0.85,
+              },
+            );
             if (!uploaded) throw new Error("Échec de l'upload");
             parc_image_url = uploaded.publicUrl;
           } catch (e: unknown) {
@@ -280,24 +345,22 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
             toast.error(msg || "Échec de l'upload de l'image");
           }
         }
-        const { error } = await supabase
-          .from('activities')
-          .insert({
-            name: formData.name,
-            description: formData.description,
-            icon: formData.icon,
-            is_parc_product: formData.is_parc_product,
-            parc_description: formData.parc_description || null,
-            parc_category: formData.parc_category || null,
-            parc_sort_order: formData.parc_sort_order,
-            parc_requires_time_slot: formData.parc_requires_time_slot,
-            ...(parc_image_url ? { parc_image_url } : {}),
-          });
+        const { error } = await supabase.from('activities').insert({
+          name: formData.name,
+          description: formData.description,
+          icon: formData.icon,
+          is_parc_product: formData.is_parc_product,
+          parc_description: formData.parc_description || null,
+          parc_category: formData.parc_category || null,
+          parc_sort_order: formData.parc_sort_order,
+          parc_requires_time_slot: formData.parc_requires_time_slot,
+          ...(parc_image_url ? { parc_image_url } : {}),
+        });
 
         if (error) throw error;
         toast.success('Activité créée avec succès');
       }
-      
+
       onSave();
     } catch (err) {
       logger.error('Erreur sauvegarde activité', { error: err });
@@ -307,7 +370,20 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
     }
   };
 
-  const commonIcons = ['🐴', '🏹', '🎯', '🎪', '🎨', '🎵', '🏃', '🚴', '🏊', '⚽', '🏀', '🎾'];
+  const commonIcons = [
+    '🐴',
+    '🏹',
+    '🎯',
+    '🎪',
+    '🎨',
+    '🎵',
+    '🏃',
+    '🚴',
+    '🏊',
+    '⚽',
+    '🏀',
+    '🎾',
+  ];
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4 z-50 overflow-y-auto">
@@ -317,7 +393,10 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
             <h2 className="text-xl font-semibold text-gray-900">
               {activity ? "Modifier l'Activité" : 'Créer une Activité'}
             </h2>
-            <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
+            <button
+              onClick={onClose}
+              className="text-gray-400 hover:text-gray-600"
+            >
               <X className="h-6 w-6" />
             </button>
           </div>
@@ -330,7 +409,9 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
               <input
                 type="text"
                 value={formData.name}
-                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, name: e.target.value })
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
                 required
               />
@@ -341,7 +422,9 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
                 id="description"
                 label="Description"
                 value={formData.description}
-                onChange={(value) => setFormData({ ...formData, description: value })}
+                onChange={(value) =>
+                  setFormData({ ...formData, description: value })
+                }
                 rows={3}
               />
             </div>
@@ -357,7 +440,9 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
                     type="button"
                     onClick={() => setFormData({ ...formData, icon })}
                     className={`p-2 text-xl border rounded-md hover:bg-gray-50 ${
-                      formData.icon === icon ? 'border-blue-500 bg-blue-50' : 'border-gray-300'
+                      formData.icon === icon
+                        ? 'border-blue-500 bg-blue-50'
+                        : 'border-gray-300'
                     }`}
                   >
                     {icon}
@@ -367,7 +452,9 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
               <input
                 type="text"
                 value={formData.icon}
-                onChange={(e) => setFormData({ ...formData, icon: e.target.value })}
+                onChange={(e) =>
+                  setFormData({ ...formData, icon: e.target.value })
+                }
                 placeholder="Ou saisissez un emoji"
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
@@ -375,32 +462,53 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
 
             {/* Champs Parc */}
             <div className="border-t pt-4">
-              <h3 className="text-sm font-semibold text-gray-900 mb-2">Paramètres Parc</h3>
+              <h3 className="text-sm font-semibold text-gray-900 mb-2">
+                Paramètres Parc
+              </h3>
               <label className="inline-flex items-center gap-2 mb-3">
                 <input
                   type="checkbox"
                   checked={formData.is_parc_product}
-                  onChange={(e) => setFormData({ ...formData, is_parc_product: e.target.checked })}
+                  onChange={(e) =>
+                    setFormData({
+                      ...formData,
+                      is_parc_product: e.target.checked,
+                    })
+                  }
                   className="h-4 w-4 text-blue-600 border-gray-300 rounded"
                 />
                 Activer cette activité dans la billetterie du Parc
               </label>
               <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Catégorie (Parc)</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Catégorie (Parc)
+                  </label>
                   <input
                     type="text"
                     value={formData.parc_category}
-                    onChange={(e) => setFormData({ ...formData, parc_category: e.target.value })}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        parc_category: e.target.value,
+                      })
+                    }
                     className="w-full px-3 py-2 border border-gray-300 rounded-md"
                   />
                 </div>
                 <div>
-                  <label className="block text-sm font-medium text-gray-700 mb-1">Ordre (Parc)</label>
+                  <label className="block text-sm font-medium text-gray-700 mb-1">
+                    Ordre (Parc)
+                  </label>
                   <input
                     type="number"
                     value={formData.parc_sort_order}
-                    onChange={(e) => setFormData({ ...formData, parc_sort_order: parseInt(e.target.value || '0') })}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        parc_sort_order: parseInt(e.target.value || '0'),
+                      })
+                    }
                     className="w-full px-3 py-2 border border-gray-300 rounded-md"
                   />
                 </div>
@@ -410,7 +518,12 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
                   <input
                     type="checkbox"
                     checked={formData.parc_requires_time_slot}
-                    onChange={(e) => setFormData({ ...formData, parc_requires_time_slot: e.target.checked })}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        parc_requires_time_slot: e.target.checked,
+                      })
+                    }
                     className="h-4 w-4 text-blue-600 border-gray-300 rounded"
                   />
                   Créneau requis (Parc)
@@ -421,16 +534,24 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
                   id="parc_description"
                   label="Description (Parc)"
                   value={formData.parc_description}
-                  onChange={(value) => setFormData({ ...formData, parc_description: value })}
+                  onChange={(value) =>
+                    setFormData({ ...formData, parc_description: value })
+                  }
                   rows={3}
                 />
               </div>
 
               <div className="mt-3">
-                <label className="block text-sm font-medium text-gray-700 mb-1">Image (Parc)</label>
+                <label className="block text-sm font-medium text-gray-700 mb-1">
+                  Image (Parc)
+                </label>
                 {imagePreview && (
                   <div className="mb-2">
-                    <img src={imagePreview} alt="aperçu" className="h-24 rounded-md object-cover" />
+                    <img
+                      src={imagePreview}
+                      alt="aperçu"
+                      className="h-24 rounded-md object-cover"
+                    />
                   </div>
                 )}
                 <div className="flex items-center gap-2">
@@ -445,7 +566,10 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
                         const f = e.target.files?.[0] || null;
                         if (f) {
                           const err = validateImageFile(f);
-                          if (err) { toast.error(err); return; }
+                          if (err) {
+                            toast.error(err);
+                            return;
+                          }
                           setImageFile(f);
                           setImagePreview(URL.createObjectURL(f));
                           setDeleteOnSave(false);
@@ -454,12 +578,22 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
                     />
                   </label>
                   {imagePreview && (
-                    <button type="button" onClick={() => { setImagePreview(null); setImageFile(null); setDeleteOnSave(true); }} className="text-sm text-red-600 hover:text-red-700">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setImagePreview(null);
+                        setImageFile(null);
+                        setDeleteOnSave(true);
+                      }}
+                      className="text-sm text-red-600 hover:text-red-700"
+                    >
                       Supprimer l'image
                     </button>
                   )}
                 </div>
-                <p className="text-xs text-gray-500 mt-1">Formats recommandés: JPG/PNG, 1200×600 min.</p>
+                <p className="text-xs text-gray-500 mt-1">
+                  Formats recommandés: JPG/PNG, 1200×600 min.
+                </p>
               </div>
             </div>
 
@@ -476,7 +610,7 @@ function ActivityFormModal({ activity, onClose, onSave }: ActivityFormModalProps
                 disabled={saving}
                 className="flex-1 bg-blue-600 hover:bg-blue-700 disabled:bg-blue-400 text-white px-4 py-2 rounded-md font-medium transition-colors"
               >
-                {saving ? 'Sauvegarde...' : (activity ? 'Modifier' : 'Créer')}
+                {saving ? 'Sauvegarde...' : activity ? 'Modifier' : 'Créer'}
               </button>
             </div>
           </form>

--- a/src/pages/admin/Communication.tsx
+++ b/src/pages/admin/Communication.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Mail, Send, Users, FileText, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -47,7 +47,7 @@ Informations pratiques :
 
 Nous avons hâte de vous accueillir !
 
-L'équipe BilletEvent`
+L'équipe BilletEvent`,
     },
     {
       id: '2',
@@ -67,7 +67,7 @@ Votre billet est en pièce jointe de cet email.
 
 Merci pour votre confiance !
 
-L'équipe BilletEvent`
+L'équipe BilletEvent`,
     },
     {
       id: '3',
@@ -82,8 +82,8 @@ Nous vous contactons concernant l'événement "{EVENT_NAME}" pour lequel vous av
 Si vous avez des questions, n'hésitez pas à nous contacter.
 
 Cordialement,
-L'équipe BilletEvent`
-    }
+L'équipe BilletEvent`,
+    },
   ];
 
   const loadEvents = useCallback(async () => {
@@ -106,19 +106,21 @@ L'équipe BilletEvent`
     try {
       const { data, error } = await supabase
         .from('reservations')
-        .select(`
+        .select(
+          `
           client_email,
           passes!inner (
             event_id
           )
-        `)
+        `,
+        )
         .eq('passes.event_id', selectedEvent)
         .eq('payment_status', 'paid');
 
       if (error) throw error;
 
       // Compter les emails uniques
-      const uniqueEmails = new Set((data || []).map(r => r.client_email));
+      const uniqueEmails = new Set((data || []).map((r) => r.client_email));
       setRecipientCount(uniqueEmails.size);
     } catch (err) {
       logger.error('Erreur comptage destinataires', { error: err });
@@ -148,13 +150,13 @@ L'équipe BilletEvent`
 
     try {
       setSending(true);
-      
+
       // Simuler l'envoi d'email
       const sendDelay = 2000;
       await wait(sendDelay);
-      
+
       toast.success(`Email envoyé à ${recipientCount} destinataire(s)`);
-      
+
       // Réinitialiser le formulaire
       setEmailSubject('');
       setEmailContent('');
@@ -162,7 +164,7 @@ L'équipe BilletEvent`
       setRecipientCount(0);
     } catch (err) {
       logger.error('Erreur envoi email', { error: err });
-      toast.error('Erreur lors de l\'envoi');
+      toast.error("Erreur lors de l'envoi");
     } finally {
       setSending(false);
     }
@@ -179,7 +181,9 @@ L'équipe BilletEvent`
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-gray-900">Communication</h1>
-          <p className="text-gray-600">Envoyez des emails aux participants de vos événements</p>
+          <p className="text-gray-600">
+            Envoyez des emails aux participants de vos événements
+          </p>
         </div>
         <button
           onClick={() => setShowTemplateModal(true)}
@@ -192,8 +196,10 @@ L'équipe BilletEvent`
 
       {/* Formulaire d'envoi */}
       <div className="bg-white rounded-lg shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-6">Nouvel Email</h2>
-        
+        <h2 className="text-lg font-semibold text-gray-900 mb-6">
+          Nouvel Email
+        </h2>
+
         <div className="space-y-6">
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-1">
@@ -208,7 +214,8 @@ L'équipe BilletEvent`
               <option value="">Sélectionner un événement</option>
               {events.map((event) => (
                 <option key={event.id} value={event.id}>
-                  {event.name} - {new Date(event.event_date).toLocaleDateString('fr-FR')}
+                  {event.name} -{' '}
+                  {new Date(event.event_date).toLocaleDateString('fr-FR')}
                 </option>
               ))}
             </select>
@@ -246,7 +253,8 @@ L'équipe BilletEvent`
               required
             />
             <p className="text-xs text-gray-500 mt-1">
-              Variables disponibles : {'{EVENT_NAME}'}, {'{EVENT_DATE}'}, {'{RESERVATION_NUMBER}'}, {'{PASS_NAME}'}
+              Variables disponibles : {'{EVENT_NAME}'}, {'{EVENT_DATE}'},{' '}
+              {'{RESERVATION_NUMBER}'}, {'{PASS_NAME}'}
             </p>
           </div>
 
@@ -254,16 +262,21 @@ L'équipe BilletEvent`
             <div className="flex items-center gap-2 text-sm text-gray-600">
               <Users className="h-4 w-4" />
               <span>
-                {recipientCount > 0 
+                {recipientCount > 0
                   ? `Prêt à envoyer à ${recipientCount} destinataire(s)`
-                  : 'Sélectionnez un événement pour voir les destinataires'
-                }
+                  : 'Sélectionnez un événement pour voir les destinataires'}
               </span>
             </div>
-            
+
             <button
               onClick={handleSendEmail}
-              disabled={!selectedEvent || !emailSubject || !emailContent || recipientCount === 0 || sending}
+              disabled={
+                !selectedEvent ||
+                !emailSubject ||
+                !emailContent ||
+                recipientCount === 0 ||
+                sending
+              }
               className="bg-blue-600 hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed text-white px-6 py-2 rounded-lg font-medium transition-colors flex items-center gap-2"
             >
               {sending ? (
@@ -284,7 +297,9 @@ L'équipe BilletEvent`
 
       {/* Historique des envois */}
       <div className="bg-white rounded-lg shadow-sm p-6">
-        <h2 className="text-lg font-semibold text-gray-900 mb-4">Historique des Envois</h2>
+        <h2 className="text-lg font-semibold text-gray-900 mb-4">
+          Historique des Envois
+        </h2>
         <div className="text-center py-8 text-gray-500">
           <Mail className="h-12 w-12 mx-auto mb-4 text-gray-300" />
           <p>Aucun email envoyé pour le moment</p>
@@ -303,21 +318,36 @@ L'équipe BilletEvent`
           >
             <div className="p-6 border-b border-gray-200">
               <div className="flex items-center justify-between">
-                <h2 id="email-templates-title" className="text-xl font-semibold text-gray-900">Modèles d'Email</h2>
-                <button onClick={() => setShowTemplateModal(false)} className="text-gray-400 hover:text-gray-600">
+                <h2
+                  id="email-templates-title"
+                  className="text-xl font-semibold text-gray-900"
+                >
+                  Modèles d'Email
+                </h2>
+                <button
+                  onClick={() => setShowTemplateModal(false)}
+                  className="text-gray-400 hover:text-gray-600"
+                >
                   <X className="h-6 w-6" />
                 </button>
               </div>
             </div>
-            
+
             <div className="p-6 overflow-y-auto max-h-[calc(80vh-140px)]">
               <div className="grid grid-cols-1 gap-4">
                 {emailTemplates.map((template) => (
-                  <div key={template.id} className="border border-gray-200 rounded-lg p-4 hover:border-blue-300 transition-colors">
+                  <div
+                    key={template.id}
+                    className="border border-gray-200 rounded-lg p-4 hover:border-blue-300 transition-colors"
+                  >
                     <div className="flex items-start justify-between mb-3">
                       <div>
-                        <h3 className="font-semibold text-gray-900">{template.name}</h3>
-                        <p className="text-sm text-gray-600">{template.subject}</p>
+                        <h3 className="font-semibold text-gray-900">
+                          {template.name}
+                        </h3>
+                        <p className="text-sm text-gray-600">
+                          {template.subject}
+                        </p>
                       </div>
                       <button
                         onClick={() => applyTemplate(template)}
@@ -327,7 +357,9 @@ L'équipe BilletEvent`
                       </button>
                     </div>
                     <div className="text-sm text-gray-700 bg-gray-50 rounded p-3 max-h-32 overflow-y-auto">
-                      <pre className="whitespace-pre-wrap font-sans">{template.content}</pre>
+                      <pre className="whitespace-pre-wrap font-sans">
+                        {template.content}
+                      </pre>
                     </div>
                   </div>
                 ))}

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { supabase } from '../../lib/supabase';
 import { Calendar, Users, Euro, TrendingUp, Activity } from 'lucide-react';

--- a/src/pages/admin/EventManagement.tsx
+++ b/src/pages/admin/EventManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { supabase, isSupabaseConfigured } from '../../lib/supabase';
 import { Calendar, Plus, Edit, Trash2, Settings } from 'lucide-react';
 import { format } from 'date-fns';
@@ -31,8 +31,12 @@ export default function EventManagement() {
   const [loading, setLoading] = useState(true);
   const [showCreateModal, setShowCreateModal] = useState(false);
   const [editingEvent, setEditingEvent] = useState<Event | null>(null);
-  const [showAnimationsModal, setShowAnimationsModal] = useState<Event | null>(null);
-  const [showActivitiesModal, setShowActivitiesModal] = useState<Event | null>(null);
+  const [showAnimationsModal, setShowAnimationsModal] = useState<Event | null>(
+    null,
+  );
+  const [showActivitiesModal, setShowActivitiesModal] = useState<Event | null>(
+    null,
+  );
 
   useEffect(() => {
     debugLog('🔧 EventManagement mounted');
@@ -51,7 +55,8 @@ export default function EventManagement() {
       setLoading(true);
       const { data, error } = await supabase
         .from('events')
-        .select(`
+        .select(
+          `
           id,
           name,
           event_date,
@@ -64,17 +69,25 @@ export default function EventManagement() {
           created_at,
           updated_at,
           event_faqs(question, answer, position)
-        `)
+        `,
+        )
         .order('created_at', { ascending: false });
 
       if (error) throw error;
-      const eventsWithFaqs = (data || []).map(e => ({
+      const eventsWithFaqs = (data || []).map((e) => ({
         ...e,
         faqs: (e.event_faqs || [])
           .sort((a, b) => a.position - b.position)
           .map(({ question, answer }) => ({ question, answer })),
       }));
-      debugLog('🔧 EventManagement Events loaded with has_animations:', eventsWithFaqs.map(e => ({ id: e.id, name: e.name, has_animations: e.has_animations }))); 
+      debugLog(
+        '🔧 EventManagement Events loaded with has_animations:',
+        eventsWithFaqs.map((e) => ({
+          id: e.id,
+          name: e.name,
+          has_animations: e.has_animations,
+        })),
+      );
       setEvents(eventsWithFaqs);
     } catch (err) {
       logger.error('Erreur chargement événements', { error: err });
@@ -85,7 +98,12 @@ export default function EventManagement() {
   };
 
   const handleDeleteEvent = async (eventId: string) => {
-    if (!confirm('Êtes-vous sûr de vouloir supprimer cet événement ? Cette action est irréversible.')) return;
+    if (
+      !confirm(
+        'Êtes-vous sûr de vouloir supprimer cet événement ? Cette action est irréversible.',
+      )
+    )
+      return;
 
     try {
       const { error } = await supabase
@@ -94,7 +112,7 @@ export default function EventManagement() {
         .eq('id', eventId);
 
       if (error) throw error;
-      
+
       toast.success('Événement supprimé avec succès');
       loadEvents();
     } catch (err) {
@@ -108,12 +126,14 @@ export default function EventManagement() {
       draft: { label: 'Brouillon', color: 'bg-gray-100 text-gray-800' },
       published: { label: 'Publié', color: 'bg-green-100 text-green-800' },
       finished: { label: 'Terminé', color: 'bg-blue-100 text-blue-800' },
-      cancelled: { label: 'Annulé', color: 'bg-red-100 text-red-800' }
+      cancelled: { label: 'Annulé', color: 'bg-red-100 text-red-800' },
     };
 
     const config = statusConfig[status as keyof typeof statusConfig];
     return (
-      <span className={`px-2 py-1 rounded-full text-xs font-medium ${config.color}`}>
+      <span
+        className={`px-2 py-1 rounded-full text-xs font-medium ${config.color}`}
+      >
         {config.label}
       </span>
     );
@@ -138,17 +158,19 @@ export default function EventManagement() {
     showCreateModal,
     editingEvent: editingEvent?.id,
     showAnimationsModal: showAnimationsModal?.id,
-    showActivitiesModal: showActivitiesModal?.id
+    showActivitiesModal: showActivitiesModal?.id,
   });
 
   return (
     <div className="space-y-6">
       <div className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold text-gray-900">Gestion des Événements</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Gestion des Événements
+          </h1>
           <p className="text-gray-600">Créez et gérez vos événements</p>
         </div>
-        <button 
+        <button
           onClick={() => {
             debugLog('🔧 EventManagement opening create modal');
             setShowCreateModal(true);
@@ -163,24 +185,26 @@ export default function EventManagement() {
       {/* Statistiques */}
       <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
         <div className="bg-white rounded-lg shadow-sm p-4">
-          <div className="text-2xl font-bold text-gray-900">{events.length}</div>
+          <div className="text-2xl font-bold text-gray-900">
+            {events.length}
+          </div>
           <div className="text-sm text-gray-600">Total événements</div>
         </div>
         <div className="bg-white rounded-lg shadow-sm p-4">
           <div className="text-2xl font-bold text-green-600">
-            {events.filter(e => e.status === 'published').length}
+            {events.filter((e) => e.status === 'published').length}
           </div>
           <div className="text-sm text-gray-600">Publiés</div>
         </div>
         <div className="bg-white rounded-lg shadow-sm p-4">
           <div className="text-2xl font-bold text-gray-600">
-            {events.filter(e => e.status === 'draft').length}
+            {events.filter((e) => e.status === 'draft').length}
           </div>
           <div className="text-sm text-gray-600">Brouillons</div>
         </div>
         <div className="bg-white rounded-lg shadow-sm p-4">
           <div className="text-2xl font-bold text-purple-600">
-            {events.filter(e => e.has_animations).length}
+            {events.filter((e) => e.has_animations).length}
           </div>
           <div className="text-sm text-gray-600">Avec animations</div>
         </div>
@@ -189,19 +213,25 @@ export default function EventManagement() {
       {/* Liste des événements */}
       <div className="bg-white rounded-lg shadow-sm overflow-hidden">
         <div className="px-6 py-4 border-b border-gray-200">
-          <h2 className="text-lg font-semibold text-gray-900">Événements ({events.length})</h2>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Événements ({events.length})
+          </h2>
         </div>
 
         {events.length === 0 ? (
           <div className="p-12 text-center">
             <Calendar className="h-12 w-12 text-gray-400 mx-auto mb-4" />
-            <h3 className="text-lg font-medium text-gray-900 mb-2">Aucun événement</h3>
+            <h3 className="text-lg font-medium text-gray-900 mb-2">
+              Aucun événement
+            </h3>
             <p className="text-gray-600 mb-4">
               Créez votre premier événement pour commencer à vendre des billets.
             </p>
             <button
               onClick={() => {
-                debugLog('🔧 EventManagement opening create modal from empty state');
+                debugLog(
+                  '🔧 EventManagement opening create modal from empty state',
+                );
                 setShowCreateModal(true);
               }}
               className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-medium transition-colors"
@@ -212,35 +242,55 @@ export default function EventManagement() {
         ) : (
           <div className="divide-y divide-gray-200">
             {events.map((event) => (
-              <div key={event.id} className="p-6 hover:bg-gray-50 transition-colors">
+              <div
+                key={event.id}
+                className="p-6 hover:bg-gray-50 transition-colors"
+              >
                 <div className="flex items-start justify-between">
                   <div className="flex-1">
                     <div className="flex items-center gap-3 mb-2">
-                      <h3 className="text-lg font-semibold text-gray-900">{event.name}</h3>
+                      <h3 className="text-lg font-semibold text-gray-900">
+                        {event.name}
+                      </h3>
                       {getStatusBadge(event.status)}
                     </div>
-                    
+
                     <div className="flex items-center gap-6 text-sm text-gray-500 mb-3">
                       <div className="flex items-center gap-1">
                         <Calendar className="h-4 w-4" />
-                        <span>{format(new Date(event.event_date), 'EEEE d MMMM yyyy', { locale: fr })}</span>
+                        <span>
+                          {format(
+                            new Date(event.event_date),
+                            'EEEE d MMMM yyyy',
+                            { locale: fr },
+                          )}
+                        </span>
                       </div>
-                      <div>Créé le {format(new Date(event.created_at), 'dd/MM/yyyy')}</div>
                       <div>
-                        Animations: {event.has_animations ? '✅ Activées' : '❌ Désactivées'}
+                        Créé le{' '}
+                        {format(new Date(event.created_at), 'dd/MM/yyyy')}
+                      </div>
+                      <div>
+                        Animations:{' '}
+                        {event.has_animations
+                          ? '✅ Activées'
+                          : '❌ Désactivées'}
                       </div>
                     </div>
-                    
+
                     <MarkdownRenderer
                       content={event.key_info_content}
                       className="text-gray-600 text-sm line-clamp-2"
                     />
                   </div>
-                  
+
                   <div className="flex items-center gap-2 ml-4">
                     <button
                       onClick={() => {
-                        debugLog('🔧 EventManagement opening activities modal for:', event.id);
+                        debugLog(
+                          '🔧 EventManagement opening activities modal for:',
+                          event.id,
+                        );
                         setShowActivitiesModal(event);
                       }}
                       className="p-2 text-green-600 hover:text-green-700 hover:bg-green-50 rounded-md transition-colors"
@@ -248,11 +298,14 @@ export default function EventManagement() {
                     >
                       <Settings className="h-4 w-4" />
                     </button>
-                    
+
                     {event.has_animations && (
                       <button
                         onClick={() => {
-                          debugLog('🔧 EventManagement opening animations modal for:', event.id);
+                          debugLog(
+                            '🔧 EventManagement opening animations modal for:',
+                            event.id,
+                          );
                           setShowAnimationsModal(event);
                         }}
                         className="p-2 text-purple-600 hover:text-purple-700 hover:bg-purple-50 rounded-md transition-colors"
@@ -261,10 +314,13 @@ export default function EventManagement() {
                         <span className="text-lg">🎭</span>
                       </button>
                     )}
-                    
+
                     <button
                       onClick={() => {
-                        debugLog('🔧 EventManagement opening edit modal for:', event.id);
+                        debugLog(
+                          '🔧 EventManagement opening edit modal for:',
+                          event.id,
+                        );
                         setEditingEvent(event);
                       }}
                       className="p-2 text-blue-600 hover:text-blue-700 hover:bg-blue-50 rounded-md transition-colors"
@@ -272,7 +328,7 @@ export default function EventManagement() {
                     >
                       <Edit className="h-4 w-4" />
                     </button>
-                    
+
                     <button
                       onClick={() => handleDeleteEvent(event.id)}
                       className="p-2 text-red-600 hover:text-red-700 hover:bg-red-50 rounded-md transition-colors"
@@ -290,10 +346,7 @@ export default function EventManagement() {
 
       {/* Modals - UN SEUL À LA FOIS */}
       {(showCreateModal || editingEvent) && (
-        <EventForm
-          event={editingEvent}
-          onClose={handleFormClose}
-        />
+        <EventForm event={editingEvent} onClose={handleFormClose} />
       )}
 
       {showAnimationsModal && (

--- a/src/pages/admin/FlowManagement.tsx
+++ b/src/pages/admin/FlowManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState, useCallback } from 'react';
+import { useEffect, useMemo, useState, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import {
   Users,

--- a/src/pages/admin/PassManagement.tsx
+++ b/src/pages/admin/PassManagement.tsx
@@ -1,4 +1,10 @@
-import React, { useEffect, useState, useCallback, useMemo } from 'react';
+import {
+  useEffect,
+  useState,
+  useCallback,
+  useMemo,
+  type FormEvent,
+} from 'react';
 import { supabase, isSupabaseConfigured } from '../../lib/supabase';
 import { Ticket, Plus, Edit, Trash2, Package, X } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -570,7 +576,7 @@ function PassFormModal({ pass, events, onClose, onSave }: PassFormModalProps) {
     }
   }, [formData.event_id, loadEventActivities]);
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
 
     if (!formData.event_id || !formData.name || formData.price <= 0) {

--- a/src/pages/admin/Reports.tsx
+++ b/src/pages/admin/Reports.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import { BarChart3, TrendingUp, Euro, Users, Download } from 'lucide-react';
 import {

--- a/src/pages/admin/ReservationManagement.tsx
+++ b/src/pages/admin/ReservationManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Users, Search, Download, Mail } from 'lucide-react';
 import { format } from 'date-fns';

--- a/src/pages/admin/Settings.tsx
+++ b/src/pages/admin/Settings.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { supabase } from '../../lib/supabase';
 import { Save, User, Shield, Database, Globe, Bell } from 'lucide-react';
 import { toast } from 'react-hot-toast';
@@ -24,7 +24,7 @@ export default function Settings() {
     contact_email: 'contact@billetevent.com',
     notification_email: 'admin@billetevent.com',
     maintenance_mode: false,
-    registration_enabled: true
+    registration_enabled: true,
   });
   const [loading, setLoading] = useState(true);
   const [saving, setSaving] = useState(false);
@@ -36,7 +36,7 @@ export default function Settings() {
   const loadUserAndSettings = async () => {
     try {
       setLoading(true);
-      
+
       // Charger l'utilisateur actuel
       const currentUser = await getCurrentUser();
       setUser(currentUser);
@@ -58,11 +58,11 @@ export default function Settings() {
   const handleSaveSettings = async () => {
     try {
       setSaving(true);
-      
+
       // Sauvegarder les paramètres (simulé avec localStorage)
       // En production, cela serait sauvegardé dans Supabase
       safeStorage.setItem('system_settings', JSON.stringify(settings));
-      
+
       toast.success('Paramètres sauvegardés avec succès');
     } catch (err) {
       logger.error('Erreur sauvegarde paramètres', { error: err });
@@ -73,24 +73,47 @@ export default function Settings() {
   };
 
   const handleResetDatabase = async () => {
-    if (!confirm('⚠️ ATTENTION: Cette action va supprimer TOUTES les données (événements, réservations, etc.). Cette action est IRRÉVERSIBLE. Êtes-vous absolument sûr ?')) {
+    if (
+      !confirm(
+        '⚠️ ATTENTION: Cette action va supprimer TOUTES les données (événements, réservations, etc.). Cette action est IRRÉVERSIBLE. Êtes-vous absolument sûr ?',
+      )
+    ) {
       return;
     }
 
-    if (!confirm('Dernière confirmation: Voulez-vous vraiment SUPPRIMER TOUTES LES DONNÉES ?')) {
+    if (
+      !confirm(
+        'Dernière confirmation: Voulez-vous vraiment SUPPRIMER TOUTES LES DONNÉES ?',
+      )
+    ) {
       return;
     }
 
     try {
       setSaving(true);
-      
+
       // Supprimer toutes les données dans l'ordre correct (contraintes FK)
-      await supabase.from('cart_items').delete().neq('id', '00000000-0000-0000-0000-000000000000');
-      await supabase.from('reservations').delete().neq('id', '00000000-0000-0000-0000-000000000000');
-      await supabase.from('time_slots').delete().neq('id', '00000000-0000-0000-0000-000000000000');
-      await supabase.from('passes').delete().neq('id', '00000000-0000-0000-0000-000000000000');
-      await supabase.from('events').delete().neq('id', '00000000-0000-0000-0000-000000000000');
-      
+      await supabase
+        .from('cart_items')
+        .delete()
+        .neq('id', '00000000-0000-0000-0000-000000000000');
+      await supabase
+        .from('reservations')
+        .delete()
+        .neq('id', '00000000-0000-0000-0000-000000000000');
+      await supabase
+        .from('time_slots')
+        .delete()
+        .neq('id', '00000000-0000-0000-0000-000000000000');
+      await supabase
+        .from('passes')
+        .delete()
+        .neq('id', '00000000-0000-0000-0000-000000000000');
+      await supabase
+        .from('events')
+        .delete()
+        .neq('id', '00000000-0000-0000-0000-000000000000');
+
       toast.success('Base de données réinitialisée avec succès');
     } catch (err) {
       logger.error('Erreur réinitialisation', { error: err });
@@ -112,19 +135,25 @@ export default function Settings() {
     <div className="space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-gray-900">Paramètres</h1>
-        <p className="text-gray-600">Configurez votre plateforme et gérez les paramètres système</p>
+        <p className="text-gray-600">
+          Configurez votre plateforme et gérez les paramètres système
+        </p>
       </div>
 
       {/* Informations utilisateur */}
       <div className="bg-white rounded-lg shadow-sm p-6">
         <div className="flex items-center gap-3 mb-4">
           <User className="h-5 w-5 text-blue-600" />
-          <h2 className="text-lg font-semibold text-gray-900">Profil Administrateur</h2>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Profil Administrateur
+          </h2>
         </div>
-        
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Email
+            </label>
             <input
               type="email"
               value={user?.email || ''}
@@ -133,7 +162,9 @@ export default function Settings() {
             />
           </div>
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Rôle</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Rôle
+            </label>
             <div className="flex items-center gap-2">
               <Shield className="h-4 w-4 text-green-600" />
               <span className="px-2 py-1 bg-green-100 text-green-800 text-sm font-medium rounded-full">
@@ -148,36 +179,50 @@ export default function Settings() {
       <div className="bg-white rounded-lg shadow-sm p-6">
         <div className="flex items-center gap-3 mb-4">
           <Globe className="h-5 w-5 text-blue-600" />
-          <h2 className="text-lg font-semibold text-gray-900">Paramètres du Site</h2>
+          <h2 className="text-lg font-semibold text-gray-900">
+            Paramètres du Site
+          </h2>
         </div>
-        
+
         <div className="space-y-4">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Nom du site</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Nom du site
+              </label>
               <input
                 type="text"
                 value={settings.site_name}
-                onChange={(e) => setSettings({ ...settings, site_name: e.target.value })}
+                onChange={(e) =>
+                  setSettings({ ...settings, site_name: e.target.value })
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
             <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Email de contact</label>
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Email de contact
+              </label>
               <input
                 type="email"
                 value={settings.contact_email}
-                onChange={(e) => setSettings({ ...settings, contact_email: e.target.value })}
+                onChange={(e) =>
+                  setSettings({ ...settings, contact_email: e.target.value })
+                }
                 className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               />
             </div>
           </div>
-          
+
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Description du site</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Description du site
+            </label>
             <textarea
               value={settings.site_description}
-              onChange={(e) => setSettings({ ...settings, site_description: e.target.value })}
+              onChange={(e) =>
+                setSettings({ ...settings, site_description: e.target.value })
+              }
               rows={3}
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
             />
@@ -191,31 +236,44 @@ export default function Settings() {
           <Bell className="h-5 w-5 text-blue-600" />
           <h2 className="text-lg font-semibold text-gray-900">Notifications</h2>
         </div>
-        
+
         <div className="space-y-4">
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email de notification</label>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Email de notification
+            </label>
             <input
               type="email"
               value={settings.notification_email}
-              onChange={(e) => setSettings({ ...settings, notification_email: e.target.value })}
+              onChange={(e) =>
+                setSettings({ ...settings, notification_email: e.target.value })
+              }
               className="w-full px-3 py-2 border border-gray-300 rounded-md focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
               placeholder="admin@exemple.com"
             />
             <p className="text-xs text-gray-500 mt-1">
-              Adresse email qui recevra les notifications de nouvelles réservations
+              Adresse email qui recevra les notifications de nouvelles
+              réservations
             </p>
           </div>
-          
+
           <div className="flex items-center gap-3">
             <input
               type="checkbox"
               id="registration_enabled"
               checked={settings.registration_enabled}
-              onChange={(e) => setSettings({ ...settings, registration_enabled: e.target.checked })}
+              onChange={(e) =>
+                setSettings({
+                  ...settings,
+                  registration_enabled: e.target.checked,
+                })
+              }
               className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
             />
-            <label htmlFor="registration_enabled" className="text-sm font-medium text-gray-700">
+            <label
+              htmlFor="registration_enabled"
+              className="text-sm font-medium text-gray-700"
+            >
               Autoriser les nouvelles inscriptions
             </label>
           </div>
@@ -228,26 +286,33 @@ export default function Settings() {
           <Database className="h-5 w-5 text-blue-600" />
           <h2 className="text-lg font-semibold text-gray-900">Système</h2>
         </div>
-        
+
         <div className="space-y-4">
           <div className="flex items-center gap-3">
             <input
               type="checkbox"
               id="maintenance_mode"
               checked={settings.maintenance_mode}
-              onChange={(e) => setSettings({ ...settings, maintenance_mode: e.target.checked })}
+              onChange={(e) =>
+                setSettings({ ...settings, maintenance_mode: e.target.checked })
+              }
               className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
             />
-            <label htmlFor="maintenance_mode" className="text-sm font-medium text-gray-700">
+            <label
+              htmlFor="maintenance_mode"
+              className="text-sm font-medium text-gray-700"
+            >
               Mode maintenance
             </label>
             <span className="text-xs text-gray-500">
               (Désactive temporairement l'accès public au site)
             </span>
           </div>
-          
+
           <div className="border-t border-gray-200 pt-4">
-            <h3 className="text-sm font-medium text-gray-900 mb-2">Zone de danger</h3>
+            <h3 className="text-sm font-medium text-gray-900 mb-2">
+              Zone de danger
+            </h3>
             <button
               onClick={handleResetDatabase}
               disabled={saving}
@@ -256,7 +321,8 @@ export default function Settings() {
               Réinitialiser la base de données
             </button>
             <p className="text-xs text-red-600 mt-1">
-              ⚠️ Cette action supprimera TOUTES les données (événements, réservations, etc.)
+              ⚠️ Cette action supprimera TOUTES les données (événements,
+              réservations, etc.)
             </p>
           </div>
         </div>

--- a/src/pages/admin/TimeSlotManagement.tsx
+++ b/src/pages/admin/TimeSlotManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { supabase } from '../../lib/supabase';
 import {
   Calendar,

--- a/src/pages/admin/UserManagement.tsx
+++ b/src/pages/admin/UserManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { supabase } from '../../lib/supabase';
 import { toast } from 'react-hot-toast';
 import { logger } from '../../lib/logger';
@@ -13,7 +13,7 @@ const ROLES: Role[] = [
   'archery_provider',
   'luge_provider',
   'atlm_collaborator',
-  'client'
+  'client',
 ];
 
 interface UserRow {
@@ -41,7 +41,7 @@ export default function UserManagement() {
     })();
     // Chargement initial des utilisateurs
     void search();
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -76,12 +76,12 @@ export default function UserManagement() {
   };
 
   const toggleSelectAll = () => {
-    setSelectedIds(allSelected ? [] : users.map(u => u.id));
+    setSelectedIds(allSelected ? [] : users.map((u) => u.id));
   };
 
   const toggleSelection = (id: string) => {
     setSelectedIds((ids) =>
-      ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id]
+      ids.includes(id) ? ids.filter((i) => i !== id) : [...ids, id],
     );
   };
 
@@ -100,7 +100,7 @@ export default function UserManagement() {
       logger.error('Erreur mise à jour rôle groupée', {
         error: err,
         ids: selectedIds,
-        role
+        role,
       });
       toast.error('Échec de la mise à jour');
     } finally {
@@ -122,7 +122,7 @@ export default function UserManagement() {
     } catch (err) {
       logger.error('Erreur suppression utilisateurs', {
         error: err,
-        ids: selectedIds
+        ids: selectedIds,
       });
       toast.error('Échec de la suppression');
     } finally {
@@ -133,9 +133,12 @@ export default function UserManagement() {
   const updateRole = async (id: string, role: Role) => {
     try {
       setSaving((s) => ({ ...s, [id]: true }));
-      const { error } = await supabase.from('users').update({ role }).eq('id', id);
+      const { error } = await supabase
+        .from('users')
+        .update({ role })
+        .eq('id', id);
       if (error) throw error;
-      setUsers((list) => list.map(u => (u.id === id ? { ...u, role } : u)));
+      setUsers((list) => list.map((u) => (u.id === id ? { ...u, role } : u)));
       toast.success('Rôle mis à jour');
     } catch (err) {
       logger.error('Erreur mise à jour rôle', { error: err, userId: id, role });
@@ -150,7 +153,9 @@ export default function UserManagement() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <Shield className="h-5 w-5 text-blue-600" />
-          <h1 className="text-2xl font-bold text-gray-900">Gestion des Utilisateurs</h1>
+          <h1 className="text-2xl font-bold text-gray-900">
+            Gestion des Utilisateurs
+          </h1>
         </div>
       </div>
 
@@ -172,7 +177,9 @@ export default function UserManagement() {
         >
           <option value="">Tous</option>
           {ROLES.map((r) => (
-            <option key={r} value={r}>{r}</option>
+            <option key={r} value={r}>
+              {r}
+            </option>
           ))}
         </select>
         <button
@@ -193,7 +200,9 @@ export default function UserManagement() {
             aria-label="Nouveau rôle"
           >
             {ROLES.map((r) => (
-              <option key={r} value={r}>{r}</option>
+              <option key={r} value={r}>
+                {r}
+              </option>
             ))}
           </select>
           <button
@@ -227,8 +236,12 @@ export default function UserManagement() {
                   aria-label="Sélectionner tous les utilisateurs"
                 />
               </th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Email</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Rôle</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Email
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Rôle
+              </th>
               <th className="px-6 py-3"></th>
             </tr>
           </thead>
@@ -253,7 +266,9 @@ export default function UserManagement() {
                     aria-label={`Rôle de ${u.email}`}
                   >
                     {ROLES.map((r) => (
-                      <option key={r} value={r}>{r}</option>
+                      <option key={r} value={r}>
+                        {r}
+                      </option>
                     ))}
                   </select>
                 </td>
@@ -272,7 +287,10 @@ export default function UserManagement() {
             ))}
             {users.length === 0 && (
               <tr>
-                <td className="px-6 py-10 text-center text-sm text-gray-500" colSpan={4}>
+                <td
+                  className="px-6 py-10 text-center text-sm text-gray-500"
+                  colSpan={4}
+                >
                   Aucun utilisateur trouvé.
                 </td>
               </tr>
@@ -283,4 +301,3 @@ export default function UserManagement() {
     </div>
   );
 }
-

--- a/src/pages/provider/ArcheryValidation.tsx
+++ b/src/pages/provider/ArcheryValidation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReservationValidationForm from '../../components/validation/ReservationValidationForm';
 
 export default function ArcheryValidation() {
@@ -10,4 +9,3 @@ export default function ArcheryValidation() {
     />
   );
 }
-

--- a/src/pages/provider/LugeValidation.tsx
+++ b/src/pages/provider/LugeValidation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReservationValidationForm from '../../components/validation/ReservationValidationForm';
 
 export default function LugeValidation() {
@@ -10,4 +9,3 @@ export default function LugeValidation() {
     />
   );
 }
-

--- a/src/pages/provider/PonyValidation.tsx
+++ b/src/pages/provider/PonyValidation.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import ReservationValidationForm from '../../components/validation/ReservationValidationForm';
 
 export default function PonyValidation() {
@@ -10,4 +9,3 @@ export default function PonyValidation() {
     />
   );
 }
-

--- a/src/pages/provider/ProviderLayout.tsx
+++ b/src/pages/provider/ProviderLayout.tsx
@@ -1,11 +1,17 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Outlet, Link, useLocation } from 'react-router-dom';
 import { getCurrentUser, signOut } from '../../lib/auth';
 import type { User } from '../../lib/auth';
 import ProviderLogin from '../../components/ProviderLogin';
 import { QrCode, LogOut } from 'lucide-react';
 
-const ALLOWED: User['role'][] = ['pony_provider', 'archery_provider', 'luge_provider', 'atlm_collaborator', 'admin'];
+const ALLOWED: User['role'][] = [
+  'pony_provider',
+  'archery_provider',
+  'luge_provider',
+  'atlm_collaborator',
+  'admin',
+];
 
 export default function ProviderLayout() {
   const location = useLocation();
@@ -33,11 +39,37 @@ export default function ProviderLayout() {
   }
 
   const nav = (() => {
-    const items = [] as Array<{ to: string; label: string; roles?: User['role'][] }>;
-    items.push({ to: '/provider/pony', label: 'Poney', roles: ['pony_provider', 'admin', 'atlm_collaborator'] });
-    items.push({ to: '/provider/archery', label: "Tir à l'arc", roles: ['archery_provider', 'admin', 'atlm_collaborator'] });
-    items.push({ to: '/provider/luge', label: 'Luge', roles: ['luge_provider', 'admin', 'atlm_collaborator'] });
-    items.push({ to: '/provider/stats', label: 'Statistiques', roles: ['pony_provider','archery_provider','luge_provider','atlm_collaborator','admin'] });
+    const items = [] as Array<{
+      to: string;
+      label: string;
+      roles?: User['role'][];
+    }>;
+    items.push({
+      to: '/provider/pony',
+      label: 'Poney',
+      roles: ['pony_provider', 'admin', 'atlm_collaborator'],
+    });
+    items.push({
+      to: '/provider/archery',
+      label: "Tir à l'arc",
+      roles: ['archery_provider', 'admin', 'atlm_collaborator'],
+    });
+    items.push({
+      to: '/provider/luge',
+      label: 'Luge',
+      roles: ['luge_provider', 'admin', 'atlm_collaborator'],
+    });
+    items.push({
+      to: '/provider/stats',
+      label: 'Statistiques',
+      roles: [
+        'pony_provider',
+        'archery_provider',
+        'luge_provider',
+        'atlm_collaborator',
+        'admin',
+      ],
+    });
     return items.filter((n) => n.roles?.includes(user.role));
   })();
 
@@ -62,7 +94,10 @@ export default function ProviderLayout() {
               ))}
             </nav>
             <button
-              onClick={async () => { await signOut(); setUser(null); }}
+              onClick={async () => {
+                await signOut();
+                setUser(null);
+              }}
               className="flex items-center gap-2 text-sm text-gray-600 hover:text-gray-900"
             >
               <LogOut className="h-4 w-4" />

--- a/src/pages/provider/Stats.tsx
+++ b/src/pages/provider/Stats.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { supabase } from '../../lib/supabase';
 import { logger } from '../../lib/logger';
 import { toast } from 'react-hot-toast';
@@ -58,21 +58,29 @@ export default function ProviderStats() {
     <div className="space-y-6">
       <div className="flex items-center gap-2">
         <BarChart3 className="h-5 w-5 text-blue-600" />
-        <h1 className="text-xl font-semibold">Statistiques (7 derniers jours)</h1>
+        <h1 className="text-xl font-semibold">
+          Statistiques (7 derniers jours)
+        </h1>
       </div>
       <div className="bg-white rounded-lg shadow-sm overflow-hidden">
         <table className="min-w-full divide-y divide-gray-200">
           <thead className="bg-gray-50">
             <tr>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Activité</th>
-              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Validations</th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Activité
+              </th>
+              <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Validations
+              </th>
             </tr>
           </thead>
           <tbody className="bg-white divide-y divide-gray-200">
             {rows.map((r) => (
               <tr key={r.key}>
                 <td className="px-6 py-4 text-sm text-gray-900">{r.label}</td>
-                <td className="px-6 py-4 text-sm text-gray-900">{counts[r.key] || 0}</td>
+                <td className="px-6 py-4 text-sm text-gray-900">
+                  {counts[r.key] || 0}
+                </td>
               </tr>
             ))}
           </tbody>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,8 +1,8 @@
 import '@testing-library/jest-dom';
 import { vi, expect } from 'vitest';
-import React from 'react';
 import { toHaveNoViolations } from 'jest-axe';
 import { installConsoleFilters } from '../lib/consoleFilters';
+import { createElement, type ReactNode } from 'react';
 
 installConsoleFilters();
 
@@ -70,12 +70,14 @@ const createMockQueryBuilder = (): MockBuilder => {
     delete: vi.fn(() => mockBuilder),
     insert: vi.fn(() => mockBuilder),
     update: vi.fn(() => mockBuilder),
-    then: vi.fn((callback?: (arg: { data: unknown[]; error: null }) => unknown) => {
-      if (callback) {
-        return callback({ data: [], error: null });
-      }
-      return Promise.resolve({ data: [], error: null });
-    }),
+    then: vi.fn(
+      (callback?: (arg: { data: unknown[]; error: null }) => unknown) => {
+        if (callback) {
+          return callback({ data: [], error: null });
+        }
+        return Promise.resolve({ data: [], error: null });
+      },
+    ),
   };
 
   return mockBuilder;
@@ -86,13 +88,15 @@ vi.mock('../lib/supabase', () => ({
     from: vi.fn(() => createMockQueryBuilder()),
     rpc: vi.fn(() => Promise.resolve({ data: 10, error: null })),
     select: vi.fn(() => ({
-      count: vi.fn(() => Promise.resolve({ count: 0, error: null }))
+      count: vi.fn(() => Promise.resolve({ count: 0, error: null })),
     })),
     auth: {
       signUp: vi.fn(() => Promise.resolve({ data: null, error: null })),
       signIn: vi.fn(() => Promise.resolve({ data: null, error: null })),
       signOut: vi.fn(() => Promise.resolve({ error: null })),
-      getUser: vi.fn(() => Promise.resolve({ data: { user: null }, error: null })),
+      getUser: vi.fn(() =>
+        Promise.resolve({ data: { user: null }, error: null }),
+      ),
     },
   },
   isSupabaseConfigured: vi.fn(() => true),
@@ -106,9 +110,16 @@ vi.mock('react-router-dom', async () => {
     useNavigate: () => vi.fn(),
     useParams: () => ({ eventId: 'test-event-id' }),
     useLocation: () => ({ pathname: '/' }),
-    Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) =>
-      React.createElement('a', { href: to, ...props }, children),
-    Outlet: () => React.createElement('div', null, 'Outlet'),
+    Link: ({
+      children,
+      to,
+      ...props
+    }: {
+      children: ReactNode;
+      to: string;
+      [key: string]: unknown;
+    }) => createElement('a', { href: to, ...props }, children),
+    Outlet: () => createElement('div', null, 'Outlet'),
   };
 });
 
@@ -119,7 +130,7 @@ vi.mock('react-hot-toast', () => ({
     error: vi.fn(),
     loading: vi.fn(),
   },
-  Toaster: () => React.createElement('div', null, 'Toaster'),
+  Toaster: () => createElement('div', null, 'Toaster'),
 }));
 
 // Mock crypto for UUID generation
@@ -136,7 +147,10 @@ const localStorageMock = {
   removeItem: vi.fn(),
   clear: vi.fn(),
 };
-Object.defineProperty(window, 'localStorage', { value: localStorageMock, configurable: true });
+Object.defineProperty(window, 'localStorage', {
+  value: localStorageMock,
+  configurable: true,
+});
 
 // Mock HTMLAnchorElement.click for download tests
 Object.defineProperty(HTMLAnchorElement.prototype, 'click', {
@@ -149,4 +163,7 @@ class ResizeObserver {
   unobserve() {}
   disconnect() {}
 }
-Object.defineProperty(window, 'ResizeObserver', { value: ResizeObserver, configurable: true });
+Object.defineProperty(window, 'ResizeObserver', {
+  value: ResizeObserver,
+  configurable: true,
+});

--- a/src/test/utils.tsx
+++ b/src/test/utils.tsx
@@ -1,10 +1,10 @@
 /* eslint-disable react-refresh/only-export-components */
-import React from 'react';
 import { render, RenderOptions } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
+import type { ReactNode, ReactElement } from 'react';
 
 // Custom render function with providers
-const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
+const AllTheProviders = ({ children }: { children: ReactNode }) => {
   const futureConfig =
     import.meta.env.MODE === 'test'
       ? undefined
@@ -13,16 +13,12 @@ const AllTheProviders = ({ children }: { children: React.ReactNode }) => {
           v7_relativeSplatPath: true,
         };
 
-  return (
-    <MemoryRouter future={futureConfig}>
-      {children}
-    </MemoryRouter>
-  );
+  return <MemoryRouter future={futureConfig}>{children}</MemoryRouter>;
 };
 
 const customRender = (
-  ui: React.ReactElement,
-  options?: Omit<RenderOptions, 'wrapper'>
+  ui: ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>,
 ) => render(ui, { wrapper: AllTheProviders, ...options });
 
 export * from '@testing-library/react';


### PR DESCRIPTION
## Summary
- drop default `React` imports across components
- keep only required hooks and type imports
- update event handlers to use React types directly

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4e7f8f35c832b87e9eb696f013fd9