### PR TITLE
Sprint S10: validation UX details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Toutes les modifications sont consignées ici. Suivre le format **Keep a Changel
 ### Corrigé
 
 - Renommage de la migration `extend_get_parc_activities_with_variants` et conversion du script de seed Luge en migration (US-23)
+- Amélioration de l'UX de validation : affichage du numéro de réservation et de la date lors du scan
 
 ---
 

--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -111,3 +111,16 @@
     - Le code est accepté mais l'ux n'est pas terrible. on a l'info que le code est validé mais ça aurait était bien d'avoir des informations. De plus quand je re-scan, ça me met que le scan est déjç validé.
     - Dans les fichiers interractions, rajoute une information indiquant la ou les prochaines tâches (20SP) à faire en cas de validation du PO
   action: Fix
+
+- who: ChatGPT
+  when: 2025-09-06T23:30:00Z
+  topic: Validation UX details
+  did: |
+    - Affiche le numéro de réservation et la date lors d'une validation
+    - Message détaillé pour les codes déjà validés
+  ask: |
+    Confirmer que la page de validation montre ces détails après scan
+  context: |
+    commit: fix show reservation details after validation
+    next: Si validé, prochaines tâches (20SP) — exposer plus d'infos de billet et historique de validations
+  status: pending

--- a/src/components/validation/ReservationValidationForm.tsx
+++ b/src/components/validation/ReservationValidationForm.tsx
@@ -304,12 +304,19 @@ export default function ReservationValidationForm({
       const res = await validateReservation(value.trim(), activity);
       if (res.ok) {
         setStatus('success');
-        setMessage('Validation enregistrée');
+        setMessage(`Réservation ${res.reservationNumber} validée`);
         if ('vibrate' in navigator) navigator.vibrate?.(60);
         setTimeout(() => setCode(''), 250);
       } else {
         setStatus('error');
-        setMessage(res.reason ?? 'Billet invalide');
+        if (res.reason === 'Déjà validé' && res.validation) {
+          const when = new Date(res.validation.validated_at);
+          setMessage(
+            `Réservation ${value.trim()} déjà validée le ${when.toLocaleDateString()} à ${when.toLocaleTimeString()}`,
+          );
+        } else {
+          setMessage(res.reason ?? 'Billet invalide');
+        }
       }
     } catch (e) {
       console.error(e);

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -57,7 +57,11 @@ describe('validateReservation', () => {
     });
 
     const res = await validateReservation('RES-2025-001-0001', 'poney');
-    expect(res).toEqual({ ok: true, reservationId: 'res-1' });
+    expect(res).toEqual({
+      ok: true,
+      reservationId: 'res-1',
+      reservationNumber: 'RES-2025-001-0001',
+    });
     expect(validationsTable.insert).toHaveBeenCalledWith({
       reservation_id: 'res-1',
       activity: 'poney',

--- a/tests/e2e/happy-path.test.ts
+++ b/tests/e2e/happy-path.test.ts
@@ -89,7 +89,12 @@ state.from = (table: string) => {
         }),
       }),
       insert: async (row: any) => {
-        validations.push(row);
+        const rec = {
+          id: `val-${validations.length + 1}`,
+          validated_at: new Date().toISOString(),
+          ...row,
+        };
+        validations.push(rec);
         return { error: null };
       },
     };
@@ -164,12 +169,23 @@ describe.skip('E2E happy path', () => {
       'RES-2025-001-0001',
       'luge_bracelet',
     );
-    expect(first).toEqual({ ok: true, reservationId: 'res-1' });
+    expect(first).toEqual({
+      ok: true,
+      reservationId: 'res-1',
+      reservationNumber: 'RES-2025-001-0001',
+    });
 
     const second = await validateReservation(
       'RES-2025-001-0001',
       'luge_bracelet',
     );
-    expect(second).toEqual({ ok: false, reason: 'Déjà validé' });
+    expect(second).toMatchObject({
+      ok: false,
+      reason: 'Déjà validé',
+      validation: {
+        validated_at: expect.any(String),
+        validated_by: 'prov-1',
+      },
+    });
   });
 });


### PR DESCRIPTION
## Summary
- show reservation number and validation timestamp in ticket validation flow
- log next steps in sprint interactions

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bca2a2a670832bb488958e3b499cb2