### PR TITLE
Sprint S10: explicit activity mismatch message

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -212,3 +212,14 @@
     commit: feat normalize reservation validation payload
     next: Supporter l'annulation de validation (20SP)
   status: pending
+- who: ChatGPT
+  when: 2025-09-08T15:44:00Z
+  topic: Activity mismatch explicit message (API)
+  did: |
+    - Retourne ok:false et les activités réservée/demandée via meta
+    - Met à jour les tests de validation
+  ask: |
+    Confirmer que la nouvelle réponse convient
+  context: |
+    commit: feat return activity mismatch meta
+  status: pending

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -40,6 +40,7 @@ describe('validateReservation', () => {
         alreadyValidated: false,
         validated: false,
       },
+      ok: false,
     });
   });
 
@@ -137,6 +138,7 @@ describe('validateReservation', () => {
         alreadyValidated: false,
         validated: true,
       },
+      ok: true,
     });
     expect(validationsTable.insert).toHaveBeenCalledWith({
       reservation_id: 'res-1',
@@ -233,6 +235,7 @@ describe('validateReservation', () => {
         alreadyValidated: true,
         validated: false,
       },
+      ok: false,
     });
     expect(validationsTable.insert).not.toHaveBeenCalled();
   });
@@ -299,6 +302,9 @@ describe('validateReservation', () => {
         alreadyValidated: false,
         validated: false,
       },
+      ok: false,
+      reason: 'Réservation invalide pour cette activité',
+      meta: { reservedActivity: 'tir_arc', requested: 'poney' },
     });
     expect(validationsTable.insert).not.toHaveBeenCalled();
   });

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -46,6 +46,9 @@ export interface ValidationPayload {
     alreadyValidated: boolean;
     validated: boolean;
   };
+  ok: boolean;
+  reason?: string;
+  meta?: { reservedActivity: string | null; requested: ValidationActivity };
 }
 
 export async function validateReservation(
@@ -74,6 +77,7 @@ export async function validateReservation(
       alreadyValidated: false,
       validated: false,
     },
+    ok: false,
   };
 
   const trimmed = reservationCode.trim();
@@ -179,6 +183,14 @@ export async function validateReservation(
       });
       payload.status.validated = true;
     }
+  }
+  payload.ok = payload.status.validated;
+  if (!payload.ok && payload.status.wrongActivity) {
+    payload.reason = 'Réservation invalide pour cette activité';
+    payload.meta = {
+      reservedActivity: payload.reservation.activity_expected,
+      requested: activity,
+    };
   }
 
   return payload;


### PR DESCRIPTION
## Summary
- return explicit activity mismatch info with `ok`, `reason`, and activity details in validation payload
- log sprint interaction for activity mismatch message

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bda78f31fc832bae93e5fa1aa7f000