### PR TITLE
Sprint S10 : retour enrichi côté validation

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -154,6 +154,17 @@
     - L'email de l'agent s'affiche correctement lors d'une double validation
   action: Implement activity guard for reservations
 - who: ChatGPT
+  when: 2025-09-07T12:00:00Z
+  topic: Validation enriched response
+  did: |
+    - Retourne les informations billet (email, pass, créneau...) lors de la validation
+  ask: |
+    Confirmer que le poste de contrôle affiche bien ces détails
+  context: |
+    commit: feat include reservation details in validation
+    next: Ajouter l'historique des validations (20SP)
+  status: pending
+- who: ChatGPT
   when: 2025-09-07T10:00:00Z
   topic: Activity guard validation
   did: |

--- a/src/components/validation/ReservationValidationForm.tsx
+++ b/src/components/validation/ReservationValidationForm.tsx
@@ -304,7 +304,7 @@ export default function ReservationValidationForm({
       const res = await validateReservation(value.trim(), activity);
       if (res.ok) {
         setStatus('success');
-        setMessage(`Réservation ${res.reservationNumber} validée`);
+        setMessage(`Réservation ${res.reservation.number} validée`);
         if ('vibrate' in navigator) navigator.vibrate?.(60);
         setTimeout(() => setCode(''), 250);
       } else {

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -34,8 +34,16 @@ describe('validateReservation', () => {
         data: {
           id: 'res-1',
           reservation_number: 'RES-2025-001-0001',
+          client_email: 'c@example.com',
           payment_status: 'paid',
+          created_at: '2025-01-01T09:00:00.000Z',
+          pass: { id: 'pass-1', name: 'Pass Poney' },
           event_activities: { activities: { name: 'poney' } },
+          time_slots: {
+            id: 'slot-1',
+            start_at: '2025-01-02T10:00:00.000Z',
+            end_at: '2025-01-02T11:00:00.000Z',
+          },
         },
         error: null,
       }),
@@ -60,8 +68,20 @@ describe('validateReservation', () => {
     const res = await validateReservation('RES-2025-001-0001', 'poney');
     expect(res).toEqual({
       ok: true,
-      reservationId: 'res-1',
-      reservationNumber: 'RES-2025-001-0001',
+      reservation: {
+        id: 'res-1',
+        number: 'RES-2025-001-0001',
+        client_email: 'c@example.com',
+        payment_status: 'paid',
+        created_at: '2025-01-01T09:00:00.000Z',
+        pass: { id: 'pass-1', name: 'Pass Poney' },
+        activity: 'poney',
+        time_slot: {
+          id: 'slot-1',
+          start_at: '2025-01-02T10:00:00.000Z',
+          end_at: '2025-01-02T11:00:00.000Z',
+        },
+      },
     });
     expect(validationsTable.insert).toHaveBeenCalledWith({
       reservation_id: 'res-1',
@@ -82,7 +102,9 @@ describe('validateReservation', () => {
         data: {
           id: 'res-1',
           reservation_number: 'RES-2025-001-0001',
+          client_email: 'c@example.com',
           payment_status: 'paid',
+          created_at: '2025-01-01T09:00:00.000Z',
           event_activities: { activities: { name: 'poney' } },
         },
         error: null,
@@ -147,7 +169,9 @@ describe('validateReservation', () => {
         data: {
           id: 'res-1',
           reservation_number: 'RES-2025-001-0001',
+          client_email: 'c@example.com',
           payment_status: 'paid',
+          created_at: '2025-01-01T09:00:00.000Z',
           event_activities: { activities: { name: 'tir_arc' } },
         },
         error: null,


### PR DESCRIPTION
## Summary
- enrich validateReservation to return full reservation details
- adjust validation form and tests for new response shape

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcbdf3f8a8832b8632fea1bd60b7b5