### PR TITLE
test: fix stubEnv boolean values

### DIFF
--- a/src/pages/admin/__tests__/EventManagement.test.tsx
+++ b/src/pages/admin/__tests__/EventManagement.test.tsx
@@ -52,8 +52,8 @@ describe('EventManagement', () => {
   });
 
   it('should not output debug logs in production mode', async () => {
-    vi.stubEnv('DEV', 'false');
-    vi.stubEnv('PROD', 'true');
+    vi.stubEnv('DEV', false);
+    vi.stubEnv('PROD', true);
     vi.stubEnv('MODE', 'production'); // reste une chaîne
     vi.stubEnv('VITE_DEBUG', 'true');
 


### PR DESCRIPTION
## Summary
- fix stubbed environment variables to use booleans in EventManagement tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4ee4c4cbc832b960f5d565490d0e7