### PR TITLE
Sprint S1: align sprint instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,64 +8,70 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
 
 ## 1) Contrats d’exécution
 
-* **Branche** : unique, `work`.
-* **PR** : **une seule PR en fin de sprint** → `work → main`, titre : `Sprint S<N>: <résumé>`.
-* **Timebox** : 25 min (gel **T+22** pour docs/review/rétro/PO\_NOTES).
-* **Autonomie produit** : si besoin, ChatGPT **propose, crée et sélectionne** des US (MVP + qualité irréprochable).
-* **Rôle du PO** : fournit **OK/KO**, **secrets/clé API**, **orientations** dans `PO_NOTES.md`.
-* **Qualité** : respecter `QUALITY-GATES.md` et `DoD.md`.
-* **Sécurité** : pas de secrets en repo ; idempotence ; **RLS/policies** testées ; en‑têtes sécurité ; rate‑limit endpoints publics.
-* **Garde‑fous locaux** : tout commit doit passer le **hook Husky** `.husky/pre-commit`. Aucune dépendance à GitHub Actions.
+- **Branche** : unique, `work`.
+- **PR** : **une seule PR en fin de sprint** → `work → main`, titre : `Sprint S<N>: <résumé>`.
+- **Timebox** : 25 min (gel **T+22** pour docs/review/rétro/PO_NOTES).
+- **Autonomie produit** : si besoin, ChatGPT **propose, crée et sélectionne** des US (MVP + qualité irréprochable).
+- **Rôle du PO** : fournit **OK/KO**, **secrets/clé API**, **orientations** dans `PO_NOTES.md`.
+- **Qualité** : respecter `QUALITY-GATES.md` et `DoD.md`.
+- **Sécurité** : pas de secrets en repo ; idempotence ; **RLS/policies** testées ; en‑têtes sécurité ; rate‑limit endpoints publics.
+- **Garde‑fous locaux** : tout commit doit passer le **hook Husky** `.husky/pre-commit`. Aucune dépendance à GitHub Actions.
 
 ---
 
 ## 2) Mode Sprint (commande : « Passe au sprint suivant »)
 
 1. **Bootstrap & minuteur**
+   - Démarrer un **minuteur 25 min** (checkpoints **T+10**, **T+22**).
+   - Créer `/docs/sprints/S<N>/` si absent et initialiser : `PLAN.md`, `BOARD.md`, `DEMO.md`, `REVIEW.md`, `RETRO.md`, `PREFLIGHT.md`, `INTERACTIONS.yaml` (depuis templates).
 
-   * Démarrer un **minuteur 25 min** (checkpoints **T+10**, **T+22**).
-   * Créer `/docs/sprints/S<N>/` si absent et initialiser : `PLAN.md`, `BOARD.md`, `DEMO.md`, `REVIEW.md`, `RETRO.md`, `PREFLIGHT.md`, `INTERACTIONS.yaml` (depuis templates).
 2. **Pré‑vol (audit existant) → `PREFLIGHT.md`**
+   - **Code** : cartographier endpoints/contrats/tests, relever doublons, **code mort**, dette bloquante ; proposer refactors **≤ timebox**.
+   - **BDD** : état schéma/migrations/RLS/fonctions ; exiger snapshot **`schema.sql`** (ou `unchanged` justifié). Le PO applique les migrations validées.
 
-   * **Code** : cartographier endpoints/contrats/tests, relever doublons, **code mort**, dette bloquante ; proposer refactors **≤ timebox**.
-   * **BDD** : état schéma/migrations/RLS/fonctions ; exiger snapshot **`schema.sql`** (ou `unchanged` justifié). Le PO applique les migrations validées.
-3. **Intégrer review & rétro (apprentissage)** : lire `PO_NOTES.md` & `RETRO.md` ; ajuster pratiques.
+3. **Intégrer review & rétro (apprentissage)** :
+   - Lire `PO_NOTES.md` & `RETRO.md` ; ajuster pratiques.
+   - Consulter `docs/sprints/S<N-1>/INTERACTIONS.yaml` :
+     - US `Delivered` validées par le PO → passer en `Done`.
+     - Corrections demandées → créer les US de fix et ajuster le backlog/capacité.
 4. **Collecte & grooming automatique**
+   - Lire `BACKLOG.md` (`Ready`) et `PO_NOTES.md`.
+   - **Si aucune US `Ready`** :
+     - 1. `PO_NOTES.md` (NEW_FEATURES) → **générer** des US ;
+     - 2. si vide : **discovery produit** alignée MVP, consigner idées, puis **créer** les US.
 
-   * Lire `BACKLOG.md` (`Ready`) et `PO_NOTES.md`.
-   * **Si aucune US `Ready`** :
+   - Toute US auto‑générée : `id,title,value,priority,type`, **≥2 AC**, **note sécurité/RLS**, `links.api` **placeholder**, `origin: auto`, `status: Ready`.
 
-     * 1. `PO_NOTES.md` (NEW\_FEATURES) → **générer** des US ;
-     * 2. si vide : **discovery produit** alignée MVP, consigner idées, puis **créer** les US.
-   * Toute US auto‑générée : `id,title,value,priority,type`, **≥2 AC**, **note sécurité/RLS**, `links.api` **placeholder**, `origin: auto`, `status: Ready`.
 5. **Estimation & capacité**
+   - `sp ∈ {1,2,3,5,8,13}` ; **vélocité** = moyenne `delivered_sp` (3 derniers, défaut 8) ; **capacité** = floor(vel×0.8) ; réserver ≈10 % aux **improvements**.
 
-   * `sp ∈ {1,2,3,5,8,13}` ; **vélocité** = moyenne `delivered_sp` (3 derniers, défaut 8) ; **capacité** = floor(vel×0.8) ; réserver ≈10 % aux **improvements**.
 6. **Planification**
+   - Sélectionner des US jusqu’à la capacité ; marquer `Selected`, `sprint: N`, `sp` dans `BACKLOG.md` et `/docs/sprints/S<N>/PLAN.md`. Initialiser `BOARD.md`.
 
-   * Sélectionner des US jusqu’à la capacité ; marquer `Selected`, `sprint: N`, `sp` dans `BACKLOG.md` et `/docs/sprints/S<N>/PLAN.md`. Initialiser `BOARD.md`.
 7. **Exécution (A→B→C→D), sans PR intermédiaire**
+   - Par US : `Selected → InSprint → Delivered` en passant les **gates** :
+     - **Gate 0 — Préflight** (code+BDD, `schema.sql`).
+     - **Gate A — Serverless/Backend**.
+     - **Gate B — Data**.
+     - **Gate C — Front**.
+     - **Gate D — QA**.
 
-   * Par US : `Selected → InSprint → Done` en passant les **gates** :
+   - Mettre à jour `owner` (serverless→data→frontend→qa) et `BOARD.md`. Déplacer en `Spillover` si dépassement.
 
-     * **Gate 0 — Préflight** (code+BDD, `schema.sql`).
-     * **Gate A — Serverless/Backend**.
-     * **Gate B — Data**.
-     * **Gate C — Front**.
-     * **Gate D — QA**.
-   * Mettre à jour `owner` (serverless→data→frontend→qa) et `BOARD.md`. Déplacer en `Spillover` si dépassement.
 8. **Checkpoint T+22 (gel)** : figer code ; compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, finaliser `PREFLIGHT.md` ; renseigner `INTERACTIONS.yaml` (tests prod).
-9. **Clôture & PR unique** : calculer `committed_sp` vs `delivered_sp`, écrire `SPRINT_HISTORY` ; ouvrir **une PR** `work→main` `Sprint S<N>: …` ; après merge : passer US livrées en `Merged`.
+9. **Clôture & PR unique** : calculer `committed_sp` vs `delivered_sp`, consigner la **vélocité** dans `REVIEW.md` et `SPRINT_HISTORY` ; ouvrir **une PR** `work→main` `Sprint S<N>: …`. Après merge, les US restent en `Delivered` jusqu'à validation PO ; elles passeront en `Done` au sprint suivant.
 
 ---
 
 ## 3) Backlog — statuts & schéma US
 
-* `status`: `Ready | Selected | InSprint | Done | Spillover | Merged`
-* `owner`: `serverless | data | frontend | qa`
-* `sp`: `1|2|3|5|8|13` ; `sprint`: `<N|null>`
-* `type`: `feature | improvement | fix` ; `origin`: `po | auto`
-* `links.api`: contrat d’API/DTO (placeholder accepté pour `origin: auto`)
+- `status`: `Ready | Selected | InSprint | Delivered | Done | Spillover`
+  - `Delivered` : implémenté, QA OK, PR ouverte/mergée en attente validation PO.
+  - `Done` : validé par le PO après merge et tests.
+- `owner`: `serverless | data | frontend | qa`
+- `sp`: `1|2|3|5|8|13` ; `sprint`: `<N|null>`
+- `type`: `feature | improvement | fix` ; `origin`: `po | auto`
+- `links.api`: contrat d’API/DTO (placeholder accepté pour `origin: auto`)
 
 > **Pré‑vol obligatoire** avant implémentation ; `schema.sql` **à jour** ou `unchanged` justifié.
 
@@ -79,28 +85,28 @@ Avant **tout commit**, le hook **`.husky/pre-commit`** doit réussir. Il vérifi
 2. `PREFLIGHT.md` contient **Code audit**, **DB audit**, et **schema.sql RefreshedAt (ISO)** ou **`unchanged`** justifié.
 3. `INTERACTIONS.yaml` contient une entrée **Sprint S<N>** (tests prod à exécuter).
 4. `BACKLOG.md` :
+   - US `origin: auto` en `Delivered` ou `Done` → **`links.api`** présent, **≥2 AC**, **note sécurité/RLS**.
+   - US `Delivered` ou `Done` → `sp` et `type` présents.
 
-   * US `origin: auto` en `Done` → **`links.api`** présent, **≥2 AC**, **note sécurité/RLS**.
-   * US `Done` → `sp` et `type` présents.
 5. Si des **migrations** sont modifiées → `schema.sql` est mis à jour, **ou** `PREFLIGHT.md` justifie `unchanged`. ⚠️ **ChatGPT ne les applique pas**, le PO exécute les commandes fournies.
 
 ---
 
 ## 5) Rôles & switching (rappel)
 
-* ChatGPT joue **tous les rôles techniques** ; le **PO** valide et fournit secrets/orientations.
-* Ordre par US : **Gate 0** → **A (serverless)** → **B (data)** → **C (front)** → **D (qa)** ; `owner` reflète le rôle courant.
+- ChatGPT joue **tous les rôles techniques** ; le **PO** valide et fournit secrets/orientations.
+- Ordre par US : **Gate 0** → **A (serverless)** → **B (data)** → **C (front)** → **D (qa)** ; `owner` reflète le rôle courant.
 
 ---
 
 ## 6) Journal PO & décisions
 
-* À chaque sprint, ajouter une entrée **horodatée** dans `/docs/sprints/S<N>/INTERACTIONS.yaml` :
+- À chaque sprint, **ChatGPT** ajoute une entrée **horodatée** dans `/docs/sprints/S<N>/INTERACTIONS.yaml` :
+  - `topic: Sprint S<N> — validation prod`
+  - `ask:` étapes de test simples
+  - `context:` env/URL utiles
 
-  * `topic: Sprint S<N> — validation prod`
-  * `ask:` étapes de test simples
-  * `context:` env/URL utiles
-* Le PO répond **OK/KO** ; ChatGPT ajuste le backlog (fix/Spillover) et la capacité du sprint suivant (vélocité).
+- Le PO répond **OK/KO** (sans horodatage) ; ChatGPT ajuste le backlog (fix/Spillover) et la capacité du sprint suivant (vélocité).
 
 ---
 
@@ -108,5 +114,5 @@ Avant **tout commit**, le hook **`.husky/pre-commit`** doit réussir. Il vérifi
 
 Toute dérogation (scope, qualité, sécurité) doit être :
 
-* mentionnée dans `/docs/sprints/S<N>/REVIEW.md`, et
-* ajoutée en **improvement** dans `/docs/sprints/S<N>/RETRO.md` avec action corrective planifiée.
+- mentionnée dans `/docs/sprints/S<N>/REVIEW.md`, et
+- ajoutée en **improvement** dans `/docs/sprints/S<N>/RETRO.md` avec action corrective planifiée.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,6 @@
 # BACKLOG — Billeterie Maïdo (MVP)
 
-> Statuts US : `Ready | Selected | InSprint | Done | Spillover | Merged`
+> Statuts US : `Ready | Selected | InSprint | Delivered | Done | Spillover`
 > Champs : `owner`, `sp`, `sprint`, `type` (feature|improvement|fix), `origin` (po|auto), `links.api`
 
 ---
@@ -287,4 +287,4 @@ ac:
 - Une **note sécurité/RLS** dans `notes:`
 - Un lien `links.api` (placeholder accepté)
 
-> Le hook Husky vérifie ces règles pour toute US `origin: auto` passée en `Done`.
+> Le hook Husky vérifie ces règles pour toute US `origin: auto` passée en `Delivered`.

--- a/QA_CHECKLIST.md
+++ b/QA_CHECKLIST.md
@@ -8,11 +8,11 @@
 
 **Objectif** : vérifier l’existant et figer le plan minimal.
 
-* [ ] `/docs/sprints/S<N>/PREFLIGHT.md` rempli (sections 1→8)
-* [ ] **Code audit** : doublons / code mort listés + décision (supprimer/refactor ≤ timebox)
-* [ ] **DB audit** : tables/colonnes, RLS/policies, fonctions, **écarts** et migrations envisagées
-* [ ] **`schema.sql`** : `RefreshedAt` (ISO) **ou** `unchanged` **justifié**
-* [ ] **Plan d’action** (nettoyages/refactors ≤ timebox) défini
+- [ ] `/docs/sprints/S<N>/PREFLIGHT.md` rempli (sections 1→8)
+- [ ] **Code audit** : doublons / code mort listés + décision (supprimer/refactor ≤ timebox)
+- [ ] **DB audit** : tables/colonnes, RLS/policies, fonctions, **écarts** et migrations envisagées
+- [ ] **`schema.sql`** : `RefreshedAt` (ISO) **ou** `unchanged` **justifié**
+- [ ] **Plan d’action** (nettoyages/refactors ≤ timebox) défini
 
 **Preuves** : `PREFLIGHT.md` ; diff `schema.sql` si rafraîchi
 
@@ -22,10 +22,10 @@
 
 **Objectif** : contrats stables, logique robuste, idempotence.
 
-* [ ] Contrats d’API/DTO (validation entrée – Zod/FluentValidation) + erreurs normalisées
-* [ ] Idempotence (webhooks/validations) + déduplication
-* [ ] Tests **unitaires & intégration** verts (incl. erreurs)
-* [ ] Logs structurés (correlation id), pas de PII
+- [ ] Contrats d’API/DTO (validation entrée – Zod/FluentValidation) + erreurs normalisées
+- [ ] Idempotence (webhooks/validations) + déduplication
+- [ ] Tests **unitaires & intégration** verts (incl. erreurs)
+- [ ] Logs structurés (correlation id), pas de PII
 
 **Preuves** : fichiers contrats, tests, extraits logs / README section API
 
@@ -35,10 +35,10 @@
 
 **Objectif** : intégrité & sécurité des données.
 
-* [ ] **Migrations** versionnées + scripts de rollback
-* [ ] **RLS/policies** testées par rôle (fixtures auto/seed)
-* [ ] Index/constraints en place (PK/UK/FK, unique, check)
-* [ ] Fonctions SQL atomiques + **tests de concurrence** (verrouillage / sérialisation)
+- [ ] **Migrations** versionnées + scripts de rollback
+- [ ] **RLS/policies** testées par rôle (fixtures auto/seed)
+- [ ] Index/constraints en place (PK/UK/FK, unique, check)
+- [ ] Fonctions SQL atomiques + **tests de concurrence** (verrouillage / sérialisation)
 
 **Preuves** : migrations, tests RLS/concurrence, `schema.sql` ou justification
 
@@ -48,9 +48,9 @@
 
 **Objectif** : UX accessible et performante.
 
-* [ ] UI responsive ; i18n si prévu ; états `loading/empty/error/success`
-* [ ] Lighthouse **a11y & perf ≥ 90** (capture rapport)
-* [ ] VRT OK (si configuré) ; intégration contrats (types sûrs)
+- [ ] UI responsive ; i18n si prévu ; états `loading/empty/error/success`
+- [ ] Lighthouse **a11y & perf ≥ 90** (capture rapport)
+- [ ] VRT OK (si configuré) ; intégration contrats (types sûrs)
 
 **Preuves** : captures Lighthouse, snapshots VRT, checklists a11y
 
@@ -60,9 +60,9 @@
 
 **Objectif** : valider le flux bout‑en‑bout et les garde‑fous sécurité.
 
-* [ ] E2E **happy path** + **≥ 2 cas d’erreur** critiques
-* [ ] Tests rôle/RLS ; **charge ciblée** si endpoint critique
-* [ ] `QA_CHECKLIST.md` coché
+- [ ] E2E **happy path** + **≥ 2 cas d’erreur** critiques
+- [ ] Tests rôle/RLS ; **charge ciblée** si endpoint critique
+- [ ] `QA_CHECKLIST.md` coché
 
 **Preuves** : rapports tests (E2E/charge), `QA_CHECKLIST.md`
 
@@ -72,11 +72,11 @@
 
 **Objectif** : livrer, documenter, préparer la validation PO et la rétro.
 
-* [ ] `PLAN.md` (capacité & SP) à jour
-* [ ] `BOARD.md` à jour (`Selected → InSprint → Done → Spillover`)
-* [ ] `DEMO.md`, `REVIEW.md`, `RETRO.md` présents et complétés à **T+22**
-* [ ] `/docs/sprints/S<N>/INTERACTIONS.yaml` contient l’entrée **Sprint S<N>** (tests prod)
-* [ ] `CHANGELOG.md` **\[Unreleased]** mis à jour
+- [ ] `PLAN.md` (capacité & SP) à jour
+- [ ] `BOARD.md` à jour (`Selected → InSprint → Delivered → Spillover`)
+- [ ] `DEMO.md`, `REVIEW.md`, `RETRO.md` présents et complétés à **T+22**
+- [ ] `/docs/sprints/S<N>/INTERACTIONS.yaml` contient l’entrée **Sprint S<N>** (tests prod)
+- [ ] `CHANGELOG.md` **\[Unreleased]** mis à jour
 
 **Preuves** : fichiers sprint, `INTERACTIONS.yaml`
 
@@ -84,6 +84,6 @@
 
 ## Conditions d’échec (bloquantes pre‑commit)
 
-* Une des cases ci‑dessus non cochée → **commit bloqué** par `.husky/pre-commit`
-* US `origin: auto` en `Done` **sans** `links.api` **ou** **< 2 AC** **ou** **sans note sécurité/RLS** → **commit bloqué**
-* Migrations modifiées **sans** mise à jour de `schema.sql` **et sans** justification `unchanged` dans `PREFLIGHT.md` → **commit bloqué**
+- Une des cases ci‑dessus non cochée → **commit bloqué** par `.husky/pre-commit`
+- US `origin: auto` en `Delivered` **sans** `links.api` **ou** **< 2 AC** **ou** **sans note sécurité/RLS** → **commit bloqué**
+- Migrations modifiées **sans** mise à jour de `schema.sql` **et sans** justification `unchanged` dans `PREFLIGHT.md` → **commit bloqué**

--- a/QUALITY-GATES.md
+++ b/QUALITY-GATES.md
@@ -8,11 +8,11 @@
 
 **Objectif** : vérifier l’existant et figer le plan minimal.
 
-* [ ] `/docs/sprints/S<N>/PREFLIGHT.md` rempli (sections 1→8)
-* [ ] **Code audit** : doublons / code mort listés + décision (supprimer/refactor ≤ timebox)
-* [ ] **DB audit** : tables/colonnes, RLS/policies, fonctions, **écarts** et migrations envisagées
-* [ ] **`schema.sql`** : `RefreshedAt` (ISO) **ou** `unchanged` **justifié**
-* [ ] **Plan d’action** (nettoyages/refactors ≤ timebox) défini
+- [ ] `/docs/sprints/S<N>/PREFLIGHT.md` rempli (sections 1→8)
+- [ ] **Code audit** : doublons / code mort listés + décision (supprimer/refactor ≤ timebox)
+- [ ] **DB audit** : tables/colonnes, RLS/policies, fonctions, **écarts** et migrations envisagées
+- [ ] **`schema.sql`** : `RefreshedAt` (ISO) **ou** `unchanged` **justifié**
+- [ ] **Plan d’action** (nettoyages/refactors ≤ timebox) défini
 
 **Preuves** : `PREFLIGHT.md` ; diff `schema.sql` si rafraîchi
 
@@ -22,10 +22,10 @@
 
 **Objectif** : contrats stables, logique robuste, idempotence.
 
-* [ ] Contrats d’API/DTO (validation entrée – Zod/FluentValidation) + erreurs normalisées
-* [ ] Idempotence (webhooks/validations) + déduplication
-* [ ] Tests **unitaires & intégration** verts (incl. erreurs)
-* [ ] Logs structurés (correlation id), pas de PII
+- [ ] Contrats d’API/DTO (validation entrée – Zod/FluentValidation) + erreurs normalisées
+- [ ] Idempotence (webhooks/validations) + déduplication
+- [ ] Tests **unitaires & intégration** verts (incl. erreurs)
+- [ ] Logs structurés (correlation id), pas de PII
 
 **Preuves** : fichiers contrats, tests, extraits logs / README section API
 
@@ -35,10 +35,10 @@
 
 **Objectif** : intégrité & sécurité des données.
 
-* [ ] **Migrations** versionnées + scripts de rollback
-* [ ] **RLS/policies** testées par rôle (fixtures auto/seed)
-* [ ] Index/constraints en place (PK/UK/FK, unique, check)
-* [ ] Fonctions SQL atomiques + **tests de concurrence** (verrouillage / sérialisation)
+- [ ] **Migrations** versionnées + scripts de rollback
+- [ ] **RLS/policies** testées par rôle (fixtures auto/seed)
+- [ ] Index/constraints en place (PK/UK/FK, unique, check)
+- [ ] Fonctions SQL atomiques + **tests de concurrence** (verrouillage / sérialisation)
 
 **Preuves** : migrations, tests RLS/concurrence, `schema.sql` ou justification
 
@@ -48,9 +48,9 @@
 
 **Objectif** : UX accessible et performante.
 
-* [ ] UI responsive ; i18n si prévu ; états `loading/empty/error/success`
-* [ ] Lighthouse **a11y & perf ≥ 90** (capture rapport)
-* [ ] VRT OK (si configuré) ; intégration contrats (types sûrs)
+- [ ] UI responsive ; i18n si prévu ; états `loading/empty/error/success`
+- [ ] Lighthouse **a11y & perf ≥ 90** (capture rapport)
+- [ ] VRT OK (si configuré) ; intégration contrats (types sûrs)
 
 **Preuves** : captures Lighthouse, snapshots VRT, checklists a11y
 
@@ -60,9 +60,9 @@
 
 **Objectif** : valider le flux bout‑en‑bout et les garde‑fous sécurité.
 
-* [ ] E2E **happy path** + **≥ 2 cas d’erreur** critiques
-* [ ] Tests rôle/RLS ; **charge ciblée** si endpoint critique
-* [ ] `QA_CHECKLIST.md` coché
+- [ ] E2E **happy path** + **≥ 2 cas d’erreur** critiques
+- [ ] Tests rôle/RLS ; **charge ciblée** si endpoint critique
+- [ ] `QA_CHECKLIST.md` coché
 
 **Preuves** : rapports tests (E2E/charge), `QA_CHECKLIST.md`
 
@@ -72,11 +72,11 @@
 
 **Objectif** : livrer, documenter, préparer la validation PO et la rétro.
 
-* [ ] `PLAN.md` (capacité & SP) à jour
-* [ ] `BOARD.md` à jour (`Selected → InSprint → Done → Spillover`)
-* [ ] `DEMO.md`, `REVIEW.md`, `RETRO.md` présents et complétés à **T+22**
-* [ ] `/docs/sprints/S<N>/INTERACTIONS.yaml` contient l’entrée **Sprint S<N>** (tests prod)
-* [ ] `CHANGELOG.md` **\[Unreleased]** mis à jour
+- [ ] `PLAN.md` (capacité & SP) à jour
+- [ ] `BOARD.md` à jour (`Selected → InSprint → Delivered → Spillover`)
+- [ ] `DEMO.md`, `REVIEW.md`, `RETRO.md` présents et complétés à **T+22**
+- [ ] `/docs/sprints/S<N>/INTERACTIONS.yaml` contient l’entrée **Sprint S<N>** (tests prod)
+- [ ] `CHANGELOG.md` **\[Unreleased]** mis à jour
 
 **Preuves** : fichiers sprint, `INTERACTIONS.yaml`
 
@@ -84,6 +84,6 @@
 
 ## Conditions d’échec (bloquantes pre‑commit)
 
-* Une des cases ci‑dessus non cochée → **commit bloqué** par `.husky/pre-commit`
-* US `origin: auto` en `Done` **sans** `links.api` **ou** **< 2 AC** **ou** **sans note sécurité/RLS** → **commit bloqué**
-* Migrations modifiées **sans** mise à jour de `schema.sql` **et sans** justification `unchanged` dans `PREFLIGHT.md` → **commit bloqué**
+- Une des cases ci‑dessus non cochée → **commit bloqué** par `.husky/pre-commit`
+- US `origin: auto` en `Delivered` **sans** `links.api` **ou** **< 2 AC** **ou** **sans note sécurité/RLS** → **commit bloqué**
+- Migrations modifiées **sans** mise à jour de `schema.sql` **et sans** justification `unchanged` dans `PREFLIGHT.md` → **commit bloqué**

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 
 ## 1) Pré‑requis & installation
 
-* Windows 11, PowerShell 7+
-* Node.js 20+, npm
-* (Selon stack) Supabase CLI **ou** outils SQL Server
-* Comptes/API : Stripe (clé test), service d’email (clé API)
+- Windows 11, PowerShell 7+
+- Node.js 20+, npm
+- (Selon stack) Supabase CLI **ou** outils SQL Server
+- Comptes/API : Stripe (clé test), service d’email (clé API)
 
 ### Variables d’environnement
 
@@ -19,7 +19,7 @@ SUPABASE_URL=...
 SUPABASE_ANON_KEY=...
 ```
 
-*(Ne pas committer de secrets)*
+_(Ne pas committer de secrets)_
 
 ---
 
@@ -39,13 +39,13 @@ supabase functions serve
 
 > À exécuter **par le PO** sur demande de ChatGPT (Gate 0 – Préflight). ChatGPT **ne lance pas** de migrations.
 
-* **Supabase/Postgres** :
+- **Supabase/Postgres** :
 
 ```powershell
 supabase db dump --schema public -f schema.sql
 ```
 
-* **SQL Server** :
+- **SQL Server** :
 
 ```powershell
 sqlpackage /Action:Export /SourceConnectionString:"<...>" /TargetFile:schema.sql
@@ -68,15 +68,15 @@ npx husky install
 
 ### Ce que vérifie `.husky/pre-commit`
 
-* Artefacts sprint présents : `/docs/sprints/S<N>/{PLAN.md, BOARD.md, DEMO.md, REVIEW.md, RETRO.md, PREFLIGHT.md, INTERACTIONS.yaml}`
-* `PREFLIGHT.md` contient **Code audit**, **DB audit** et **schema.sql RefreshedAt (ISO)** ou **`unchanged` justifié**
-* `INTERACTIONS.yaml` du sprint est **stagé** et contient `topic: Sprint S<N> — …`
-* `BACKLOG.md` :
+- Artefacts sprint présents : `/docs/sprints/S<N>/{PLAN.md, BOARD.md, DEMO.md, REVIEW.md, RETRO.md, PREFLIGHT.md, INTERACTIONS.yaml}`
+- `PREFLIGHT.md` contient **Code audit**, **DB audit** et **schema.sql RefreshedAt (ISO)** ou **`unchanged` justifié**
+- `INTERACTIONS.yaml` du sprint est **stagé** et contient `topic: Sprint S<N> — …`
+- `BACKLOG.md` :
+  - US `origin: auto` en `Delivered` → **`links.api`**, **≥ 2 AC**, **note sécurité/RLS**
+  - US `Delivered` → `sp` et `type` présents
 
-  * US `origin: auto` en `Done` → **`links.api`**, **≥ 2 AC**, **note sécurité/RLS**
-  * US `Done` → `sp` et `type` présents
-* Si **migrations** modifiées → `schema.sql` mis à jour **ou** justification `unchanged` dans `PREFLIGHT.md`
-* `git-secrets --scan` si dispo, puis `npm run lint && npm test && lint-staged`
+- Si **migrations** modifiées → `schema.sql` mis à jour **ou** justification `unchanged` dans `PREFLIGHT.md`
+- `git-secrets --scan` si dispo, puis `npm run lint && npm test && lint-staged`
 
 > Si un point échoue, **le commit est bloqué**. Corrigez puis recommittez.
 
@@ -87,26 +87,26 @@ npx husky install
 1. **Déclencheur** : « **Passe au sprint suivant** »
 2. **Gate 0 — Pré‑vol** : remplir `PREFLIGHT.md` (audit code + BDD, `schema.sql`)
 3. **Planification** : estimer en **SP** (1,2,3,5,8,13), capacité = vélocité×0.8 (+10% improvements) → `PLAN.md`
-4. **Exécution** : A→B→C→D, mise à jour `BOARD.md` (**Selected → InSprint → Done → Spillover**)
+4. **Exécution** : A→B→C→D, mise à jour `BOARD.md` (**Selected → InSprint → Delivered → Spillover**)
 5. **Gel T+22** : compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, consigner l’entrée **INTERACTIONS** (tests prod) dans `/docs/sprints/S<N>/INTERACTIONS.yaml`
 6. **PR unique** : `work → main`, titre `Sprint S<N>: …`
 
 **Rappels**
 
-* Branche **unique** : `work`
-* **Une seule PR** en fin de sprint
-* **Pré‑vol obligatoire** ; `schema.sql` **à jour** (ou `unchanged` justifié)
-* **Migrations** : ChatGPT **documente** ; le **PO** les **applique**
+- Branche **unique** : `work`
+- **Une seule PR** en fin de sprint
+- **Pré‑vol obligatoire** ; `schema.sql` **à jour** (ou `unchanged` justifié)
+- **Migrations** : ChatGPT **documente** ; le **PO** les **applique**
 
 ---
 
 ## 5) Backlog & user stories
 
-* `status` : `Ready → Selected → InSprint → Done → Spillover → Merged`
-* `owner` : `serverless | data | frontend | qa`
-* `sp` : `1|2|3|5|8|13` ; `sprint` : `<N|null>`
-* `type` : `feature | improvement | fix` ; `origin` : `po | auto`
-* `links.api` : chemin d’un contrat d’API/DTO (placeholder accepté pour `origin: auto`)
+- `status` : `Ready → Selected → InSprint → Delivered → Done → Spillover`
+- `owner` : `serverless | data | frontend | qa`
+- `sp` : `1|2|3|5|8|13` ; `sprint` : `<N|null>`
+- `type` : `feature | improvement | fix` ; `origin` : `po | auto`
+- `links.api` : chemin d’un contrat d’API/DTO (placeholder accepté pour `origin: auto`)
 
 **Autogrooming** : si aucune US **Ready**, ChatGPT génère des US (MVP) avec **≥2 AC**, **note sécurité/RLS**, `links.api` placeholder.
 
@@ -114,14 +114,13 @@ npx husky install
 
 ## 6) Qualité & sécurité
 
-* **Quality Gates** : `QUALITY-GATES.md` (Gate 0/A/B/C/D/S)
-* **DoD** : CI locale verte, couverture ≥ 80% des nouvelles lignes, docs à jour, sécurité OK
-* **Sécurité** :
-
-  * Jamais de secrets en repo/PR
-  * Webhooks Stripe **signés**, logique **idempotente**
-  * **RLS/policies** testées (admin, parc, prestataires, customer)
-  * Logs structurés (corrélation), pas de PII
+- **Quality Gates** : `QUALITY-GATES.md` (Gate 0/A/B/C/D/S)
+- **DoD** : CI locale verte, couverture ≥ 80% des nouvelles lignes, docs à jour, sécurité OK
+- **Sécurité** :
+  - Jamais de secrets en repo/PR
+  - Webhooks Stripe **signés**, logique **idempotente**
+  - **RLS/policies** testées (admin, parc, prestataires, customer)
+  - Logs structurés (corrélation), pas de PII
 
 ---
 
@@ -145,13 +144,13 @@ DoD.md                     # Definition of Done
 
 ## 8) Dépannage
 
-* **Commit bloqué** : lire le message du hook, compléter l’artefact manquant (PREFLIGHT/DEMO/… ou INTERACTIONS)
-* **Migrations modifiées** : mettre à jour `schema.sql` ou justifier `unchanged` dans `PREFLIGHT.md`
-* **Lighthouse < 90** : optimiser images, lazy‑load, réduire JS bloquant, corriger a11y (labels/contraste)
+- **Commit bloqué** : lire le message du hook, compléter l’artefact manquant (PREFLIGHT/DEMO/… ou INTERACTIONS)
+- **Migrations modifiées** : mettre à jour `schema.sql` ou justifier `unchanged` dans `PREFLIGHT.md`
+- **Lighthouse < 90** : optimiser images, lazy‑load, réduire JS bloquant, corriger a11y (labels/contraste)
 
 ---
 
 ## 9) Rôle du PO
 
-* Le **PO** fournit **OK/KO**, **secrets/clé API**, et **exécute** les actions listées par ChatGPT dans `ACTIONS_PO`.
-* ChatGPT gère **grooming**, **planification**, **exécution** et **documentation** du sprint timeboxé.
+- Le **PO** fournit **OK/KO**, **secrets/clé API**, et **exécute** les actions listées par ChatGPT dans `ACTIONS_PO`.
+- ChatGPT gère **grooming**, **planification**, **exécution** et **documentation** du sprint timeboxé.

--- a/docs/sprints/S1/BOARD.md
+++ b/docs/sprints/S1/BOARD.md
@@ -10,20 +10,20 @@
 
 > Déplacer les US sélectionnées dans la colonne correspondante. Chaque transition doit être justifiée dans les artefacts sprint.
 
-| ID    | Title                     | SP  | Owner | Status |
-| ----- | ------------------------- | --- | ----- | ------ |
-| US-10 | Parcourir offres & passes | 3   | qa    | Done   |
-| US-11 | Panier + CGV              | 3   | qa    | Done   |
+| ID    | Title                     | SP  | Owner | Status    |
+| ----- | ------------------------- | --- | ----- | --------- |
+| US-10 | Parcourir offres & passes | 3   | qa    | Delivered |
+| US-11 | Panier + CGV              | 3   | qa    | Delivered |
 
 ## 3) Légende statuts
 
 - **Selected**: choisi dans le plan, pas encore commencé
 - **InSprint**: en cours d’implémentation (A→B→C→D)
-- **Done**: terminé et validé QA (prêt PR)
+- **Delivered**: terminé et validé QA (PR ouverte/mergée, en attente validation PO)
 - **Spillover**: non terminé, reporté
 
 ## 4) Notes
 
 - Chaque US doit avoir `sp`, `owner`, `origin`, `type`, `links.api` si `origin:auto`
-- Le hook Husky bloque si une US `origin:auto` est `Done` **sans** `links.api` ou **<2 AC** ou **pas de note sécurité/RLS**
+- Le hook Husky bloque si une US `origin:auto` est `Delivered` **sans** `links.api` ou **<2 AC** ou **pas de note sécurité/RLS**
 - Les transitions doivent être cohérentes avec `BACKLOG.md`

--- a/docs/sprints/S1/INTERACTIONS.yaml
+++ b/docs/sprints/S1/INTERACTIONS.yaml
@@ -15,9 +15,8 @@
   status: pending
   note: sprint history updated
 
-- who: PO
-  when: 2025-09-04T22:41:15+00:00
-  topic: Sprint S1 — validation prod
+  - who: PO
+    topic: Sprint S1 — validation prod
   reply: KO
   details: |
     - Je n'ai pas pu afficher les passes pour vérifier l'affichage des créneaux 

--- a/docs/templates/BOARD.md
+++ b/docs/templates/BOARD.md
@@ -2,30 +2,30 @@
 
 ## 1) Métadonnées
 
-* **Sprint**: S<N>
-* **Branche**: `work`
-* **Timebox**: 25 min (gel **T+22**)
+- **Sprint**: S<N>
+- **Branche**: `work`
+- **Timebox**: 25 min (gel **T+22**)
 
 ## 2) Kanban du sprint
 
 > Déplacer les US sélectionnées dans la colonne correspondante. Chaque transition doit être justifiée dans les artefacts sprint.
 
-| ID    | Title | SP | Owner      | Status    |
-| ----- | ----- | -- | ---------- | --------- |
-| US-.. | …     | 3  | serverless | Selected  |
-| US-.. | …     | 2  | data       | InSprint  |
-| US-.. | …     | 5  | frontend   | Done      |
-| US-.. | …     | 3  | qa         | Spillover |
+| ID    | Title | SP  | Owner      | Status    |
+| ----- | ----- | --- | ---------- | --------- |
+| US-.. | …     | 3   | serverless | Selected  |
+| US-.. | …     | 2   | data       | InSprint  |
+| US-.. | …     | 5   | frontend   | Delivered |
+| US-.. | …     | 3   | qa         | Spillover |
 
 ## 3) Légende statuts
 
-* **Selected**: choisi dans le plan, pas encore commencé
-* **InSprint**: en cours d’implémentation (A→B→C→D)
-* **Done**: terminé et validé QA (prêt PR)
-* **Spillover**: non terminé, reporté
+- **Selected**: choisi dans le plan, pas encore commencé
+- **InSprint**: en cours d’implémentation (A→B→C→D)
+- **Delivered**: terminé et validé QA (PR ouverte/mergée, en attente validation PO)
+- **Spillover**: non terminé, reporté
 
 ## 4) Notes
 
-* Chaque US doit avoir `sp`, `owner`, `origin`, `type`, `links.api` si `origin:auto`
-* Le hook Husky bloque si une US `origin:auto` est `Done` **sans** `links.api` ou **<2 AC** ou **pas de note sécurité/RLS**
-* Les transitions doivent être cohérentes avec `BACKLOG.md`
+- Chaque US doit avoir `sp`, `owner`, `origin`, `type`, `links.api` si `origin:auto`
+- Le hook Husky bloque si une US `origin:auto` est `Delivered` **sans** `links.api` ou **<2 AC** ou **pas de note sécurité/RLS**
+- Les transitions doivent être cohérentes avec `BACKLOG.md`


### PR DESCRIPTION
## Summary
- document Delivered status before PO validation
- remove PO timestamps in sprint interactions
- update templates and quality gates for new workflow

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba27a1a244832b80170d7c9949866c