### PR TITLE
Sprint S6: kickoff and backlog update

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -254,7 +254,7 @@ persona: parc
 title: Données test compteur luge
 value: valider le flux
 priority: P1
-status: Delivered
+status: Done
 owner: data
 sp: 1
 sprint: 5
@@ -265,6 +265,27 @@ ac:
   - Démo compteur >0 avec données seed
 notes:
   - RLS inchangées
+```
+
+### US-23
+
+```yaml
+id: US-23
+persona: data
+title: Corriger nommage migrations Supabase
+value: éviter les réparations manuelles
+priority: P1
+status: Selected
+owner: data
+sp: 1
+sprint: 6
+type: fix
+origin: po
+ac:
+  - Remplacer le script `seed_luge_validations.sql` par une migration Supabase
+  - Renommer la migration `20250829_extend_get_parc_activities_with_variants.sql` pour respecter le format attendu
+notes:
+  - Sécurité: RLS inchangées, garantit `supabase migration repair` sans intervention manuelle
 ```
 
 ---

--- a/PO_NOTES.md
+++ b/PO_NOTES.md
@@ -45,12 +45,12 @@
 ## 3) SPRINT — EN‑TÊTE (renseigné par ChatGPT)
 
 ```yaml
-sprint_id: 4
+sprint_id: 6
 highlights: |
-  - Processus ajusté selon feedback PO (horodatage des US, blocage si pending/KO)
+  - US-22 validée par le PO, seed luge disponible
 risks_or_todo: |
-  - Résoudre les entrées pending du sprint précédent avant tout nouveau développement
-interaction_log: ./docs/sprints/S4/INTERACTIONS.yaml
+  - Remplacer le script de seed par une migration et corriger le nommage Supabase
+interaction_log: ./docs/sprints/S5/INTERACTIONS.yaml
 status: pending
 ```
 

--- a/SPRINT_HISTORY.md
+++ b/SPRINT_HISTORY.md
@@ -4,4 +4,4 @@
 - Sprint S2 (2025-09-05): committed 2 SP, delivered 2 SP, focus 1.0, PO pending
 - Sprint S3 (2025-09-05): committed 1 SP, delivered 1 SP, focus 1.0, PO OK
 - Sprint S4 (2025-09-05): committed 2 SP, delivered 2 SP, focus 1.0, PO pending
-- Sprint S5 (2025-09-05): committed 1 SP, delivered 1 SP, focus 1.0, PO pending
+- Sprint S5 (2025-09-05): committed 1 SP, delivered 1 SP, focus 1.0, PO OK

--- a/docs/sprints/S5/INTERACTIONS.yaml
+++ b/docs/sprints/S5/INTERACTIONS.yaml
@@ -13,7 +13,7 @@
     1) `pnpm run seed:luge`
     2) Ouvrir `/provider/luge-counter` → compteur >0
   context: "env: http://localhost:5173 ; PR: Sprint S5"
-  status: waiting_PO
+  status: done
 
 - who: PO
   when: 2025-09-05T08:10:00Z
@@ -23,4 +23,4 @@
     - Les test en local on fonctionner, j'ai du modifier le script SQL.
     - Pour les prochaines fois, préfère les migrations plutot que les scripts.
     - Et j'aimerai que le problème m'obligeant à toujours faire un "supabase migration repair --status reverted 20250829 " soit résolu. Il doit sagir d'un problème de nommage car je vois que l'horodatage du début du nom du ficheir ne correspond pas au meme format que les autres.
-  action: 
+  action: fix

--- a/docs/sprints/S6/BOARD.md
+++ b/docs/sprints/S6/BOARD.md
@@ -1,0 +1,28 @@
+# BOARD — Sprint S6
+
+## 1) Métadonnées
+
+- **Sprint**: S6
+- **Branche**: `work`
+- **Timebox**: 25 min (gel **T+22**)
+
+## 2) Kanban du sprint
+
+> Déplacer les US sélectionnées dans la colonne correspondante. Chaque transition doit être justifiée dans les artefacts sprint.
+
+| ID    | Title                                | SP  | Owner | Start | End | Status   |
+| ----- | ------------------------------------ | --- | ----- | ----- | --- | -------- |
+| US-23 | Corriger nommage migrations Supabase | 1   | data  |       |     | Selected |
+
+## 3) Légende statuts
+
+- **Selected**: choisi dans le plan, pas encore commencé
+- **InSprint**: en cours d’implémentation (A→B→C→D)
+- **Delivered**: terminé et validé QA (PR ouverte/mergée, en attente validation PO)
+- **Spillover**: non terminé, reporté
+
+## 4) Notes
+
+- Chaque US doit avoir `sp`, `owner`, `origin`, `type`, `links.api` si `origin:auto`
+- Le hook Husky bloque si une US `origin:auto` est `Delivered` **sans** `links.api` ou **<2 AC** ou **pas de note sécurité/RLS**
+- Les transitions doivent être cohérentes avec `BACKLOG.md`

--- a/docs/sprints/S6/DEMO.md
+++ b/docs/sprints/S6/DEMO.md
@@ -1,0 +1,47 @@
+# DEMO — Sprint S6
+
+## 1) Contexte
+
+- **Sprint**: S6
+- **Scope démo**: US-23 — Corriger nommage migrations Supabase
+- **Environnement**: local
+- **Prerequis**: migration appliquée
+
+## 2) Scénario de démo (pas-à-pas)
+
+> Objectif: décrire un enchaînement simple, vérifiable par le PO en 2–5 minutes.
+
+1. Ouvrir … (URL)
+2. Choisir le pass …
+3. Ajouter au panier …
+4. Payer via Checkout … (retour /success)
+5. Recevoir l’email de confirmation (n° + QR)
+6. Scanner le QR côté activité … (refus du double scan)
+
+## 3) Données de test
+
+- **Comptes**: `customer_demo@example.com` / `***` (si nécessaire)
+- **Pass/événements**: …
+- **Codes de test**: Stripe test cards (4242 …)
+
+## 4) Résultats attendus
+
+- **API**: codes HTTP corrects (200/201/4xx) ; logs sans PII
+- **UI**: affichage succès/erreur ; a11y/perf ≥ 90 (Lighthouse)
+- **Data**: réservation créée, paiement `PAID`, validations comptées
+
+## 5) Preuves
+
+- Captures d’écran clés (ou enregistrement court)
+- Extraits de logs (corrélation) si utile
+- Exemples de payloads/réponses (redactés)
+
+## 6) Limitations connues / dérogations
+
+- …
+
+## 7) Suivi
+
+- Liens vers PR : `Sprint S6: …`
+- Liens vers tests : unit/intégration/E2E
+- Tickets follow‑up (si nécessaires)

--- a/docs/sprints/S6/INTERACTIONS.yaml
+++ b/docs/sprints/S6/INTERACTIONS.yaml
@@ -1,0 +1,15 @@
+# INTERACTIONS — Sprint S6
+
+# Journal
+
+- who: ChatGPT
+  when: 2025-09-05T09:05:00Z
+  topic: Sprint S6 — validation prod
+  did: |
+    - À compléter en fin de sprint
+  ask: |
+    Tester en local :
+    1) TODO
+    2) TODO
+  context: env: http://localhost:5173 ; PR: Sprint S6
+  status: pending

--- a/docs/sprints/S6/PLAN.md
+++ b/docs/sprints/S6/PLAN.md
@@ -1,0 +1,56 @@
+# PLAN — Sprint S6
+
+## 1) Métadonnées
+
+- **Sprint**: S6
+- **Timebox**: 25 min (gel **T+22**)
+- **Branche**: `work`
+- **PR fin de sprint**: `work → main` (titre `Sprint S6: …`)
+
+## 2) Capacité & vélocité
+
+- **Vélocité de référence** (moy. 3 derniers): 2
+- **Capacité engagée (SP)** = floor(vélocité × 0.8): 1
+- **Buffer improvements (\~10%)**: 0
+
+## 3) Sélection des US (commit du sprint)
+
+> Déplacer ces US en `Selected` dans `BACKLOG.md` et renseigner `sprint: N`.
+
+| ID    | Title                                | Type | SP  | Owner initial | Notes |
+| ----- | ------------------------------------ | ---- | --- | ------------- | ----- |
+| US-23 | Corriger nommage migrations Supabase | fix  | 1   | data          |       |
+
+**Total SP sélectionnés**: 1 / **Capacité**: 1
+
+## 4) Stratégie & plan d’exécution
+
+- **Gate 0 — Préflight**: `PREFLIGHT.md` (audit code+BDD, `schema.sql` RefreshedAt|unchanged)
+- **A — Serverless**: contrats/DTO, handlers, idempotence, tests unit/integration
+- **B — Data**: migrations+rollback, tests RLS/policies, index/constraints
+- **C — Front**: pages, état loading/empty/error/success, Lighthouse ≥ 90
+- **D — QA**: E2E happy + 2 erreurs, charge ciblée si critique
+
+## 5) Risques & mitigations
+
+- R1: Nommage incohérent des migrations → Mitigation: audit et renaming
+
+## 6) Dépendances & actions PO
+
+- **Secrets/API**: néant
+- **Migrations**: renommer la migration fautive et en ajouter une pour les validations Luge (appliquées par le PO après merge)
+- **Seed/fixtures**: néant
+
+## 7) Timeline du sprint
+
+- **T+00**: Plan + Préflight
+- **T+10**: Checkpoint mi‑parcours (risques/Spillover potentiels)
+- **T+22**: Gel — compléter `DEMO.md`, `REVIEW.md`, `RETRO.md`, `INTERACTIONS.yaml`
+- **T+25**: PR unique `work → main`
+
+## 8) Definition of Done (rappel)
+
+- CI locale verte, coverage ≥ 80% (lignes nouvelles)
+- Quality Gates 0/A/B/C/D/S OK
+- Sécurité: no secrets, RLS testées, idempotence
+- Docs sprint à jour + entrée `INTERACTIONS.yaml`

--- a/docs/sprints/S6/PREFLIGHT.md
+++ b/docs/sprints/S6/PREFLIGHT.md
@@ -1,0 +1,51 @@
+# PREFLIGHT — Sprint S6
+
+## 1) Contexte
+
+- **Sprint**: S6
+- **Date**: 2025-09-05T09:00:00Z
+- **Objectif**: préparer migration pour validations Luge
+
+## 2) Code audit
+
+- Doublons détectés: néant
+- Code mort/obsolète: script `seed_luge_validations.sql` à remplacer
+- Refactors simples (≤ timebox): renommage migration ciblée
+
+## 3) DB audit
+
+- Tables/colonnes: `reservation_validations`, `luge_validations_today`
+- RLS/policies: existantes sur `reservation_validations`
+- Fonctions/procédures: vue `luge_validations_today`
+- Index/contraintes: conformes
+
+## 4) Migrations
+
+- Nouvelles migrations prévues: migration validations Luge + renaming `20250829_extend_get_parc_activities_with_variants.sql`
+- Rollback: n/a
+- **Application**: par le PO après merge (ChatGPT ne lance pas la CLI DB)
+
+## 5) Schéma SQL (`schema.sql`)
+
+- **RefreshedAt**: unchanged (pas de migration appliquée)
+- Ou justification `unchanged`: —
+
+## 6) Sécurité
+
+- Validation entrées: n/a
+- Secrets: aucun nouveau
+- Policies RLS: inchangées
+
+## 7) Observabilité
+
+- Logs structurés: logger existant
+- Tracing/Correlation: non implémenté
+
+## 8) Plan d’action ≤ timebox
+
+- Nettoyage/refactor immédiat: déplacer script seed en migration
+- Actions différées (ticket backlog): n/a
+
+---
+
+> ⚠️ Ce fichier doit être complété **au début du sprint**. Les hooks Husky bloquent le commit si `schema.sql` n’est pas **rafraîchi** ou noté `unchanged` justifié.

--- a/docs/sprints/S6/RETRO.md
+++ b/docs/sprints/S6/RETRO.md
@@ -1,0 +1,34 @@
+# RETRO — Sprint S6
+
+## 1) Contexte
+
+- **Sprint**: S6
+- **Date rétro**: …
+- **Participants**: ChatGPT (équipe) + PO
+
+## 2) Points positifs 👍
+
+- …
+- …
+
+## 3) Points à améliorer 👎
+
+- …
+- …
+
+## 4) Actions concrètes (improvements)
+
+- IMP-01: … (responsable: …, sprint cible: S7)
+- IMP-02: … (responsable: …, sprint cible: S7)
+
+## 5) Décisions d’équipe
+
+- …
+
+## 6) Suivi
+
+- Ces actions sont recopiées dans `PO_NOTES.md` section **RETRO** ou dans `/docs/sprints/S7/PLAN.md` (improvements réservés).
+
+---
+
+> ⚠️ \~10 % de la capacité du sprint suivant doit être réservée aux **actions d’amélioration** décidées ici.

--- a/docs/sprints/S6/REVIEW.md
+++ b/docs/sprints/S6/REVIEW.md
@@ -1,0 +1,44 @@
+# REVIEW — Sprint S6
+
+## 1) Contexte
+
+- **Sprint**: S6
+- **Date review**: …
+- **Participants**: ChatGPT (équipe) + PO
+
+## 2) Bilan du sprint
+
+- **Capacité engagée**: 1 SP
+- **SP livrés**: … SP
+- **Focus factor**: … (livrés/engagés)
+
+## 3) Objectifs atteints
+
+- US-23 ✔️
+
+## 4) Dérogations / écarts
+
+- US-.. : … (raison, impact)
+- Qualité: Lighthouse à 85 (cause: …)
+- Schéma BDD: `unchanged` justifié (aucune modif réelle)
+
+## 5) Feedback PO
+
+- Validation prod: OK/KO
+- Retours fonctionnels: …
+
+## 6) Actions d’amélioration (reportées en rétro)
+
+- Améliorer tests RLS prestataires
+- Stabiliser webhook Stripe (retry/alerte)
+
+## 7) Décisions
+
+- Maintenir Stripe Checkout uniquement (pas d’autres moyens de paiement)
+- Standardiser logs (format JSON + correlation)
+
+## 8) Suivi
+
+- PR merge: `Sprint S6: …`
+- CHANGELOG mis à jour (`[Unreleased]`)
+- Tickets follow‑up créés si besoin


### PR DESCRIPTION
## Summary
- mark Sprint S5 interactions as done and flag migration script for fix
- move US-22 to Done and add US-23 fix for Supabase migration naming
- bootstrap Sprint S6 docs and planning

## Testing
- `pnpm run lint`
- `pnpm test`
- `pnpm run validate:backlog` *(fails: US-00, US-01, US-02, US-12, US-20, US-30, US-31, US-40, US-41, US-42 missing fields)*

------
https://chatgpt.com/codex/tasks/task_e_68bae33f17b0832b82dbfe71b1c1a710