### PR TITLE
Sprint S: validation history utilities

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1216,6 +1216,9 @@ CREATE INDEX "idx_passes_is_park" ON "public"."passes" USING "btree" ("is_park")
 
 CREATE INDEX "idx_reservations_email" ON "public"."reservations" USING "btree" ("client_email");
 
+CREATE INDEX "idx_reservation_validations_validated_at_desc" ON "public"."reservation_validations" USING "btree" ("validated_at" DESC);
+CREATE INDEX "idx_reservation_validations_activity" ON "public"."reservation_validations" USING "btree" ("activity");
+CREATE INDEX "idx_reservation_validations_validated_by" ON "public"."reservation_validations" USING "btree" ("validated_by");
 
 
 CREATE INDEX "idx_shop_products_shop_id" ON "public"."shop_products" USING "btree" ("shop_id");

--- a/src/lib/__tests__/history.test.ts
+++ b/src/lib/__tests__/history.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../supabase', () => ({ supabase: { from: vi.fn() } }));
+vi.mock('../auth', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('../logger', () => ({ debugLog: vi.fn() }));
+
+import { fetchValidationHistory, exportValidationHistoryCSV } from '../history';
+import { supabase } from '../supabase';
+import { getCurrentUser } from '../auth';
+import { debugLog } from '../logger';
+
+describe('history utils', () => {
+  it('fetches history with filters', async () => {
+    const rows = [
+      {
+        id: 'val-1',
+        validated_at: '2025-01-01T10:00:00Z',
+        activity: 'poney',
+        reservations: {
+          reservation_number: 'RES-1',
+          client_email: 'client@example.com',
+          payment_status: 'paid',
+          pass: { name: 'Pass Poney' },
+        },
+        agent: { email: 'agent@example.com' },
+      },
+    ];
+
+    const builder = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      lte: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      or: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      range: vi.fn().mockReturnThis(),
+      then: vi.fn((resolve) => resolve({ data: rows, error: null, count: 1 })),
+    };
+
+    const user = { id: 'user-1' };
+    vi.mocked(getCurrentUser).mockResolvedValue(user);
+    vi.mocked(debugLog).mockImplementation(() => {});
+    vi.mocked(supabase.from).mockReturnValue(builder as never);
+
+    const result = await fetchValidationHistory({
+      startDate: '2025-01-01',
+      activities: ['poney'],
+      search: 'RES-1',
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(builder.gte).toHaveBeenCalledWith('validated_at', '2025-01-01');
+    expect(builder.in).toHaveBeenCalledWith('activity', ['poney']);
+    expect(builder.or).toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 'val-1',
+        validated_at: '2025-01-01T10:00:00Z',
+        reservation_number: 'RES-1',
+        client_email: 'client@example.com',
+        pass_name: 'Pass Poney',
+        activity: 'poney',
+        agent_email: 'agent@example.com',
+        payment_status: 'paid',
+      },
+    ]);
+  });
+
+  it('exports csv', () => {
+    const csv = exportValidationHistoryCSV([
+      {
+        id: '1',
+        validated_at: '2025-01-01',
+        reservation_number: 'RES-1',
+        client_email: 'c@example.com',
+        pass_name: 'Pass',
+        activity: 'poney',
+        agent_email: 'a@example.com',
+        payment_status: 'paid',
+      },
+    ]);
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('validated_at');
+    expect(lines[1]).toContain('RES-1');
+  });
+});

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,157 @@
+import { supabase } from './supabase';
+import { getCurrentUser } from './auth';
+import { debugLog } from './logger';
+
+export interface ValidationHistoryFilters {
+  startDate?: string;
+  endDate?: string;
+  activities?: string[];
+  agentId?: string;
+  status?: 'validated' | 'already_validated';
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ValidationHistoryRow {
+  id: string;
+  validated_at: string;
+  reservation_number: string;
+  client_email: string;
+  pass_name: string | null;
+  activity: string;
+  agent_email: string | null;
+  payment_status: string;
+}
+
+interface RawHistoryRow {
+  id: string;
+  validated_at: string;
+  activity: string;
+  reservations?: {
+    reservation_number?: string;
+    client_email?: string;
+    payment_status?: string;
+    pass?: { name?: string } | null;
+  } | null;
+  agent?: { email?: string | null } | null;
+}
+
+/**
+ * Fetch reservation validations history with optional filters.
+ * Filters can be combined; server-side pagination supported via limit/offset.
+ */
+export async function fetchValidationHistory(
+  filters: ValidationHistoryFilters = {},
+): Promise<ValidationHistoryRow[]> {
+  const me = await getCurrentUser();
+
+  const query = supabase
+    .from('reservation_validations')
+    .select(
+      `id,validated_at,activity,reservations:reservations(id,reservation_number,client_email,payment_status,pass:passes(name)),agent:users(email)`,
+      { count: 'exact' },
+    )
+    .order('validated_at', { ascending: false });
+
+  if (filters.startDate) query.gte('validated_at', filters.startDate);
+  if (filters.endDate) query.lte('validated_at', filters.endDate);
+  if (filters.activities && filters.activities.length)
+    query.in('activity', filters.activities);
+  if (filters.agentId) query.eq('validated_by', filters.agentId);
+  if (filters.search)
+    query.or(
+      `reservations.reservation_number.eq.${filters.search},reservations.client_email.eq.${filters.search}`,
+    );
+  if (typeof filters.limit === 'number') query.limit(filters.limit);
+  if (typeof filters.offset === 'number' && typeof filters.limit === 'number')
+    query.range(filters.offset, filters.offset + filters.limit - 1);
+
+  const { data, error, count } = await query;
+  if (me) {
+    const safeFilters = JSON.stringify(filters);
+    debugLog('history_access', {
+      user_id: me.id,
+      filters: safeFilters,
+      count: count ?? data?.length ?? 0,
+    });
+  }
+  if (error || !data) return [];
+
+  return (data as RawHistoryRow[]).map((row) => ({
+    id: row.id,
+    validated_at: row.validated_at,
+    reservation_number: row.reservations?.reservation_number ?? '',
+    client_email: row.reservations?.client_email ?? '',
+    pass_name: row.reservations?.pass?.name ?? null,
+    activity: row.activity,
+    agent_email: row.agent?.email ?? null,
+    payment_status: row.reservations?.payment_status ?? '',
+  }));
+}
+
+export interface ValidationDetail {
+  reservation_number: string;
+  client_email: string;
+  payment_status: string;
+  created_at: string;
+  pass_name: string | null;
+  activity: string;
+  validated_at: string;
+  agent_email: string | null;
+}
+
+/** Fetch detailed info for a single validation record. */
+export async function fetchValidationDetail(
+  id: string,
+): Promise<ValidationDetail | null> {
+  const { data, error } = await supabase
+    .from('reservation_validations')
+    .select(
+      `validated_at,activity,reservations:reservations(reservation_number,client_email,payment_status,created_at,pass:passes(name)),agent:users(email)`,
+    )
+    .eq('id', id)
+    .single();
+
+  if (error || !data) return null;
+
+  return {
+    reservation_number: data.reservations?.reservation_number ?? '',
+    client_email: data.reservations?.client_email ?? '',
+    payment_status: data.reservations?.payment_status ?? '',
+    created_at: data.reservations?.created_at ?? '',
+    pass_name: data.reservations?.pass?.name ?? null,
+    activity: data.activity as string,
+    validated_at: data.validated_at as string,
+    agent_email: data.agent?.email ?? null,
+  } as ValidationDetail;
+}
+
+/**
+ * Convert history rows to CSV string for export.
+ */
+export function exportValidationHistoryCSV(
+  rows: ValidationHistoryRow[],
+): string {
+  const header = [
+    'validated_at',
+    'reservation_number',
+    'pass_name',
+    'activity',
+    'agent_email',
+    'payment_status',
+  ];
+  const csvRows = rows.map((r) =>
+    [
+      r.validated_at,
+      r.reservation_number,
+      r.pass_name ?? '',
+      r.activity,
+      r.agent_email ?? '',
+      r.payment_status,
+    ]
+      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+      .join(','),
+  );
+  return [header.join(','), ...csvRows].join('\n');
+}

--- a/supabase/migrations/20250907000000_add_validation_indexes.sql
+++ b/supabase/migrations/20250907000000_add_validation_indexes.sql
@@ -1,0 +1,9 @@
+-- Add indexes to reservation_validations for faster history queries
+CREATE INDEX IF NOT EXISTS idx_reservation_validations_validated_at_desc
+  ON public.reservation_validations (validated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_reservation_validations_activity
+  ON public.reservation_validations (activity);
+
+CREATE INDEX IF NOT EXISTS idx_reservation_validations_validated_by
+  ON public.reservation_validations (validated_by);


### PR DESCRIPTION
## Summary
- add database indexes for reservation validation history queries
- implement validation history retrieval, detail fetch and CSV export utilities

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb8bc1508832b80495a30379e3241