### PR TITLE
Sprint S5: init and process updates

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,9 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
 
 ---
 
-## 2) Mode Sprint (commande : « Passe au sprint suivant »)
+## 2) Mode Sprint (appliqué à chaque demande)
+
+Les étapes suivantes s'appliquent à chaque nouvelle demande du PO, pas seulement à la commande « Passe au sprint suivant ».
 
 1. **Bootstrap & minuteur**
    - Exécuter `npm run sprint:init` (crée `/docs/sprints/S<N>` depuis `docs/templates`).
@@ -27,7 +29,7 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
 
 2. **Pré‑vol (audit existant) → `PREFLIGHT.md`**
    - **Code** : cartographier endpoints/contrats/tests, relever doublons, **code mort**, dette bloquante ; proposer refactors **≤ timebox**.
-   - **BDD** : état schéma/migrations/RLS/fonctions ; exiger snapshot **`schema.sql`** (ou `unchanged` justifié). Le PO applique les migrations validées.
+   - **BDD** : état schéma/migrations/RLS/fonctions ; exiger snapshot **`schema.sql`** (ou `unchanged` justifié). Le PO applique les migrations validées et tout problème de migration `reverted` (ex. `supabase migration repair`) doit être résolu ou signalé.
 
 3. **Intégrer review & rétro (apprentissage)** :
    - Lire `PO_NOTES.md` & `RETRO.md` ; ajuster pratiques.
@@ -42,6 +44,7 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
    - **Si aucune US `Ready`** :
      - 1. `PO_NOTES.md` (NEW_FEATURES) → **générer** des US ;
      - 2. si vide : **discovery produit** alignée MVP, consigner idées, puis **créer** les US.
+   - Vérifier la **Definition of Ready (DoR)** : chaque US doit être bien rédigée (persona, title, value, priority, `status: Ready`, `sp`, ≥2 AC, note sécurité/RLS, `links.api` pour `origin:auto`).
 
    - Toute US auto‑générée : `id,title,value,priority,type`, **≥2 AC**, **note sécurité/RLS**, `links.api` **placeholder**, `origin: auto`, `status: Ready`.
 
@@ -55,13 +58,13 @@ Manuel d’exécution pour **ChatGPT**. À la commande **« Passe au sprint suiv
    - Par US : `Selected → InSprint → Delivered` en passant les **gates** :
      - **Gate 0 — Préflight** (code+BDD, `schema.sql`).
      - **Gate A — Serverless/Backend**.
-     - **Gate B — Data**.
+     - **Gate B — Data** (migrations + rollback, RLS/policies, index/constraints, résolution des migrations `reverted`).
      - **Gate C — Front**.
-     - **Gate D — QA**.
+     - **Gate D — QA** (suivre `QA_CHECKLIST.md` + `QUALITY-GATES.md`).
    - Mettre à jour `owner` (serverless→data→frontend→qa) et `BOARD.md`. Déplacer en `Spillover` si dépassement.
    - À l'entrée en `InSprint`, noter `start` (horodatage ISO `HH:MM:SS`), et à la transition `Delivered`, noter `end` dans `BOARD.md`.
 
-8. **Checkpoint T+22 (gel)** : figer code ; compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, finaliser `PREFLIGHT.md` ; renseigner `INTERACTIONS.yaml` (tests prod).
+8. **Checkpoint T+22 (gel)** : figer code ; compléter `DEMO.md`, `REVIEW.md` (inclure temps par US et temps total de sprint), `RETRO.md`, finaliser `PREFLIGHT.md` ; renseigner `INTERACTIONS.yaml` (tests prod) ; mettre à jour `CHANGELOG.md`.
 9. **Clôture & PR unique** : calculer `committed_sp` vs `delivered_sp`, consigner la **vélocité** dans `REVIEW.md` et `SPRINT_HISTORY` ; ouvrir **une PR** `work→main` `Sprint S<N>: …`. Après merge, les US restent en `Delivered` jusqu'à validation PO ; elles passeront en `Done` au sprint suivant.
 
 ---

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -246,6 +246,27 @@ ac:
   - Vue compteur validés aujourd’hui (agrégat simple)
 ```
 
+### US-22
+
+```yaml
+id: US-22
+persona: parc
+title: Données test compteur luge
+value: valider le flux
+priority: P1
+status: Selected
+owner: data
+sp: 1
+sprint: 5
+type: fix
+origin: po
+ac:
+  - Script ou doc pour créer des validations Luge en test
+  - Démo compteur >0 avec données seed
+notes:
+  - RLS inchangées
+```
+
 ---
 
 ## Sprint Prestataires — exemples

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,16 +8,9 @@ Toutes les modifications sont consignées ici. Suivre le format **Keep a Changel
 
 ### Ajouté
 
-- Affichage des activités des passes avec badge "Créneau requis"
-- Panier: paiement désactivé tant que les CGV ne sont pas acceptées
-
 ### Modifié
 
-- …
-
 ### Corrigé
-
-- Ajout de la colonne `guaranteed_runs` dans `passes`
 
 ---
 
@@ -40,6 +33,51 @@ Toutes les modifications sont consignées ici. Suivre le format **Keep a Changel
 
 ---
 
-## \[Sprint S<N>] — YYYY-MM-DD
+## \[Sprint S1] — 2025-09-04
 
-_(à compléter par ChatGPT lors de la clôture de chaque sprint)_
+### Ajouté
+
+- Affichage des activités des passes avec badge "Créneau requis" (US-10)
+- Panier: paiement désactivé tant que les CGV ne sont pas acceptées (US-11)
+
+### Corrigé
+
+- N/A
+
+---
+
+## \[Sprint S2] — 2025-09-05
+
+### Ajouté
+
+- Fonction `get_passes_with_activities` et logger `fetchPasses`
+
+### Corrigé
+
+- N/A
+
+---
+
+## \[Sprint S3] — 2025-09-05
+
+### Ajouté
+
+- Colonne `guaranteed_runs` pour les passes
+
+### Corrigé
+
+- N/A
+
+---
+
+## \[Sprint S4] — 2025-09-05
+
+### Ajouté
+
+- Vue `luge_validations_today` et page compteur Luge (US-21)
+
+### Corrigé
+
+- N/A
+
+---

--- a/docs/sprints/S5/BOARD.md
+++ b/docs/sprints/S5/BOARD.md
@@ -1,0 +1,28 @@
+# BOARD — Sprint S5
+
+## 1) Métadonnées
+
+- **Sprint**: S5
+- **Branche**: `work`
+- **Timebox**: 25 min (gel **T+22**)
+
+## 2) Kanban du sprint
+
+> Déplacer les US sélectionnées dans la colonne correspondante. Chaque transition doit être justifiée dans les artefacts sprint.
+
+| ID    | Title                      | SP  | Owner | Start | End | Status   |
+| ----- | -------------------------- | --- | ----- | ----- | --- | -------- |
+| US-22 | Données test compteur luge | 1   | data  |       |     | Selected |
+
+## 3) Légende statuts
+
+- **Selected**: choisi dans le plan, pas encore commencé
+- **InSprint**: en cours d’implémentation (A→B→C→D)
+- **Delivered**: terminé et validé QA (PR ouverte/mergée, en attente validation PO)
+- **Spillover**: non terminé, reporté
+
+## 4) Notes
+
+- Chaque US doit avoir `sp`, `owner`, `origin`, `type`, `links.api` si `origin:auto`
+- Le hook Husky bloque si une US `origin:auto` est `Delivered` **sans** `links.api` ou **<2 AC** ou **pas de note sécurité/RLS**
+- Les transitions doivent être cohérentes avec `BACKLOG.md`

--- a/docs/sprints/S5/DEMO.md
+++ b/docs/sprints/S5/DEMO.md
@@ -1,0 +1,47 @@
+# DEMO — Sprint S5
+
+## 1) Contexte
+
+- **Sprint**: S5
+- **Scope démo**: US présentées (IDs + titre)
+- **Environnement**: local / stage / prod (URL)
+- **Prerequis**: seed exécuté ? comptes de test ?
+
+## 2) Scénario de démo (pas-à-pas)
+
+> Objectif: décrire un enchaînement simple, vérifiable par le PO en 2–5 minutes.
+
+1. Ouvrir … (URL)
+2. Choisir le pass …
+3. Ajouter au panier …
+4. Payer via Checkout … (retour /success)
+5. Recevoir l’email de confirmation (n° + QR)
+6. Scanner le QR côté activité … (refus du double scan)
+
+## 3) Données de test
+
+- **Comptes**: `customer_demo@example.com` / `***` (si nécessaire)
+- **Pass/événements**: …
+- **Codes de test**: Stripe test cards (4242 …)
+
+## 4) Résultats attendus
+
+- **API**: codes HTTP corrects (200/201/4xx) ; logs sans PII
+- **UI**: affichage succès/erreur ; a11y/perf ≥ 90 (Lighthouse)
+- **Data**: réservation créée, paiement `PAID`, validations comptées
+
+## 5) Preuves
+
+- Captures d’écran clés (ou enregistrement court)
+- Extraits de logs (corrélation) si utile
+- Exemples de payloads/réponses (redactés)
+
+## 6) Limitations connues / dérogations
+
+- …
+
+## 7) Suivi
+
+- Liens vers PR : `Sprint S5: …`
+- Liens vers tests : unit/intégration/E2E
+- Tickets follow‑up (si nécessaires)

--- a/docs/sprints/S5/INTERACTIONS.yaml
+++ b/docs/sprints/S5/INTERACTIONS.yaml
@@ -1,0 +1,65 @@
+# INTERACTIONS — Sprint S5
+
+## Gabarit des échanges ChatGPT ↔ PO
+
+```yaml
+- who: ChatGPT
+  when: 2025-09-04T15:00:00+02:00
+  topic: Sprint S5 — validation prod
+  did: |
+    - Implémenté : …
+    - Gates passées : …
+  ask: |
+    Tester en prod :
+    1) …
+    2) …
+  context: env: https://stage.example.app ; PR: Sprint S5
+  status: pending
+
+- who: PO
+  when: 2025-09-04T16:20:00+02:00
+  topic: Sprint S5 — validation prod
+  reply: OK | KO
+  details: "…"
+  action: none | fix
+```
+
+---
+
+## Règles d’usage
+
+* **Obligatoire** : au moins une entrée `ChatGPT` + une entrée `PO` par sprint.
+* **Horodatage** : ISO8601 `YYYY-MM-DDThh:mm:ss±TZ`.
+* **Topic** : `Sprint S<N> — validation prod`.
+* **Statut** : `pending → waiting_PO → done`.
+* Les hooks Husky bloquent si :
+
+  * `INTERACTIONS.yaml` absent ou non stagé,
+  * ou aucune entrée `topic: Sprint S<N>` trouvée.
+
+---
+
+## Exemple complet
+
+```yaml
+- who: ChatGPT
+  when: 2025-09-04T15:00:00+02:00
+  topic: Sprint S3 — validation prod
+  did: |
+    - Implémenté : Checkout + webhook idempotent
+    - Gate 0/A/B/C/D passées
+  ask: |
+    Tester en prod :
+    1) Achat pass → Checkout Stripe → retour /success
+    2) Réception email (QR inclus)
+    3) Scan QR côté luge → 2ᵉ scan refusé
+  context: env: https://stage.example.app ; PR: Sprint S3
+  status: pending
+
+- who: PO
+  when: 2025-09-04T16:15:00+02:00
+  topic: Sprint S3 — validation prod
+  reply: OK
+  details: "Flux complet validé, email reçu, QR fonctionne."
+  action: none
+```

--- a/docs/sprints/S5/PLAN.md
+++ b/docs/sprints/S5/PLAN.md
@@ -1,0 +1,56 @@
+# PLAN — Sprint S5
+
+## 1) Métadonnées
+
+- **Sprint**: S5
+- **Timebox**: 25 min (gel **T+22**)
+- **Branche**: `work`
+- **PR fin de sprint**: `work → main` (titre `Sprint S<N>: …`)
+
+## 2) Capacité & vélocité
+
+- **Vélocité de référence** (moy. 3 derniers): 2
+- **Capacité engagée (SP)** = floor(vélocité × 0.8): 1
+- **Buffer improvements (\~10%)**: 0
+
+## 3) Sélection des US (commit du sprint)
+
+> Déplacer ces US en `Selected` dans `BACKLOG.md` et renseigner `sprint: N`.
+
+| ID    | Title                      | Type | SP  | Owner initial | Notes |
+| ----- | -------------------------- | ---- | --- | ------------- | ----- |
+| US-22 | Données test compteur luge | fix  | 1   | data          |       |
+
+**Total SP sélectionnés**: 1 / **Capacité**: 1
+
+## 4) Stratégie & plan d’exécution
+
+- **Gate 0 — Préflight**: `PREFLIGHT.md` (audit code+BDD, `schema.sql` RefreshedAt|unchanged)
+- **A — Serverless**: contrats/DTO, handlers, idempotence, tests unit/integration
+- **B — Data**: migrations+rollback, tests RLS/policies, index/constraints
+- **C — Front**: pages, état loading/empty/error/success, Lighthouse ≥ 90
+- **D — QA**: E2E happy + 2 erreurs, charge ciblée si critique
+
+## 5) Risques & mitigations
+
+- R1: Pas de données de test disponibles → Mitigation: fournir script ou documentation pour en créer
+
+## 6) Dépendances & actions PO
+
+- **Secrets/API**: néant
+- **Migrations**: aucune
+- **Seed/fixtures**: commande fournie pour créer des validations Luge de test
+
+## 7) Timeline du sprint
+
+- **T+00**: Plan + Préflight
+- **T+10**: Checkpoint mi‑parcours (risques/Spillover potentiels)
+- **T+22**: Gel — compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, `INTERACTIONS.yaml`
+- **T+25**: PR unique `work → main`
+
+## 8) Definition of Done (rappel)
+
+- CI locale verte, coverage ≥ 80% (lignes nouvelles)
+- Quality Gates 0/A/B/C/D/S OK
+- Sécurité: no secrets, RLS testées, idempotence
+- Docs sprint à jour + entrée `INTERACTIONS.yaml`

--- a/docs/sprints/S5/PREFLIGHT.md
+++ b/docs/sprints/S5/PREFLIGHT.md
@@ -1,0 +1,50 @@
+# PREFLIGHT — Sprint S5
+
+## 1) Contexte
+
+- **Sprint**: S5
+- **Date**: 2025-09-05T07:53:26Z
+- **Objectif**: audit existant avant implémentation
+
+## 2) Code audit
+
+- Doublons détectés: néant
+- Code mort/obsolète: aucun repéré
+- Refactors simples (≤ timebox): ajouter script/commande pour seed validations Luge
+
+## 3) DB audit
+
+- Tables/colonnes: `reservation_validations` pour comptage Luge
+- RLS/policies: policies existantes sur `reservation_validations`
+- Fonctions/procédures: vue `luge_validations_today`
+- Index/contraintes: index existants suffisent
+
+## 4) Migrations
+
+- Nouvelles migrations prévues: aucune
+- Rollback: n/a
+- **Application**: par le PO après merge (ChatGPT ne lance pas la CLI DB)
+
+## 5) Schéma SQL (`schema.sql`)
+
+- **RefreshedAt**: unchanged (pas de migration)
+
+## 6) Sécurité
+
+- Validation entrées: contrôles existants dans `LugeValidation.tsx`
+- Secrets: aucun nouveau secret
+- Policies RLS: déjà en place pour rôles `luge_provider`
+
+## 7) Observabilité
+
+- Logs structurés: logger existant utilisé dans `LugeCounter`
+- Tracing/Correlation: non implémenté
+
+## 8) Plan d’action ≤ timebox
+
+- Nettoyage/refactor immédiat: documenter script de seed
+- Actions différées (ticket backlog): renommer migration récurrente `20250829_extend_get_parc_activities_with_variants.sql`
+
+---
+
+> ⚠️ Ce fichier doit être complété **au début du sprint**. Les hooks Husky bloquent le commit si `schema.sql` n’est pas **rafraîchi** ou noté `unchanged` justifié.

--- a/docs/sprints/S5/RETRO.md
+++ b/docs/sprints/S5/RETRO.md
@@ -1,0 +1,34 @@
+# RETRO — Sprint S5
+
+## 1) Contexte
+
+- **Sprint**: S5
+- **Date rétro**: …
+- **Participants**: ChatGPT (équipe) + PO
+
+## 2) Points positifs 👍
+
+- …
+- …
+
+## 3) Points à améliorer 👎
+
+- …
+- …
+
+## 4) Actions concrètes (improvements)
+
+- IMP-01: … (responsable: …, sprint cible: S6)
+- IMP-02: … (responsable: …, sprint cible: S6)
+
+## 5) Décisions d’équipe
+
+- …
+
+## 6) Suivi
+
+- Ces actions sont recopiées dans `PO_NOTES.md` section **RETRO** ou dans `/docs/sprints/S6/PLAN.md` (improvements réservés).
+
+---
+
+> ⚠️ \~10 % de la capacité du sprint suivant doit être réservée aux **actions d’amélioration** décidées ici.

--- a/docs/sprints/S5/REVIEW.md
+++ b/docs/sprints/S5/REVIEW.md
@@ -1,0 +1,45 @@
+# REVIEW — Sprint S5
+
+## 1) Contexte
+
+- **Sprint**: S5
+- **Date review**: …
+- **Participants**: ChatGPT (équipe) + PO
+
+## 2) Bilan du sprint
+
+- **Capacité engagée**: … SP
+- **SP livrés**: … SP
+- **Focus factor**: … (livrés/engagés)
+
+## 3) Objectifs atteints
+
+- US-.. ✔️
+- US-.. ❌ (Spillover)
+
+## 4) Dérogations / écarts
+
+- US-.. : … (raison, impact)
+- Qualité: Lighthouse à 85 (cause: …)
+- Schéma BDD: `unchanged` justifié (aucune modif réelle)
+
+## 5) Feedback PO
+
+- Validation prod: OK/KO
+- Retours fonctionnels: …
+
+## 6) Actions d’amélioration (reportées en rétro)
+
+- Améliorer tests RLS prestataires
+- Stabiliser webhook Stripe (retry/alerte)
+
+## 7) Décisions
+
+- Maintenir Stripe Checkout uniquement (pas d’autres moyens de paiement)
+- Standardiser logs (format JSON + correlation)
+
+## 8) Suivi
+
+- PR merge: `Sprint S5: …`
+- CHANGELOG mis à jour (`[Unreleased]`)
+- Tickets follow‑up créés si besoin


### PR DESCRIPTION
## Summary
- incorporate PO feedback into sprint instructions (DoR, QA checks, changelog, migration issues)
- add US-22 fix for Luge counter test data and plan Sprint S5
- record previous sprint work in changelog and prepare sprint S5 docs

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba960aa200832baeca504d0f244dd9