### PR TITLE
Sprint S10: fix reservation pass relation in validation query

### DIFF
--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -54,7 +54,7 @@ export async function validateReservation(
   const { data, error } = await supabase
     .from('reservations')
     .select(
-      'id,reservation_number,client_email,payment_status,created_at,pass(id,name),event_activities(activities(name)),time_slots(id,start_at,end_at)',
+      'id,reservation_number,client_email,payment_status,created_at,pass:passes(id,name),event_activities(activities(name)),time_slots(id,start_at,end_at)',
     )
     .eq('reservation_number', trimmed)
     .single<ReservationLookup>();


### PR DESCRIPTION
## Summary
- fix reservation validation query by aliasing passes relation

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bcc20780d8832ba4b5ac1840bb5eb8