### PR TITLE
Sprint S1: align workflow with PO validation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
    - Consulter `docs/sprints/S<N-1>/INTERACTIONS.yaml` :
      - US `Delivered` validées par le PO → passer en `Done`.
      - Corrections demandées → créer les US de fix et ajuster le backlog/capacité.
+     - Ce fichier prévaut sur `REVIEW.md` pour l'état des US ; en cas de `reply: KO`, laisser l'US en `Delivered`.
 4. **Collecte & grooming automatique**
    - Lire `BACKLOG.md` (`Ready`) et `PO_NOTES.md`.
    - **Si aucune US `Ready`** :
@@ -103,10 +104,11 @@ Avant **tout commit**, le hook **`.husky/pre-commit`** doit réussir. Il vérifi
 
 - À chaque sprint, **ChatGPT** ajoute une entrée **horodatée** dans `/docs/sprints/S<N>/INTERACTIONS.yaml` :
   - `topic: Sprint S<N> — validation prod`
-  - `ask:` étapes de test simples
-  - `context:` env/URL utiles
+- `ask:` étapes de test simples
+- `context:` env/URL utiles
 
 - Le PO répond **OK/KO** (sans horodatage) ; ChatGPT ajuste le backlog (fix/Spillover) et la capacité du sprint suivant (vélocité).
+  - Les réponses du PO dans `INTERACTIONS.yaml` font foi et priment sur `REVIEW.md` ou tout autre artefact.
 
 ---
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -85,7 +85,7 @@ persona: client
 title: Parcourir offres & passes
 value: choisir facilement
 priority: P1
-status: Done
+status: Delivered
 owner: qa
 sp: 3
 sprint: 1
@@ -104,7 +104,7 @@ persona: client
 title: Panier + CGV
 value: préparer ma commande
 priority: P1
-status: Done
+status: Delivered
 owner: qa
 sp: 3
 sprint: 1
@@ -134,6 +134,29 @@ links:
 ac:
   - Redirection Checkout + retour success/cancel
   - Email confirmation avec n° de réservation + QR
+```
+
+### US-13
+
+```yaml
+id: US-13
+persona: client
+title: Corriger liste passes (fonction get_passes_with_activities)
+value: pouvoir vérifier les passes en prod
+priority: P1
+status: Ready
+owner: data
+sp: 1
+sprint: null
+type: fix
+origin: po
+links:
+  - api: ./src/shared/contracts/passes.ts
+ac:
+  - Fonction SQL get_passes_with_activities(event_uuid) disponible via Supabase
+  - Page Passes affiche les passes sans erreur et badge "Créneau requis" le cas échéant
+notes:
+  - RLS: vérifier que la fonction respecte les policies existantes
 ```
 
 ---

--- a/PO_NOTES.md
+++ b/PO_NOTES.md
@@ -14,6 +14,7 @@
 - **Journal d’interaction** :
   - Écrire dans `INTERACTIONS.yaml` une **entrée horodatée** avec : `did` (fait/livré), `ask` (tests prod PO), `context` (URLs, comptes de test), `status: pending`.
   - Le **PO** répond **dans le même fichier** (`who: PO`, `reply: OK|KO`, `details`).
+  - En cas de reprise du développement, se fier au **dernier** `INTERACTIONS.yaml` (PO), qui prime sur `REVIEW.md` ou tout autre artefact.
 
 - **Seeds & fixtures** : ChatGPT **génère/maintient** les scripts/fixtures et fournit **une commande** (ex. `npm run seed`, `dotnet run --project tools/Seeder`, `psql -f seed.sql`). Le PO **exécute la commande** si demandé.
 - **Migrations & schéma** : ChatGPT **propose** les migrations et documente les commandes. Le **PO** les **applique** si validées. `schema.sql` est **rafraîchi par le PO** ou noté `unchanged` (justifié) dans `PREFLIGHT.md`.

--- a/SPRINT_HISTORY.md
+++ b/SPRINT_HISTORY.md
@@ -1,3 +1,3 @@
 # SPRINT_HISTORY
 
-- Sprint S1 (2025-09-04): committed 6 SP, delivered 6 SP, focus 1.0
+- Sprint S1 (2025-09-04): committed 6 SP, delivered 6 SP, focus 1.0, PO KO (fonction get_passes_with_activities manquante)

--- a/docs/sprints/S1/INTERACTIONS.yaml
+++ b/docs/sprints/S1/INTERACTIONS.yaml
@@ -15,12 +15,21 @@
   status: pending
   note: sprint history updated
 
-  - who: PO
-    topic: Sprint S1 — validation prod
+- who: PO
+  topic: Sprint S1 — validation prod
   reply: KO
   details: |
-    - Je n'ai pas pu afficher les passes pour vérifier l'affichage des créneaux 
+    - Je n'ai pas pu afficher les passes pour vérifier l'affichage des créneaux
     - error POST https://rvotxqsgaolddvpqbkhy.supabase.co/rest/v1/rpc/get_passes_with_activities 404 (Not Found)
-    - Erreur chargement événement: |
-      - {code: 'PGRST202', details: 'Searched for the function public.get_passes_with_a…r, but no matches were found in the schema cache.', hint: 'Perhaps you meant to call the function public.get_pass_max_stock_from_activities', message: 'Could not find the function public.get_passes_with_activities(event_uuid) in the schema cache'}
+    - Erreur chargement événement:
+      - {code: 'PGRST202', details: 'Searched for the function public.get_passes_with_activities, but no matches were found in the schema cache.', hint: 'Perhaps you meant to call the function public.get_pass_max_stock_from_activities', message: 'Could not find the function public.get_passes_with_activities(event_uuid) in the schema cache'}
   action: fix
+
+- who: ChatGPT
+  when: 2025-09-04T23:10:00+00:00
+  topic: Sprint S1 — workflow update
+  did: |
+    - Mis à jour BACKLOG, REVIEW et SPRINT_HISTORY suite au KO du PO
+    - Ajouté US-13 pour corriger get_passes_with_activities
+    - Clarifié dans les instructions la priorité d'INTERACTIONS.yaml
+  status: n/a

--- a/docs/sprints/S1/REVIEW.md
+++ b/docs/sprints/S1/REVIEW.md
@@ -17,17 +17,17 @@
 
 ## 3) Objectifs atteints
 
-- US-10 ✔️
-- US-11 ✔️
+- US-10 ❌ (fonction get_passes_with_activities absente)
+- US-11 ❌ (non validée suite au bug précédent)
 
 ## 4) Dérogations / écarts
 
-- Aucune dérogation
+- Validation PO KO : erreur 404 sur `get_passes_with_activities`
 
 ## 5) Feedback PO
 
-- Validation prod: en attente
-- Retours fonctionnels: n/a
+- Validation prod: KO — impossible d'afficher les passes
+- Retours fonctionnels: vérification des créneaux impossible
 
 ## 6) Actions d’amélioration (reportées en rétro)
 
@@ -44,3 +44,4 @@
 - PR merge: `Sprint S1: …`
 - CHANGELOG mis à jour (`[Unreleased]`)
 - Tickets follow‑up créés si besoin
+- Fix à planifier : créer la fonction `get_passes_with_activities`


### PR DESCRIPTION
## Summary
- document PO response precedence over REVIEW in AGENTS and PO_NOTES
- mark US-10 and US-11 as Delivered and add fix US-13
- update sprint S1 review, history and interactions to reflect PO KO and planned fix

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba2dbacd2c832bbd58d5185e99654a