### PR TITLE
Sprint S10: expose reserved activity mismatch

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -187,3 +187,15 @@
   context: |
     commit: feat return previous validation info
   status: pending
+- who: ChatGPT
+  when: 2025-09-08T00:00:00Z
+  topic: Activity mismatch explicit message
+  did: |
+    - Expose l'activité réservée vs demandée dans validateReservation
+    - Affiche un message détaillé dans le formulaire de contrôle
+    - Teste le retour meta {reservedActivity, requested}
+  ask: |
+    Confirmer que le staff voit l'activité attendue lors d'un mauvais scan
+  context: |
+    commit: feat expose reserved activity mismatch
+  status: pending

--- a/src/components/validation/ReservationValidationForm.tsx
+++ b/src/components/validation/ReservationValidationForm.tsx
@@ -306,23 +306,36 @@ export default function ReservationValidationForm({
         if (res.alreadyValidated) {
           setStatus('error');
           const when = new Date(res.validation.validated_at);
-          const who = res.validation.validated_by_email ?? res.validation.validated_by;
-          setMessage(`Billet déjà validé le ${when.toLocaleDateString('fr-FR')} à ${when.toLocaleTimeString('fr-FR')} par ${who}`);
+          const who =
+            res.validation.validated_by_email ?? res.validation.validated_by;
+          setMessage(
+            `Billet déjà validé le ${when.toLocaleDateString('fr-FR')} à ${when.toLocaleTimeString('fr-FR')} par ${who}`,
+          );
         } else {
           setStatus('success');
           const details = [
             `Réservation: ${res.reservation.number}`,
             `Client: ${res.reservation.client_email}`,
             res.reservation.pass ? `Pass: ${res.reservation.pass.name}` : null,
-            res.reservation.time_slot ? `Créneau: ${new Date(res.reservation.time_slot.slot_time).toLocaleTimeString('fr-FR')}` : null
-          ].filter(Boolean).join(' • ');
+            res.reservation.time_slot
+              ? `Créneau: ${new Date(res.reservation.time_slot.slot_time).toLocaleTimeString('fr-FR')}`
+              : null,
+          ]
+            .filter(Boolean)
+            .join(' • ');
           setMessage(`✅ Validation réussie • ${details}`);
           if ('vibrate' in navigator) navigator.vibrate?.(60);
           setTimeout(() => setCode(''), 250);
         }
       } else {
         setStatus('error');
-        setMessage(res.reason ?? 'Billet invalide');
+        if (res.meta?.reservedActivity && res.meta?.requested) {
+          setMessage(
+            `${res.reason} (billet pour ${res.meta.reservedActivity}, activité ${res.meta.requested})`,
+          );
+        } else {
+          setMessage(res.reason ?? 'Billet invalide');
+        }
       }
     } catch (e) {
       console.error(e);

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -197,6 +197,7 @@ describe('validateReservation', () => {
     expect(res).toEqual({
       ok: false,
       reason: 'Réservation invalide pour cette activité',
+      meta: { reservedActivity: 'tir_arc', requested: 'poney' },
     });
     expect(validationsTable.insert).not.toHaveBeenCalled();
   });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -48,6 +48,7 @@ export async function validateReservation(
   | {
       ok: false;
       reason: string;
+      meta?: { reservedActivity: string | null; requested: ValidationActivity };
     }
 > {
   const trimmed = reservationCode.trim();
@@ -73,7 +74,7 @@ export async function validateReservation(
 
   // 2) Activity guard - ensure reservation matches requested activity
   const reservedActivity = data.event_activities?.activities?.name;
-  
+
   // 3) Check for existing validation first (before activity guard)
   const { data: existing, error: validationError } = await supabase
     .from('reservation_validations')
@@ -112,7 +113,11 @@ export async function validateReservation(
 
   // 4) Activity guard - ensure reservation matches requested activity
   if (!reservedActivity || reservedActivity !== activity)
-    return { ok: false, reason: 'Réservation invalide pour cette activité' };
+    return {
+      ok: false,
+      reason: 'Réservation invalide pour cette activité',
+      meta: { reservedActivity: reservedActivity ?? null, requested: activity },
+    };
 
   // 5) Insert validation
   const { error: insertError } = await supabase


### PR DESCRIPTION
## Summary
- return reserved vs requested activity when validation fails
- surface detailed mismatch message to staff in validation form
- cover reservation activity mismatch scenario with unit test

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bccc29080c832bba16e4f161da52e1