### PR TITLE
Sprint S10: show validator info on duplicate scan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Toutes les modifications sont consignées ici. Suivre le format **Keep a Changel
 - Utilitaires parsePrice, formatDate, slugify et clamp (US-100 à US-103)
 - Script de calcul de vélocité (IMP-06)
 - Aucun changement fonctionnel livré au sprint S9 (Spillover complet)
+- Affichage de l'opérateur et de la date lors d'une revalidation de billet
 
 ### Modifié
 

--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -124,3 +124,10 @@
     commit: fix show reservation details after validation
     next: Si validé, prochaines tâches (20SP) — exposer plus d'infos de billet et historique de validations
   status: pending
+- who: PO
+  topic: Validation UX details
+  reply: ok
+  details: |
+    - La page de validation affiche les détails après scan
+    - Implémente la suite
+  action: Implement next step

--- a/src/components/validation/ReservationValidationForm.tsx
+++ b/src/components/validation/ReservationValidationForm.tsx
@@ -311,8 +311,9 @@ export default function ReservationValidationForm({
         setStatus('error');
         if (res.reason === 'Déjà validé' && res.validation) {
           const when = new Date(res.validation.validated_at);
+          const who = res.validation.validated_by;
           setMessage(
-            `Réservation ${value.trim()} déjà validée le ${when.toLocaleDateString()} à ${when.toLocaleTimeString()}`,
+            `Réservation ${value.trim()} déjà validée le ${when.toLocaleDateString()} à ${when.toLocaleTimeString()} par ${who}`,
           );
         } else {
           setMessage(res.reason ?? 'Billet invalide');

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -68,4 +68,58 @@ describe('validateReservation', () => {
       validated_by: 'agent-1',
     });
   });
+
+  it('returns error with details if already validated', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({ id: 'agent-1' } as {
+      id: string;
+    });
+
+    const reservationsBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          id: 'res-1',
+          reservation_number: 'RES-2025-001-0001',
+          payment_status: 'paid',
+        },
+        error: null,
+      }),
+    };
+
+    const validationsQuery = {
+      eq: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockResolvedValue({
+        data: [
+          {
+            validated_at: '2025-01-01T10:00:00.000Z',
+            validated_by: 'agent-2',
+          },
+        ],
+        error: null,
+      }),
+    };
+
+    const validationsTable = {
+      select: vi.fn().mockReturnValue(validationsQuery),
+      insert: vi.fn().mockResolvedValue({ error: null }),
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'reservations') return reservationsBuilder as never;
+      if (table === 'reservation_validations') return validationsTable as never;
+      throw new Error('unknown table ' + table);
+    });
+
+    const res = await validateReservation('RES-2025-001-0001', 'poney');
+    expect(res).toEqual({
+      ok: false,
+      reason: 'Déjà validé',
+      validation: {
+        validated_at: '2025-01-01T10:00:00.000Z',
+        validated_by: 'agent-2',
+      },
+    });
+    expect(validationsTable.insert).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary
- show validator and timestamp when a ticket has already been scanned
- cover duplicate-scan behaviour in validateReservation tests
- note sprint interaction update

## Testing
- `pnpm run lint`
- `pnpm test`
- `pnpm run format` *(fails: Nested mappings are not allowed in compact mappings)*

------
https://chatgpt.com/codex/tasks/task_e_68bca845de88832b9be868eaaa7ffc77