### PR TITLE
Sprint S4: apply PO feedback on process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,7 +34,9 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
    - Consulter `docs/sprints/S<N-1>/INTERACTIONS.yaml` :
      - US `Delivered` validées par le PO → passer en `Done`.
      - Corrections demandées → créer les US de fix et ajuster le backlog/capacité.
-     - Ce fichier prévaut sur `REVIEW.md` pour l'état des US ; en cas de `reply: KO`, laisser l'US en `Delivered`.
+     - Ce fichier prévaut sur `REVIEW.md` pour l'état des US.
+     - Tant qu'une entrée est `pending` ou `reply: KO`, **ne sélectionner aucune nouvelle US** ; traiter ces actions d'abord.
+     - En cas de `reply: KO`, laisser l'US en `Delivered` jusqu'à correction.
 4. **Collecte & grooming automatique**
    - Lire `BACKLOG.md` (`Ready`) et `PO_NOTES.md`.
    - **Si aucune US `Ready`** :
@@ -56,8 +58,8 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
      - **Gate B — Data**.
      - **Gate C — Front**.
      - **Gate D — QA**.
-
    - Mettre à jour `owner` (serverless→data→frontend→qa) et `BOARD.md`. Déplacer en `Spillover` si dépassement.
+   - À l'entrée en `InSprint`, noter `start` (horodatage ISO `HH:MM:SS`), et à la transition `Delivered`, noter `end` dans `BOARD.md`.
 
 8. **Checkpoint T+22 (gel)** : figer code ; compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, finaliser `PREFLIGHT.md` ; renseigner `INTERACTIONS.yaml` (tests prod).
 9. **Clôture & PR unique** : calculer `committed_sp` vs `delivered_sp`, consigner la **vélocité** dans `REVIEW.md` et `SPRINT_HISTORY` ; ouvrir **une PR** `work→main` `Sprint S<N>: …`. Après merge, les US restent en `Delivered` jusqu'à validation PO ; elles passeront en `Done` au sprint suivant.

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -236,10 +236,10 @@ persona: parc
 title: Compteur jour Luge
 value: suivre le flux
 priority: P2
-status: Selected
+status: Ready
 owner: data
 sp: 2
-sprint: 4
+sprint: null
 type: feature
 origin: po
 ac:

--- a/PO_NOTES.md
+++ b/PO_NOTES.md
@@ -45,13 +45,13 @@
 ## 3) SPRINT — EN‑TÊTE (renseigné par ChatGPT)
 
 ```yaml
-sprint_id: 3
+sprint_id: 4
 highlights: |
-  - Migration guaranteed_runs ajoutée
+  - Processus ajusté selon feedback PO (horodatage des US, blocage si pending/KO)
 risks_or_todo: |
-  - Tests RLS prestataires à compléter
-interaction_log: ./docs/sprints/S3/INTERACTIONS.yaml
-status: wip
+  - Résoudre les entrées pending du sprint précédent avant tout nouveau développement
+interaction_log: ./docs/sprints/S4/INTERACTIONS.yaml
+status: pending
 ```
 
 ---

--- a/docs/sprints/S4/BOARD.md
+++ b/docs/sprints/S4/BOARD.md
@@ -10,9 +10,10 @@
 
 > Déplacer les US sélectionnées dans la colonne correspondante. Chaque transition doit être justifiée dans les artefacts sprint.
 
-| ID    | Title              | SP  | Owner | Status   |
-| ----- | ------------------ | --- | ----- | -------- |
-| US-21 | Compteur jour Luge | 2   | data  | Selected |
+| ID  | Title | SP  | Owner | Start | End | Status |
+| --- | ----- | --- | ----- | ----- | --- | ------ |
+
+> Aucune US sélectionnée tant que les retours du sprint précédent ne sont pas résolus.
 
 ## 3) Légende statuts
 

--- a/docs/sprints/S4/INTERACTIONS.yaml
+++ b/docs/sprints/S4/INTERACTIONS.yaml
@@ -19,3 +19,14 @@
   reply: ko
   details: "Pourquoi avoir sélectionné une seul US pour ce SPRINT alros que le SPRINT précédent à terminé 3 SP en moins de 10 minutes. Il faut que la réalisation des US soit horodaté, heure de début, et heure de fin, avec les minutes et secondes, sinon on ne peut pas améliorer la vélocité. De plus, pourquoi avoir pris une nouvelle US pour ce SPRINT alors que les SPRINT précédent sont en pending ou en KO ? REvois et modifie les instructions si nécessaire pour ne plus que ça arrive. La base de vérité pour commencer chaque SPRINT ce sont les fichiers interractions et mes feedbacks"
   action: fix
+
+- who: ChatGPT
+  when: 2025-09-05T06:54:50Z
+  topic: Sprint S4 — ajustements suite feedback
+  did: |
+    - Mise à jour des instructions (`AGENTS.md`) pour consulter `INTERACTIONS.yaml` et bloquer les nouvelles US en cas de pending/KO
+    - Ajout des colonnes `Start`/`End` dans `BOARD.md` (templates et S4) et retrait de US-21 de la planification
+  ask: |
+    Confirmer que ces ajustements répondent aux attentes.
+  context: repo
+  status: pending

--- a/docs/sprints/S4/PLAN.md
+++ b/docs/sprints/S4/PLAN.md
@@ -17,11 +17,12 @@
 
 > Déplacer ces US en `Selected` dans `BACKLOG.md` et renseigner `sprint: N`.
 
-| ID    | Title              | Type    | SP  | Owner initial | Notes |
-| ----- | ------------------ | ------- | --- | ------------- | ----- |
-| US-21 | Compteur jour Luge | feature | 2   | data          |       |
+| ID  | Title | Type | SP  | Owner initial | Notes |
+| --- | ----- | ---- | --- | ------------- | ----- |
 
-**Total SP sélectionnés**: 2 / **Capacité**: 2
+> Aucune US planifiée : en attente des retours du sprint précédent.
+
+**Total SP sélectionnés**: 0 / **Capacité**: 2
 
 ## 4) Stratégie & plan d’exécution
 

--- a/docs/templates/BOARD.md
+++ b/docs/templates/BOARD.md
@@ -10,12 +10,12 @@
 
 > Déplacer les US sélectionnées dans la colonne correspondante. Chaque transition doit être justifiée dans les artefacts sprint.
 
-| ID    | Title | SP  | Owner      | Status    |
-| ----- | ----- | --- | ---------- | --------- |
-| US-.. | …     | 3   | serverless | Selected  |
-| US-.. | …     | 2   | data       | InSprint  |
-| US-.. | …     | 5   | frontend   | Delivered |
-| US-.. | …     | 3   | qa         | Spillover |
+| ID    | Title | SP  | Owner      | Start    | End      | Status    |
+| ----- | ----- | --- | ---------- | -------- | -------- | --------- |
+| US-.. | …     | 3   | serverless | 00:00:00 |          | Selected  |
+| US-.. | …     | 2   | data       | 00:05:00 |          | InSprint  |
+| US-.. | …     | 5   | frontend   | 00:00:00 | 00:10:00 | Delivered |
+| US-.. | …     | 3   | qa         | 00:00:00 |          | Spillover |
 
 ## 3) Légende statuts
 


### PR DESCRIPTION
## Summary
- emphasize resolving pending or KO feedback before selecting new US and track start/end timestamps for each story
- update sprint templates and sprint 4 docs to include Start/End columns and pause new work until feedback is resolved
- revert US-21 selection and update sprint header and interaction log accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ba88baf06c832ba68864b6afdb4ca8