### PR TITLE
Sprint 10: accept hyphenated reservation codes

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -93,3 +93,14 @@
   context: |
     commit: fix inline QR attachment in reservation email
   status: pending
+- who: ChatGPT
+  when: 2025-09-06T22:45:00Z
+  topic: Validation code format
+  did: |
+    - Autorisé les codes de réservation avec tirets (RES-YYYY-DDD-NNNN)
+    - Mise à jour des tests de validation
+  ask: |
+    Vérifier qu'un code comme RES-2025-249-7908 est accepté
+  context: |
+    commit: fix accept hyphenated reservation codes
+  status: pending

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -33,7 +33,7 @@ describe('validateReservation', () => {
       single: vi.fn().mockResolvedValue({
         data: {
           id: 'res-1',
-          reservation_number: 'RES-1',
+          reservation_number: 'RES-2025-001-0001',
           payment_status: 'paid',
         },
         error: null,
@@ -56,7 +56,7 @@ describe('validateReservation', () => {
       throw new Error('unknown table ' + table);
     });
 
-    const res = await validateReservation('RES-1', 'poney');
+    const res = await validateReservation('RES-2025-001-0001', 'poney');
     expect(res).toEqual({ ok: true, reservationId: 'res-1' });
     expect(validationsTable.insert).toHaveBeenCalledWith({
       reservation_id: 'res-1',

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,7 +1,10 @@
 import { supabase } from './supabase';
 import { getCurrentUser } from './auth';
 
-const CODE_PATTERN = /^RES-[A-Za-z0-9]+$/;
+// Reservation numbers follow the pattern
+// RES-<year>-<day-of-year>-<4 random digits>
+// Example: RES-2025-249-7908
+const CODE_PATTERN = /^RES-\d{4}-\d{3}-\d{4}$/;
 
 export type ValidationActivity = 'poney' | 'tir_arc' | 'luge_bracelet';
 

--- a/tests/e2e/happy-path.test.ts
+++ b/tests/e2e/happy-path.test.ts
@@ -53,7 +53,9 @@ state.from = (table: string) => {
             const rec = {
               ...row,
               id,
-              reservation_number: `RES-${reservations.length + 1}`,
+              reservation_number: `RES-2025-001-${String(
+                reservations.length + 1,
+              ).padStart(4, '0')}`,
             };
             reservations.push(rec);
             return { data: { id }, error: null };
@@ -158,10 +160,16 @@ describe.skip('E2E happy path', () => {
     expect(reservations).toHaveLength(1);
     expect(emails[0]).toEqual({ email: 'a@b.c', reservationId: 'res-1' });
 
-    const first = await validateReservation('RES-1', 'luge_bracelet');
+    const first = await validateReservation(
+      'RES-2025-001-0001',
+      'luge_bracelet',
+    );
     expect(first).toEqual({ ok: true, reservationId: 'res-1' });
 
-    const second = await validateReservation('RES-1', 'luge_bracelet');
+    const second = await validateReservation(
+      'RES-2025-001-0001',
+      'luge_bracelet',
+    );
     expect(second).toEqual({ ok: false, reason: 'Déjà validé' });
   });
 });


### PR DESCRIPTION
## Summary
- handle reservation numbers formatted as `RES-YYYY-DDD-####`
- adjust validation tests for new code format

## Testing
- `pnpm test`
- `pnpm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc9d8c446c832bada0d675c52a5f34