### PR TITLE
Sprint S10: enforce activity guard in validation

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -147,3 +147,20 @@
   context: |
     commit: fix show agent email on double validation
   status: pending
+- who: PO
+  topic: Nom agent validation
+  reply: ok
+  details: |
+    - L'email de l'agent s'affiche correctement lors d'une double validation
+  action: Implement activity guard for reservations
+- who: ChatGPT
+  when: 2025-09-07T10:00:00Z
+  topic: Activity guard validation
+  did: |
+    - Contrôle que la réservation correspond bien à l'activité demandée
+    - Ajout d'un test pour une activité non correspondante
+  ask: |
+    Vérifier qu'un billet ne peut pas être validé pour une autre activité
+  context: |
+    commit: fix ensure reservation matches activity
+  status: pending


### PR DESCRIPTION
## Summary
- ensure reservations can only be validated for their booked activity
- cover activity mismatch with unit tests

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcb4690400832bb6a1307f88c3d34a