### PR TITLE
Sprint S: validation history utilities

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -223,3 +223,14 @@
   context: |
     commit: feat return activity mismatch meta
   status: pending
+- who: ChatGPT
+  when: 2025-09-08T19:55:00Z
+  topic: Validation history
+  did: |
+    - Ajout de l'historique des validations avec filtres et recherche
+    - Support de l'annulation avec RLS admin
+  ask: |
+    Valider l'UI et la révocation
+  context: |
+    commit: feat add validation history ui and revocation
+  status: pending

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import ArcheryValidation from './pages/provider/ArcheryValidation';
 import LugeValidation from './pages/provider/LugeValidation';
 import ProviderStats from './pages/provider/Stats';
 import LugeCounter from './pages/provider/LugeCounter';
+import ValidationHistory from './pages/provider/ValidationHistory';
 
 export default function App() {
   return (
@@ -83,6 +84,7 @@ export default function App() {
             <Route path="luge" element={<LugeValidation />} />
             <Route path="luge-counter" element={<LugeCounter />} />
             <Route path="stats" element={<ProviderStats />} />
+            <Route path="history" element={<ValidationHistory />} />
           </Route>
         </Routes>
 

--- a/src/lib/__tests__/history.test.ts
+++ b/src/lib/__tests__/history.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, vi } from 'vitest';
+vi.mock('../supabase', () => ({ supabase: { from: vi.fn() } }));
+vi.mock('../auth', () => ({ getCurrentUser: vi.fn() }));
+vi.mock('../logger', () => ({ debugLog: vi.fn() }));
+
+import {
+  fetchValidationHistory,
+  exportValidationHistoryCSV,
+  revokeValidation,
+} from '../history';
+import { supabase } from '../supabase';
+import { getCurrentUser } from '../auth';
+import { debugLog } from '../logger';
+
+describe('history utils', () => {
+  it('fetches history with filters', async () => {
+    const rows = [
+      {
+        id: 'val-1',
+        validated_at: '2025-01-01T10:00:00Z',
+        activity: 'poney',
+        revoked_at: null,
+        reservations: {
+          reservation_number: 'RES-1',
+          client_email: 'client@example.com',
+          payment_status: 'paid',
+          pass: { name: 'Pass Poney' },
+        },
+        agent: { email: 'agent@example.com' },
+      },
+    ];
+
+    const builder = {
+      select: vi.fn().mockReturnThis(),
+      order: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      lte: vi.fn().mockReturnThis(),
+      in: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      or: vi.fn().mockReturnThis(),
+      limit: vi.fn().mockReturnThis(),
+      range: vi.fn().mockReturnThis(),
+      then: vi.fn((resolve) => resolve({ data: rows, error: null, count: 1 })),
+    };
+
+    const user = { id: 'user-1' };
+    vi.mocked(getCurrentUser).mockResolvedValue(user);
+    vi.mocked(debugLog).mockImplementation(() => {});
+    vi.mocked(supabase.from).mockReturnValue(builder as never);
+
+    const result = await fetchValidationHistory({
+      startDate: '2025-01-01',
+      activities: ['poney'],
+      search: 'RES-1',
+      limit: 10,
+      offset: 0,
+    });
+
+    expect(builder.gte).toHaveBeenCalledWith('validated_at', '2025-01-01');
+    expect(builder.in).toHaveBeenCalledWith('activity', ['poney']);
+    expect(builder.or).toHaveBeenCalled();
+    expect(result).toEqual([
+      {
+        id: 'val-1',
+        validated_at: '2025-01-01T10:00:00Z',
+        revoked_at: null,
+        reservation_number: 'RES-1',
+        client_email: 'client@example.com',
+        pass_name: 'Pass Poney',
+        activity: 'poney',
+        agent_email: 'agent@example.com',
+        payment_status: 'paid',
+        status: 'validated',
+      },
+    ]);
+  });
+
+  it('exports csv', () => {
+    const csv = exportValidationHistoryCSV([
+      {
+        id: '1',
+        validated_at: '2025-01-01',
+        revoked_at: null,
+        reservation_number: 'RES-1',
+        client_email: 'c@example.com',
+        pass_name: 'Pass',
+        activity: 'poney',
+        agent_email: 'a@example.com',
+        payment_status: 'paid',
+        status: 'validated',
+      },
+    ]);
+    const lines = csv.split('\n');
+    expect(lines[0]).toContain('validated_at');
+    expect(lines[1]).toContain('RES-1');
+  });
+
+  it('revokes validation', async () => {
+    const user = { id: 'admin-1' };
+    const updater = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    };
+    vi.mocked(getCurrentUser).mockResolvedValue(user);
+    vi.mocked(debugLog).mockImplementation(() => {});
+    vi.mocked(supabase.from).mockReturnValue(updater as never);
+
+    const ok = await revokeValidation('val-1', 'mistake');
+    expect(updater.update).toHaveBeenCalled();
+    expect(ok).toBe(true);
+    expect(debugLog).toHaveBeenCalled();
+  });
+});

--- a/src/lib/history.ts
+++ b/src/lib/history.ts
@@ -1,0 +1,194 @@
+import { supabase } from './supabase';
+import { getCurrentUser } from './auth';
+import { debugLog } from './logger';
+
+export interface ValidationHistoryFilters {
+  startDate?: string;
+  endDate?: string;
+  activities?: string[];
+  agentId?: string;
+  status?: 'validated' | 'revoked';
+  search?: string;
+  limit?: number;
+  offset?: number;
+}
+
+export interface ValidationHistoryRow {
+  id: string;
+  validated_at: string;
+  revoked_at: string | null;
+  reservation_number: string;
+  client_email: string;
+  pass_name: string | null;
+  activity: string;
+  agent_email: string | null;
+  payment_status: string;
+  status: 'validated' | 'revoked';
+}
+
+interface RawHistoryRow {
+  id: string;
+  validated_at: string;
+  revoked_at: string | null;
+  activity: string;
+  reservations?: {
+    reservation_number?: string;
+    client_email?: string;
+    payment_status?: string;
+    pass?: { name?: string } | null;
+  } | null;
+  agent?: { email?: string | null } | null;
+}
+
+/**
+ * Fetch reservation validations history with optional filters.
+ * Filters can be combined; server-side pagination supported via limit/offset.
+ */
+export async function fetchValidationHistory(
+  filters: ValidationHistoryFilters = {},
+): Promise<ValidationHistoryRow[]> {
+  const me = await getCurrentUser();
+
+  const query = supabase
+    .from('reservation_validations')
+    .select(
+      `id,validated_at,revoked_at,activity,reservations:reservations(id,reservation_number,client_email,payment_status,pass:passes(name)),agent:users(email)`,
+      { count: 'exact' },
+    )
+    .order('validated_at', { ascending: false });
+
+  if (filters.startDate) query.gte('validated_at', filters.startDate);
+  if (filters.endDate) query.lte('validated_at', filters.endDate);
+  if (filters.activities && filters.activities.length)
+    query.in('activity', filters.activities);
+  if (filters.agentId) query.eq('validated_by', filters.agentId);
+  if (filters.status === 'revoked') query.not('revoked_at', 'is', null);
+  if (filters.status === 'validated') query.is('revoked_at', null);
+  if (filters.search)
+    query.or(
+      `reservations.reservation_number.eq.${filters.search},reservations.client_email.eq.${filters.search}`,
+    );
+  if (typeof filters.limit === 'number') query.limit(filters.limit);
+  if (typeof filters.offset === 'number' && typeof filters.limit === 'number')
+    query.range(filters.offset, filters.offset + filters.limit - 1);
+
+  const { data, error, count } = await query;
+  if (me) {
+    const safeFilters = JSON.stringify(filters);
+    debugLog('history_access', {
+      user_id: me.id,
+      filters: safeFilters,
+      count: count ?? data?.length ?? 0,
+    });
+  }
+  if (error || !data) return [];
+
+  return (data as RawHistoryRow[]).map((row) => ({
+    id: row.id,
+    validated_at: row.validated_at,
+    revoked_at: row.revoked_at ?? null,
+    reservation_number: row.reservations?.reservation_number ?? '',
+    client_email: row.reservations?.client_email ?? '',
+    pass_name: row.reservations?.pass?.name ?? null,
+    activity: row.activity,
+    agent_email: row.agent?.email ?? null,
+    payment_status: row.reservations?.payment_status ?? '',
+    status: row.revoked_at ? 'revoked' : 'validated',
+  }));
+}
+
+export interface ValidationDetail {
+  reservation_number: string;
+  client_email: string;
+  payment_status: string;
+  created_at: string;
+  pass_id: string | null;
+  pass_name: string | null;
+  activity: string;
+  time_slot_start: string | null;
+  time_slot_end: string | null;
+  validated_at: string;
+  agent_email: string | null;
+  revoked_at: string | null;
+  revoke_reason: string | null;
+}
+
+/** Fetch detailed info for a single validation record. */
+export async function fetchValidationDetail(
+  id: string,
+): Promise<ValidationDetail | null> {
+  const { data, error } = await supabase
+    .from('reservation_validations')
+    .select(
+      `validated_at,revoked_at,revoke_reason,activity,reservations:reservations(reservation_number,client_email,payment_status,created_at,pass_id,pass:passes(name),time_slot:time_slots(start_at,end_at)),agent:users(email)`,
+    )
+    .eq('id', id)
+    .single();
+
+  if (error || !data) return null;
+  return {
+    reservation_number: data.reservations?.reservation_number ?? '',
+    client_email: data.reservations?.client_email ?? '',
+    payment_status: data.reservations?.payment_status ?? '',
+    created_at: data.reservations?.created_at ?? '',
+    pass_id: data.reservations?.pass_id ?? null,
+    pass_name: data.reservations?.pass?.name ?? null,
+    activity: data.activity as string,
+    time_slot_start: data.reservations?.time_slot?.start_at ?? null,
+    time_slot_end: data.reservations?.time_slot?.end_at ?? null,
+    validated_at: data.validated_at as string,
+    agent_email: data.agent?.email ?? null,
+    revoked_at: data.revoked_at ?? null,
+    revoke_reason: data.revoke_reason ?? null,
+  } as ValidationDetail;
+}
+
+/** Revoke a validation with reason (admin only). */
+export async function revokeValidation(
+  id: string,
+  reason: string,
+): Promise<boolean> {
+  const me = await getCurrentUser();
+  if (!me) return false;
+  const { error } = await supabase
+    .from('reservation_validations')
+    .update({
+      revoked_at: new Date().toISOString(),
+      revoked_by: me.id,
+      revoke_reason: reason,
+    })
+    .eq('id', id);
+  if (!error) {
+    debugLog('validation_revoked', { user_id: me.id, validation_id: id });
+  }
+  return !error;
+}
+
+/**
+ * Convert history rows to CSV string for export.
+ */
+export function exportValidationHistoryCSV(
+  rows: ValidationHistoryRow[],
+): string {
+  const header = [
+    'validated_at',
+    'reservation_number',
+    'pass_name',
+    'activity',
+    'agent_email',
+    'payment_status',
+  ];
+  const csvRows = rows.map((r) =>
+    [
+      r.validated_at,
+      r.reservation_number,
+      r.pass_name ?? '',
+      r.activity,
+      r.agent_email ?? '',
+      r.payment_status,
+    ]
+      .map((v) => `"${String(v).replace(/"/g, '""')}"`)
+      .join(','),
+  );
+  return [header.join(','), ...csvRows].join('\n');
+}

--- a/src/pages/provider/ProviderLayout.tsx
+++ b/src/pages/provider/ProviderLayout.tsx
@@ -76,6 +76,17 @@ export default function ProviderLayout() {
         'admin',
       ],
     });
+    items.push({
+      to: '/provider/history',
+      label: 'Historique',
+      roles: [
+        'pony_provider',
+        'archery_provider',
+        'luge_provider',
+        'atlm_collaborator',
+        'admin',
+      ],
+    });
     return items.filter((n) => n.roles?.includes(user.role));
   })();
 
@@ -88,7 +99,7 @@ export default function ProviderLayout() {
               <QrCode className="h-5 w-5 text-blue-600" />
               Espace Prestataire
             </div>
-            
+
             {/* Desktop Navigation */}
             <div className="hidden md:flex items-center gap-6">
               <nav className="flex items-center gap-4">
@@ -140,8 +151,8 @@ export default function ProviderLayout() {
                     to={n.to}
                     onClick={() => setMobileMenuOpen(false)}
                     className={`px-3 py-2 rounded-md text-sm font-medium transition-colors ${
-                      location.pathname === n.to 
-                        ? 'bg-blue-100 text-blue-700' 
+                      location.pathname === n.to
+                        ? 'bg-blue-100 text-blue-700'
                         : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
                     }`}
                   >

--- a/src/pages/provider/ValidationHistory.tsx
+++ b/src/pages/provider/ValidationHistory.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useState } from 'react';
+import ProviderLayout from './ProviderLayout';
+import {
+  fetchValidationHistory,
+  ValidationHistoryRow,
+  ValidationHistoryFilters,
+  exportValidationHistoryCSV,
+  fetchValidationDetail,
+  revokeValidation,
+  ValidationDetail,
+} from '../../lib/history';
+
+const ACTIVITIES = ['poney', 'tir_arc', 'luge_bracelet'];
+
+export default function ValidationHistory() {
+  const [rows, setRows] = useState<ValidationHistoryRow[]>([]);
+  const [filters, setFilters] = useState<ValidationHistoryFilters>(() => {
+    const saved = localStorage.getItem('validationFilters');
+    if (saved) return JSON.parse(saved);
+    const end = new Date();
+    const start = new Date();
+    start.setDate(end.getDate() - 7);
+    return {
+      startDate: start.toISOString(),
+      endDate: end.toISOString(),
+      limit: 20,
+      offset: 0,
+    };
+  });
+  const [search, setSearch] = useState(filters.search ?? '');
+  const [detail, setDetail] = useState<ValidationDetail | null>(null);
+  const [detailId, setDetailId] = useState<string | null>(null);
+
+  // Debounce search
+  useEffect(() => {
+    const id = setTimeout(() => {
+      setFilters((f) => ({ ...f, search, offset: 0 }));
+    }, 300);
+    return () => clearTimeout(id);
+  }, [search]);
+
+  // Fetch rows when filters change
+  useEffect(() => {
+    localStorage.setItem('validationFilters', JSON.stringify(filters));
+    fetchValidationHistory(filters).then(setRows);
+  }, [filters]);
+
+  const toggleActivity = (act: string) => {
+    setFilters((f) => {
+      const list = new Set(f.activities ?? []);
+      if (list.has(act)) {
+        list.delete(act);
+      } else {
+        list.add(act);
+      }
+      return { ...f, activities: Array.from(list), offset: 0 };
+    });
+  };
+
+  const loadMore = () =>
+    setFilters((f) => ({ ...f, offset: (f.offset ?? 0) + (f.limit ?? 20) }));
+
+  const exportCsv = () => {
+    const csv = exportValidationHistoryCSV(rows);
+    const blob = new Blob([csv], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'validation_history.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const openDetail = async (id: string) => {
+    setDetailId(id);
+    const d = await fetchValidationDetail(id);
+    setDetail(d);
+  };
+
+  const revoke = async () => {
+    if (!detailId) return;
+    const reason = prompt("Motif d'annulation ?");
+    if (!reason) return;
+    const ok = await revokeValidation(detailId, reason);
+    if (ok) {
+      setDetail(null);
+      fetchValidationHistory(filters).then(setRows);
+    }
+  };
+
+  return (
+    <ProviderLayout>
+      <div className="p-4">
+        <h1 className="text-2xl mb-4">Historique des validations</h1>
+        <div className="flex flex-wrap gap-2 mb-4">
+          <label>
+            Début
+            <input
+              type="date"
+              value={filters.startDate?.slice(0, 10) || ''}
+              onChange={(e) =>
+                setFilters((f) => ({
+                  ...f,
+                  startDate: new Date(e.target.value).toISOString(),
+                  offset: 0,
+                }))
+              }
+              className="border px-2 ml-1"
+            />
+          </label>
+          <label>
+            Fin
+            <input
+              type="date"
+              value={filters.endDate?.slice(0, 10) || ''}
+              onChange={(e) =>
+                setFilters((f) => ({
+                  ...f,
+                  endDate: new Date(e.target.value).toISOString(),
+                  offset: 0,
+                }))
+              }
+              className="border px-2 ml-1"
+            />
+          </label>
+          <div className="flex items-center gap-1">
+            {ACTIVITIES.map((act) => (
+              <label key={act} className="flex items-center gap-1">
+                <input
+                  type="checkbox"
+                  checked={filters.activities?.includes(act) ?? false}
+                  onChange={() => toggleActivity(act)}
+                />
+                {act}
+              </label>
+            ))}
+          </div>
+          <input
+            type="text"
+            placeholder="Recherche (RES-..., email)"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="border px-2"
+          />
+          <button onClick={exportCsv} className="border px-2">
+            Exporter CSV
+          </button>
+        </div>
+        <table className="w-full text-left border">
+          <thead>
+            <tr>
+              <th className="border px-2">Date</th>
+              <th className="border px-2">N° réservation</th>
+              <th className="border px-2">Pass</th>
+              <th className="border px-2">Activité</th>
+              <th className="border px-2">Agent</th>
+              <th className="border px-2">Statut</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => (
+              <tr
+                key={r.id}
+                className="cursor-pointer"
+                onClick={() => openDetail(r.id)}
+              >
+                <td className="border px-2">
+                  {new Date(r.validated_at).toLocaleString()}
+                </td>
+                <td className="border px-2">{r.reservation_number}</td>
+                <td className="border px-2">{r.pass_name}</td>
+                <td className="border px-2">{r.activity}</td>
+                <td className="border px-2">{r.agent_email}</td>
+                <td className="border px-2">
+                  {r.status === 'revoked' ? 'Annulée' : 'Validée'}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="mt-2">
+          <button onClick={loadMore} className="border px-2">
+            Charger plus
+          </button>
+        </div>
+
+        {detail && (
+          <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center">
+            <div className="bg-white p-4 w-96">
+              <h2 className="text-xl mb-2">Détail</h2>
+              <p>Réservation : {detail.reservation_number}</p>
+              <p>Email client : {detail.client_email}</p>
+              <p>Statut paiement : {detail.payment_status}</p>
+              <p>Créé le : {new Date(detail.created_at).toLocaleString()}</p>
+              <p>Pass : {detail.pass_name}</p>
+              <p>Activité : {detail.activity}</p>
+              {detail.time_slot_start && (
+                <p>
+                  Créneau :{' '}
+                  {new Date(detail.time_slot_start).toLocaleTimeString()} -
+                  {detail.time_slot_end &&
+                    new Date(detail.time_slot_end).toLocaleTimeString()}
+                </p>
+              )}
+              <p>
+                Validé le : {new Date(detail.validated_at).toLocaleString()}
+              </p>
+              <p>Agent : {detail.agent_email}</p>
+              {detail.revoked_at && <p className="text-red-600">Annulé</p>}
+              <button
+                onClick={() =>
+                  navigator.clipboard.writeText(detail.reservation_number)
+                }
+                className="border px-2 mt-2"
+              >
+                Copier N° réservation
+              </button>
+              {!detail.revoked_at && (
+                <button onClick={revoke} className="border px-2 mt-2 ml-2">
+                  Annuler
+                </button>
+              )}
+              <button
+                onClick={() => setDetail(null)}
+                className="border px-2 mt-2 ml-2"
+              >
+                Fermer
+              </button>
+            </div>
+          </div>
+        )}
+      </div>
+    </ProviderLayout>
+  );
+}

--- a/src/pages/provider/__tests__/ValidationHistory.test.tsx
+++ b/src/pages/provider/__tests__/ValidationHistory.test.tsx
@@ -1,0 +1,18 @@
+import { render, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import ValidationHistory from '../ValidationHistory';
+import * as historyLib from '../../../lib/history';
+
+describe('ValidationHistory page', () => {
+  it('loads with default 7 day filter', async () => {
+    const spy = vi
+      .spyOn(historyLib, 'fetchValidationHistory')
+      .mockResolvedValue([]);
+    render(<ValidationHistory />);
+    await waitFor(() => expect(spy).toHaveBeenCalled());
+    const args = spy.mock.calls[0][0];
+    const start = new Date();
+    start.setDate(start.getDate() - 7);
+    expect(new Date(args.startDate).toDateString()).toBe(start.toDateString());
+  });
+});

--- a/supabase/migrations/20250907000000_add_validation_indexes.sql
+++ b/supabase/migrations/20250907000000_add_validation_indexes.sql
@@ -1,0 +1,9 @@
+-- Add indexes to reservation_validations for faster history queries
+CREATE INDEX IF NOT EXISTS idx_reservation_validations_validated_at_desc
+  ON public.reservation_validations (validated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_reservation_validations_activity
+  ON public.reservation_validations (activity);
+
+CREATE INDEX IF NOT EXISTS idx_reservation_validations_validated_by
+  ON public.reservation_validations (validated_by);

--- a/supabase/migrations/20250908090000_add_validation_revocation.sql
+++ b/supabase/migrations/20250908090000_add_validation_revocation.sql
@@ -1,0 +1,24 @@
+-- Add revocation fields and policies for reservation_validations history
+ALTER TABLE public.reservation_validations
+  ADD COLUMN revoked_at timestamptz,
+  ADD COLUMN revoked_by uuid,
+  ADD COLUMN revoke_reason text;
+
+-- Policy: admins can revoke validations (update rows)
+DROP POLICY IF EXISTS "Admins can revoke validations" ON reservation_validations;
+CREATE POLICY "Admins can revoke validations" ON reservation_validations
+  FOR UPDATE TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.users u WHERE u.id = auth.uid() AND u.role = 'admin'))
+  WITH CHECK (EXISTS (SELECT 1 FROM public.users u WHERE u.id = auth.uid() AND u.role = 'admin'));
+
+-- Policy: staff can read reservations for history
+DROP POLICY IF EXISTS "Staff can read reservations" ON reservations;
+CREATE POLICY "Staff can read reservations" ON reservations
+  FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.users u WHERE u.id = auth.uid() AND u.role IN ('admin','pony_provider','archery_provider','luge_provider','atlm_collaborator')));
+
+-- Policy: staff can read users emails
+DROP POLICY IF EXISTS "Staff can read users" ON users;
+CREATE POLICY "Staff can read users" ON users
+  FOR SELECT TO authenticated
+  USING (EXISTS (SELECT 1 FROM public.users u WHERE u.id = auth.uid() AND u.role IN ('admin','pony_provider','archery_provider','luge_provider','atlm_collaborator')));


### PR DESCRIPTION
## Summary
- add revocation fields and policies for validation history
- expose validation history with filters, CSV export, detail and revoke API
- provide provider UI for history with search, filters and revocation

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb8bc1508832b80495a30379e3241