### PR TITLE
Sprint S: enable RLS on webhook_events

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -1604,6 +1604,8 @@ CREATE POLICY "Users can read own data" ON "public"."users" FOR SELECT TO "authe
 
 CREATE POLICY "Users can update own data" ON "public"."users" FOR UPDATE TO "authenticated" USING (("auth"."uid"() = "id")) WITH CHECK (("auth"."uid"() = "id"));
 
+CREATE POLICY "Allow service role" ON "public"."webhook_events" FOR ALL TO "service_role" USING (true) WITH CHECK (true);
+
 
 
 ALTER TABLE "public"."activities" ENABLE ROW LEVEL SECURITY;
@@ -1658,6 +1660,8 @@ ALTER TABLE "public"."time_slots" ENABLE ROW LEVEL SECURITY;
 
 
 ALTER TABLE "public"."users" ENABLE ROW LEVEL SECURITY;
+
+ALTER TABLE "public"."webhook_events" ENABLE ROW LEVEL SECURITY;
 
 
 GRANT USAGE ON SCHEMA "public" TO "postgres";

--- a/supabase/migrations/20250906001000_enable_rls_webhook_events.sql
+++ b/supabase/migrations/20250906001000_enable_rls_webhook_events.sql
@@ -1,0 +1,8 @@
+-- Enable RLS and add service role policy for webhook_events
+ALTER TABLE public.webhook_events ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "Allow service role" ON public.webhook_events
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## Summary
- enable row level security on public.webhook_events
- allow service_role to access webhook_events

## Testing
- `pnpm run lint`
- `pnpm test`
- `npx supabase db lint` *(fails: connect ECONNREFUSED 127.0.0.1:54322)*

------
https://chatgpt.com/codex/tasks/task_e_68be047ddc38832b9129f6d955d051f6