### PR TITLE
chore: enforce PO_NOTES update in pre-commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,12 @@
 #!/usr/bin/env sh
 export PATH="$PWD/node_modules/.bin:$PATH"
+BRANCH=$(git rev-parse --abbrev-ref HEAD)
+if [ "$BRANCH" != "main" ]; then
+  if ! git diff --cached --name-only | grep -q "^PO_NOTES.md$"; then
+    echo "PO_NOTES.md must be updated and staged."
+    exit 1
+  fi
+fi
 if command -v git-secrets >/dev/null 2>&1; then
   git-secrets --scan
 fi

--- a/tools/po-notes.cjs
+++ b/tools/po-notes.cjs
@@ -1,5 +1,4 @@
 // tools/po-notes.cjs
-/* eslint-disable no-console */
 const fs = require('fs');
 const { execSync } = require('child_process');
 


### PR DESCRIPTION
## Summary
- ensure commits on non-main branches update `PO_NOTES.md`
- clean up unused eslint-disable directive

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9ac2e81c4832bb64a0d46795ba7f9