### PR TITLE
Sprint S10: show agent email on double validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Toutes les modifications sont consignées ici. Suivre le format **Keep a Changel
 
 - Renommage de la migration `extend_get_parc_activities_with_variants` et conversion du script de seed Luge en migration (US-23)
 - Amélioration de l'UX de validation : affichage du numéro de réservation et de la date lors du scan
+- Affichage du nom de l'agent lors d'une revalidation de billet
 
 ---
 

--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -131,3 +131,19 @@
     - La page de validation affiche les détails après scan
     - Implémente la suite
   action: Implement next step
+- who: PO
+  topic: Nom agent validation
+  reply: ko
+  details: |
+    - C'est le numéro de l'agent qui est renseigné et pas son nom
+  action: Fix
+- who: ChatGPT
+  when: 2025-09-07T00:00:00Z
+  topic: Nom agent validation
+  did: |
+    - Affiche l'email de l'agent lors d'une revalidation
+  ask: |
+    Vérifier que l'email de l'agent s'affiche correctement
+  context: |
+    commit: fix show agent email on double validation
+  status: pending

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -105,9 +105,19 @@ describe('validateReservation', () => {
       insert: vi.fn().mockResolvedValue({ error: null }),
     };
 
+    const usersBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: { email: 'agent2@example.com' },
+        error: null,
+      }),
+    };
+
     vi.mocked(supabase.from).mockImplementation((table: string) => {
       if (table === 'reservations') return reservationsBuilder as never;
       if (table === 'reservation_validations') return validationsTable as never;
+      if (table === 'users') return usersBuilder as never;
       throw new Error('unknown table ' + table);
     });
 
@@ -117,7 +127,7 @@ describe('validateReservation', () => {
       reason: 'Déjà validé',
       validation: {
         validated_at: '2025-01-01T10:00:00.000Z',
-        validated_by: 'agent-2',
+        validated_by: 'agent2@example.com',
       },
     });
     expect(validationsTable.insert).not.toHaveBeenCalled();

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -59,12 +59,19 @@ export async function validateReservation(
     .limit(1);
   if (existing && existing.length > 0) {
     const first = existing[0];
+    let who = first.validated_by as string;
+    const { data: agent } = await supabase
+      .from('users')
+      .select('email')
+      .eq('id', first.validated_by)
+      .single();
+    if (agent?.email) who = agent.email;
     return {
       ok: false,
       reason: 'Déjà validé',
       validation: {
         validated_at: first.validated_at as string,
-        validated_by: first.validated_by as string,
+        validated_by: who,
       },
     };
   }

--- a/tests/e2e/happy-path.test.ts
+++ b/tests/e2e/happy-path.test.ts
@@ -98,6 +98,18 @@ state.from = (table: string) => {
         return { error: null };
       },
     };
+  if (table === 'users')
+    return {
+      select: () => ({
+        eq: (_c: string, _val: string) => ({
+          single: () =>
+            Promise.resolve({
+              data: { email: 'p@test.com' },
+              error: null,
+            }),
+        }),
+      }),
+    };
   return {} as any;
 };
 
@@ -184,7 +196,7 @@ describe.skip('E2E happy path', () => {
       reason: 'Déjà validé',
       validation: {
         validated_at: expect.any(String),
-        validated_by: 'prov-1',
+        validated_by: 'p@test.com',
       },
     });
   });


### PR DESCRIPTION
## Summary
- show validator email instead of internal id when a ticket is scanned twice
- document interaction and changelog entries

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcac12bbf4832bb585d8968d930675