### PR TITLE
Sprint S3: support docs-only commits

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -12,6 +12,36 @@ if [ "$BRANCH" = "main" ]; then
   exit $?
 fi
 
+STAGED="$(git diff --cached --name-only)"
+ALLOW_EMPTY_SPRINT=${ALLOW_EMPTY_SPRINT:-0}
+if [ "$1" = "--allow-empty-sprint" ]; then
+  ALLOW_EMPTY_SPRINT=1
+fi
+
+if [ "$ALLOW_EMPTY_SPRINT" -eq 0 ]; then
+  DOCS_ONLY=1
+  for f in $STAGED; do
+    case "$f" in
+      *.md|*.markdown|*.mdx|*.txt|*.yaml|*.yml|docs/*)
+        ;;
+      *)
+        DOCS_ONLY=0
+        break
+        ;;
+    esac
+  done
+  if [ "$DOCS_ONLY" -eq 1 ]; then
+    echo "📝 Commit docs-only détecté : vérifications sprint allégées."
+    ALLOW_EMPTY_SPRINT=1
+  fi
+fi
+
+if [ "$ALLOW_EMPTY_SPRINT" -eq 1 ]; then
+  command -v git-secrets >/dev/null 2>&1 && git-secrets --scan
+  lint-staged
+  exit $?
+fi
+
 # 1) Sprint courant = dernier dossier docs/sprints/S<N>/
 SPRINT_DIR="$(ls -d docs/sprints/S*/ 2>/dev/null | sort -V | tail -n1)"
 if [ -z "$SPRINT_DIR" ]; then
@@ -51,7 +81,6 @@ grep -qi "DB audit" "$PREF"   || { echo "❌ PREFLIGHT.md: section 'DB audit' ma
 }
 
 # 5) Si migrations STAGÉES → exiger schema.sql stagé OU justification 'unchanged'
-STAGED="$(git diff --cached --name-only)"
 if echo "$STAGED" | grep -Eq '^(supabase/migrations/|Infrastructure/.*/Migrations/|migrations/)'; then
   if ! echo "$STAGED" | grep -q '^schema.sql$'; then
     if ! grep -qi "unchanged" "$PREF"; then

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,8 @@ Avant **tout commit**, le hook **`.husky/pre-commit`** doit réussir. Il vérifi
 
 5. Si des **migrations** sont modifiées → `schema.sql` est mis à jour, **ou** `PREFLIGHT.md` justifie `unchanged`. ⚠️ **ChatGPT ne les applique pas**, le PO exécute les commandes fournies.
 
+> ✍️ **Commit docs-only** : si le commit ne touche que des fichiers de documentation (`*.md`, `*.yml`, `docs/…`), le hook détecte un mode "allow-empty-sprint". Les contrôles d'artefacts sprint et les tests complets sont ignorés au profit de `lint-staged`. Pour forcer ce mode, lancer `git commit` avec `ALLOW_EMPTY_SPRINT=1` (ou en appelant le hook avec `--allow-empty-sprint`).
+
 ---
 
 ## 5) Rôles & switching (rappel)


### PR DESCRIPTION
## Summary
- relax pre-commit checks for documentation-only changes
- document how to commit docs without sprint artefacts

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3addf91c832ba15289ece25e19f7