### PR TITLE
Sprint S10: fix Stripe redirect origin

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -24,3 +24,13 @@
   context: |
     tests: npm test
   status: done
+- who: ChatGPT
+  when: 2025-09-05T22:55:00Z
+  topic: Stripe success redirect
+  did: |
+    - Corrigé l'URL de redirection en utilisant l'en-tête Origin
+  ask: |
+    Vérifier que la page de succès s'affiche après paiement
+  context: |
+    commit: fix: respect request origin for Stripe URLs
+  status: pending

--- a/supabase/functions/create-checkout-session/index.ts
+++ b/supabase/functions/create-checkout-session/index.ts
@@ -61,7 +61,7 @@ serve(async (req: Request) => {
       });
     }
 
-    const origin = new URL(req.url).origin;
+    const origin = req.headers.get('origin') ?? new URL(req.url).origin;
 
     const session = await stripe.checkout.sessions.create({
       mode: 'payment',


### PR DESCRIPTION
## Summary
- ensure Stripe success and cancel URLs use request origin
- log interaction for fix

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bb69cb48cc832ba47f709c4f9e9e52