### PR TITLE
Sprint S3: add sprint init script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,8 +22,8 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
 ## 2) Mode Sprint (commande : « Passe au sprint suivant »)
 
 1. **Bootstrap & minuteur**
+   - Exécuter `npm run sprint:init` (crée `/docs/sprints/S<N>` depuis `docs/templates`).
    - Démarrer un **minuteur 25 min** (checkpoints **T+10**, **T+22**).
-   - Créer `/docs/sprints/S<N>/` si absent et initialiser : `PLAN.md`, `BOARD.md`, `DEMO.md`, `REVIEW.md`, `RETRO.md`, `PREFLIGHT.md`, `INTERACTIONS.yaml` (depuis templates).
 
 2. **Pré‑vol (audit existant) → `PREFLIGHT.md`**
    - **Code** : cartographier endpoints/contrats/tests, relever doublons, **code mort**, dette bloquante ; proposer refactors **≤ timebox**.

--- a/README.md
+++ b/README.md
@@ -84,12 +84,13 @@ npx husky install
 
 ## 4) Mode agent — Sprint 25 min
 
-1. **Déclencheur** : « **Passe au sprint suivant** »
-2. **Gate 0 — Pré‑vol** : remplir `PREFLIGHT.md` (audit code + BDD, `schema.sql`)
-3. **Planification** : estimer en **SP** (1,2,3,5,8,13), capacité = vélocité×0.8 (+10% improvements) → `PLAN.md`
-4. **Exécution** : A→B→C→D, mise à jour `BOARD.md` (**Selected → InSprint → Delivered → Spillover**)
-5. **Gel T+22** : compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, consigner l’entrée **INTERACTIONS** (tests prod) dans `/docs/sprints/S<N>/INTERACTIONS.yaml`
-6. **PR unique** : `work → main`, titre `Sprint S<N>: …`
+1. **Initialisation** : `npm run sprint:init` (crée `/docs/sprints/S<N>` depuis `docs/templates`) puis démarrer un minuteur 25 min
+2. **Déclencheur** : « **Passe au sprint suivant** »
+3. **Gate 0 — Pré‑vol** : remplir `PREFLIGHT.md` (audit code + BDD, `schema.sql`)
+4. **Planification** : estimer en **SP** (1,2,3,5,8,13), capacité = vélocité×0.8 (+10% improvements) → `PLAN.md`
+5. **Exécution** : A→B→C→D, mise à jour `BOARD.md` (**Selected → InSprint → Delivered → Spillover**)
+6. **Gel T+22** : compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, consigner l’entrée **INTERACTIONS** (tests prod) dans `/docs/sprints/S<N>/INTERACTIONS.yaml`
+7. **PR unique** : `work → main`, titre `Sprint S<N>: …`
 
 **Rappels**
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "test": "npx vitest run",
     "test:ui": "npx vitest --ui",
     "test:coverage": "npx vitest --coverage",
+    "sprint:init": "node scripts/sprint-init.js",
     "prepare": "husky",
     "format": "prettier --write ."
   },

--- a/scripts/sprint-init.js
+++ b/scripts/sprint-init.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+import { promises as fs } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const root = path.resolve(__dirname, '..');
+const templatesDir = path.join(root, 'docs', 'templates');
+const sprintsDir = path.join(root, 'docs', 'sprints');
+
+async function main() {
+  const arg = process.argv[2];
+  let n;
+  if (arg) {
+    n = parseInt(arg.replace(/^S/i, ''), 10);
+    if (Number.isNaN(n)) {
+      console.error('Usage: npm run sprint:init -- <N>');
+      process.exit(1);
+    }
+  } else {
+    const entries = await fs
+      .readdir(sprintsDir, { withFileTypes: true })
+      .catch(() => []);
+    const nums = entries
+      .filter((e) => e.isDirectory() && /^S\d+$/.test(e.name))
+      .map((e) => parseInt(e.name.slice(1), 10));
+    n = nums.length ? Math.max(...nums) + 1 : 1;
+  }
+
+  const sprintName = `S${n}`;
+  const targetDir = path.join(sprintsDir, sprintName);
+  try {
+    await fs.mkdir(targetDir, { recursive: false });
+  } catch (e) {
+    console.error(`❌ ${sprintName} existe déjà.`);
+    process.exit(1);
+  }
+
+  const templates = await fs.readdir(templatesDir);
+  for (const file of templates) {
+    await fs.copyFile(
+      path.join(templatesDir, file),
+      path.join(targetDir, file),
+    );
+  }
+
+  console.log(
+    `✅ ${sprintName} initialisé dans ${path.relative(root, targetDir)}.`,
+  );
+  console.log('⏱️ Lancez un timer de 25 min et suivez AGENTS.md');
+}
+
+main();


### PR DESCRIPTION
## Summary
- add `sprint:init` script to copy sprint templates into next `docs/sprints/SN`
- document how to run the script and start the 25 min timer

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ba3cbd014c832b877479051a74056d