### PR TITLE
Sprint S10: show details for already validated ticket

### DIFF
--- a/src/components/validation/ReservationValidationForm.tsx
+++ b/src/components/validation/ReservationValidationForm.tsx
@@ -322,8 +322,20 @@ export default function ReservationValidationForm({
         const first = res.history[0];
         const when = new Date(first.validated_at);
         const who = first.validated_by_email ?? first.validated_by;
+        const details = [
+          `Réservation: ${res.reservation.number}`,
+          `Client: ${res.reservation.client_email}`,
+          res.reservation.pass ? `Pass: ${res.reservation.pass.name}` : null,
+          res.reservation.time_slot
+            ? `Créneau: ${new Date(
+                res.reservation.time_slot.slot_time,
+              ).toLocaleTimeString('fr-FR')}`
+            : null,
+        ]
+          .filter(Boolean)
+          .join(' • ');
         setMessage(
-          `Billet déjà validé le ${when.toLocaleDateString('fr-FR')} à ${when.toLocaleTimeString('fr-FR')} par ${who}`,
+          `Billet déjà validé le ${when.toLocaleDateString('fr-FR')} à ${when.toLocaleTimeString('fr-FR')} par ${who} • ${details}`,
         );
       } else if (res.status.wrongActivity) {
         setStatus('error');

--- a/src/components/validation/__tests__/ReservationValidationForm.test.tsx
+++ b/src/components/validation/__tests__/ReservationValidationForm.test.tsx
@@ -1,6 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import ReservationValidationForm from '../ReservationValidationForm';
+import { validateReservation } from '../../../lib/validation';
 
 vi.mock('../../../lib/validation', () => ({
   validateReservation: vi.fn(),
@@ -10,5 +11,47 @@ describe('ReservationValidationForm', () => {
   it('hides stop camera button when scanner inactive', () => {
     render(<ReservationValidationForm activity="poney" title="Validation" />);
     expect(screen.queryByText(/Arrêter la caméra/i)).toBeNull();
+  });
+
+  it('shows reservation details when ticket already validated', async () => {
+    const mockValidate = validateReservation as unknown as vi.Mock;
+    mockValidate.mockResolvedValueOnce({
+      status: {
+        alreadyValidated: true,
+        validated: false,
+        invalid: false,
+        notFound: false,
+        unpaid: false,
+        wrongActivity: false,
+      },
+      history: [
+        {
+          validated_at: '2025-09-06T20:57:25.000Z',
+          validated_by: 'admin',
+          validated_by_email: 'admin@test.com',
+        },
+      ],
+      reservation: {
+        number: 'RES-2025-249-7908',
+        client_email: 'client@example.com',
+        pass: { name: 'Pass Day' },
+        time_slot: { slot_time: '2025-09-06T20:00:00.000Z' },
+      },
+      requested_activity: 'poney',
+      ok: false,
+    });
+
+    render(<ReservationValidationForm activity="poney" title="Validation" />);
+
+    fireEvent.change(screen.getByPlaceholderText(/Saisissez le code/i), {
+      target: { value: 'RES-2025-249-7908' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /Valider le billet/i }));
+
+    const msg = await screen.findByText(/Billet déjà validé le/i);
+    expect(msg.textContent).toContain('Réservation: RES-2025-249-7908');
+    expect(msg.textContent).toContain('Client: client@example.com');
+    expect(msg.textContent).toContain('Pass: Pass Day');
+    expect(msg.textContent).toMatch(/Créneau: \d{2}:\d{2}/);
   });
 });


### PR DESCRIPTION
## Summary
- ensure already validated tickets display reservation details
- cover already validated ticket with test

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdab5900fc832bbf66b0d774661e37