### PR TITLE
Sprint S: handle Supabase user lookup errors

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -223,3 +223,14 @@
   context: |
     commit: feat return activity mismatch meta
   status: pending
+- who: ChatGPT
+  when: 2025-09-08T16:00:00Z
+  topic: Auth role lookup error
+  did: |
+    - Empêche la création d'utilisateur sur erreur serveur lors de la récupération du rôle
+    - Journalise et affiche un toast lorsque la requête de rôle échoue
+  ask: |
+    Vérifier la connexion avec un compte provoquant une erreur serveur
+  context: |
+    commit: fix handle missing user role lookup errors
+  status: pending

--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { createUser, signInWithEmail, signOut, getCurrentUser, type User } from '../auth';
+import {
+  createUser,
+  signInWithEmail,
+  signOut,
+  getCurrentUser,
+  type User,
+} from '../auth';
 import { toast } from 'react-hot-toast';
 import { logger } from '../logger';
 
 // Mock toast
 vi.mock('react-hot-toast', () => ({
-  toast: { error: vi.fn(), success: vi.fn() }
+  toast: { error: vi.fn(), success: vi.fn() },
 }));
 
 // Mock logger
@@ -19,13 +25,15 @@ const {
   fromMock,
   signInWithPasswordMock,
   signOutMock,
-  getUserMock
+  getUserMock,
 } = vi.hoisted(() => {
   const insertMock = vi.fn();
   const singleMock = vi.fn();
   const eqMock = vi.fn().mockReturnValue({ single: singleMock });
   const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
-  const fromMock = vi.fn().mockReturnValue({ insert: insertMock, select: selectMock });
+  const fromMock = vi
+    .fn()
+    .mockReturnValue({ insert: insertMock, select: selectMock });
   const signInWithPasswordMock = vi.fn();
   const signOutMock = vi.fn();
   const getUserMock = vi.fn();
@@ -35,7 +43,7 @@ const {
     fromMock,
     signInWithPasswordMock,
     signOutMock,
-    getUserMock
+    getUserMock,
   };
 });
 
@@ -44,10 +52,10 @@ vi.mock('../supabase', () => ({
     auth: {
       signInWithPassword: signInWithPasswordMock,
       signOut: signOutMock,
-      getUser: getUserMock
+      getUser: getUserMock,
     },
-    from: fromMock
-  }
+    from: fromMock,
+  },
 }));
 
 beforeEach(() => {
@@ -67,7 +75,7 @@ beforeEach(() => {
 describe('createUser', () => {
   it('refuse les rôles non autorisés', async () => {
     await expect(
-      createUser('1', 'a@b.com', 'hacker' as unknown as User['role'])
+      createUser('1', 'a@b.com', 'hacker' as unknown as User['role']),
     ).rejects.toThrow('Rôle non autorisé');
     expect(fromMock).not.toHaveBeenCalled();
   });
@@ -77,7 +85,7 @@ describe('signInWithEmail', () => {
   it('réussit avec un utilisateur existant', async () => {
     signInWithPasswordMock.mockResolvedValue({
       data: { user: { id: '1', email: 'admin@test.com' } },
-      error: null
+      error: null,
     });
 
     const result = await signInWithEmail('admin@test.com', 'pass');
@@ -88,21 +96,50 @@ describe('signInWithEmail', () => {
   it('crée un utilisateur inexistant', async () => {
     signInWithPasswordMock.mockResolvedValue({
       data: { user: { id: '2', email: 'client@test.com' } },
-      error: null
+      error: null,
     });
-    singleMock.mockResolvedValue({ data: null, error: { message: 'No user' } });
+    singleMock.mockResolvedValue({
+      data: null,
+      error: { message: 'No user', code: 'PGRST116' },
+    });
 
     const result = await signInWithEmail('client@test.com', 'pass');
 
-    expect(result).toEqual({ id: '2', email: 'client@test.com', role: 'client' });
-    expect(insertMock).toHaveBeenCalledWith({ id: '2', email: 'client@test.com', role: 'client' });
+    expect(result).toEqual({
+      id: '2',
+      email: 'client@test.com',
+      role: 'client',
+    });
+    expect(insertMock).toHaveBeenCalledWith({
+      id: '2',
+      email: 'client@test.com',
+      role: 'client',
+    });
     expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('retourne null si la récupération du rôle échoue', async () => {
+    signInWithPasswordMock.mockResolvedValue({
+      data: { user: { id: '3', email: 'err@test.com' } },
+      error: null,
+    });
+    singleMock.mockResolvedValue({
+      data: null,
+      error: { message: 'server', code: '500' },
+    });
+
+    const result = await signInWithEmail('err@test.com', 'pass');
+
+    expect(result).toBeNull();
+    expect(insertMock).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalled();
   });
 
   it('gère les erreurs de connexion', async () => {
     signInWithPasswordMock.mockResolvedValue({
       data: { user: null },
-      error: new Error('bad')
+      error: new Error('bad'),
     });
 
     const result = await signInWithEmail('bad@test.com', 'wrong');
@@ -130,7 +167,9 @@ describe('signOut', () => {
 
 describe('getCurrentUser', () => {
   it("retourne l'utilisateur courant", async () => {
-    getUserMock.mockResolvedValue({ data: { user: { id: '1', email: 'u@test.com' } } });
+    getUserMock.mockResolvedValue({
+      data: { user: { id: '1', email: 'u@test.com' } },
+    });
 
     const result = await getCurrentUser();
 
@@ -146,7 +185,9 @@ describe('getCurrentUser', () => {
   });
 
   it('retourne null quand la requête de rôle échoue', async () => {
-    getUserMock.mockResolvedValue({ data: { user: { id: '1', email: 'u@test.com' } } });
+    getUserMock.mockResolvedValue({
+      data: { user: { id: '1', email: 'u@test.com' } },
+    });
     singleMock.mockResolvedValue({ data: null, error: { message: 'fail' } });
 
     const result = await getCurrentUser();
@@ -163,4 +204,3 @@ describe('getCurrentUser', () => {
     expect(logger.error).toHaveBeenCalled();
   });
 });
-


### PR DESCRIPTION
## Summary
- handle server errors when fetching user role
- add tests for user role fetch failures
- log auth interaction in sprint notes

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68bdfae65c38832bb8368d1b4194883a