### PR TITLE
Sprint S3: add definition of done

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,7 +13,7 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
 - **Timebox** : 25 min (gel **T+22** pour docs/review/rétro/PO_NOTES).
 - **Autonomie produit** : si besoin, ChatGPT **propose, crée et sélectionne** des US (MVP + qualité irréprochable).
 - **Rôle du PO** : fournit **OK/KO**, **secrets/clé API**, **orientations** dans `PO_NOTES.md`.
-- **Qualité** : respecter `QUALITY-GATES.md` et `DoD.md`.
+- **Qualité** : respecter [QUALITY-GATES.md](QUALITY-GATES.md) et [DoD.md](DoD.md).
 - **Sécurité** : pas de secrets en repo ; idempotence ; **RLS/policies** testées ; en‑têtes sécurité ; rate‑limit endpoints publics.
 - **Garde‑fous locaux** : tout commit doit passer le **hook Husky** `.husky/pre-commit`. Aucune dépendance à GitHub Actions.
 

--- a/DoD.md
+++ b/DoD.md
@@ -1,0 +1,28 @@
+# DoD — Definition of Done
+
+Pour qu’une fonctionnalité soit considérée **Done** :
+
+## Qualité & tests
+
+- Lint, type-check et tests (`npm test`) passent.
+- Couverture ≥ 80 % des nouvelles lignes.
+- Scénarios critiques (happy path + erreurs) couverts.
+- Hook `.husky/pre-commit` vert.
+
+## Documentation
+
+- README et docs pertinentes (API, schéma, backlog) mis à jour.
+- `CHANGELOG.md` et `PREFLIGHT.md` complétés si nécessaires.
+- `schema.sql` rafraîchi ou `unchanged` justifié.
+
+## Validation
+
+- Critères d’acceptation remplis.
+- `QA_CHECKLIST.md` coché.
+- Entrée `docs/sprints/S<N>/INTERACTIONS.yaml` ajoutée et validée par le PO.
+
+## Sécurité
+
+- Aucun secret committé.
+- RLS/policies et contrôles d’accès testés.
+- Webhooks/logiciels idempotents.

--- a/README.md
+++ b/README.md
@@ -114,8 +114,8 @@ npx husky install
 
 ## 6) Qualité & sécurité
 
-- **Quality Gates** : `QUALITY-GATES.md` (Gate 0/A/B/C/D/S)
-- **DoD** : CI locale verte, couverture ≥ 80% des nouvelles lignes, docs à jour, sécurité OK
+- **Quality Gates** : [`QUALITY-GATES.md`](QUALITY-GATES.md) (Gate 0/A/B/C/D/S)
+- **DoD** : [`DoD.md`](DoD.md) — CI locale verte, couverture ≥ 80% des nouvelles lignes, docs à jour, sécurité OK
 - **Sécurité** :
   - Jamais de secrets en repo/PR
   - Webhooks Stripe **signés**, logique **idempotente**

--- a/docs/sprints/S3/INTERACTIONS.yaml
+++ b/docs/sprints/S3/INTERACTIONS.yaml
@@ -16,3 +16,14 @@
   reply: OK
   details: "L'affichage des passes se fait bien sans erreur"
   action: none
+
+- who: ChatGPT
+  when: 2025-09-05T01:13:44Z
+  topic: Sprint S3 — documentation
+  did: |
+    - Ajout du fichier DoD.md
+    - Mise à jour de AGENTS.md et README.md
+  ask: |
+    Vérifier que les liens vers DoD.md sont corrects.
+  context: repo
+  status: pending


### PR DESCRIPTION
## Summary
- add Definition of Done document
- link DoD from AGENTS and README
- record documentation update in sprint interactions

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba38e28c40832bb98879aa708811ff