### PR TITLE
fix(functions): handle cors for checkout session

### DIFF
--- a/supabase/functions/create-checkout-session/index.test.ts
+++ b/supabase/functions/create-checkout-session/index.test.ts
@@ -31,7 +31,15 @@ describe('create-checkout-session edge function', () => {
     await import('./index.ts');
   });
 
-  it('returns 405 for non POST', async () => {
+  it('handles CORS preflight', async () => {
+    const res = await handler(
+      new Request('http://localhost', { method: 'OPTIONS' }),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
+  });
+
+  it('returns 405 for unsupported methods', async () => {
     const res = await handler(new Request('http://localhost')); // GET by default
     expect(res.status).toBe(405);
   });
@@ -59,5 +67,6 @@ describe('create-checkout-session edge function', () => {
     await expect(res.json()).resolves.toEqual({
       url: 'https://stripe.test/session',
     });
+    expect(res.headers.get('access-control-allow-origin')).toBe('*');
   });
 });

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -13,6 +13,12 @@ const stripe = new Stripe(getEnv('STRIPE_SECRET'), {
   apiVersion: '2023-10-16',
 });
 
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers':
+    'authorization, x-client-info, apikey, content-type',
+};
+
 interface CartItem {
   pass: { id: string; name: string; price: number };
   eventActivity?: { id: string };
@@ -26,9 +32,19 @@ interface Customer {
 }
 
 serve(async (req: Request) => {
+  if (req.method === 'OPTIONS') {
+    return new Response('ok', {
+      headers: {
+        ...corsHeaders,
+        'Access-Control-Allow-Methods': 'POST, OPTIONS',
+      },
+    });
+  }
+
   if (req.method !== 'POST') {
     return new Response(JSON.stringify({ error: 'Method not allowed' }), {
       status: 405,
+      headers: corsHeaders,
     });
   }
 
@@ -41,6 +57,7 @@ serve(async (req: Request) => {
     if (!cartItems || cartItems.length === 0 || !customer?.email) {
       return new Response(JSON.stringify({ error: 'Invalid payload' }), {
         status: 400,
+        headers: { ...corsHeaders, 'Content-Type': 'application/json' },
       });
     }
 
@@ -67,11 +84,13 @@ serve(async (req: Request) => {
 
     return new Response(JSON.stringify({ url: session.url }), {
       status: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown error';
     return new Response(JSON.stringify({ error: message }), {
       status: 500,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
     });
   }
 });


### PR DESCRIPTION
## Summary
- add CORS headers to create-checkout-session edge function
- test preflight handling and CORS response headers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b4f1832778832b93353beca369ab6c