### PR TITLE
Sprint S10 : secure luge_validations_today view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ Toutes les modifications sont consignées ici. Suivre le format **Keep a Changel
 - Renommage de la migration `extend_get_parc_activities_with_variants` et conversion du script de seed Luge en migration (US-23)
 - Amélioration de l'UX de validation : affichage du numéro de réservation et de la date lors du scan
 - Affichage du nom de l'agent lors d'une revalidation de billet
+- Vue `luge_validations_today` exécutée avec `security_invoker` pour éviter l'escalade de privilèges
 
 ---
 

--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -245,3 +245,14 @@
   context: |
     migration: 20250905070420_luge_validations_today.sql
   status: pending
+
+- who: ChatGPT
+  when: 2025-09-07T23:30:00+00:00
+  topic: Sprint S10 — security invoker view
+  did: |
+    - Recreated luge_validations_today view with `security_invoker` option
+  ask: |
+    Ensure database lint passes for security_definer_view
+  context: |
+    migration: 20250907120000_luge_validations_today_security_invoker.sql
+  status: pending

--- a/schema.sql
+++ b/schema.sql
@@ -1954,7 +1954,7 @@ ALTER DEFAULT PRIVILEGES FOR ROLE "postgres" IN SCHEMA "public" GRANT ALL ON TAB
 -- View: public.luge_validations_today
 --
 DROP VIEW IF EXISTS public.luge_validations_today;
-CREATE VIEW public.luge_validations_today SECURITY INVOKER AS
+CREATE VIEW public.luge_validations_today WITH (security_invoker = true) AS
  SELECT count(*) AS count
    FROM public.reservation_validations
   WHERE activity = 'luge_bracelet'::text

--- a/supabase/migrations/20250907120000_luge_validations_today_security_invoker.sql
+++ b/supabase/migrations/20250907120000_luge_validations_today_security_invoker.sql
@@ -1,4 +1,4 @@
--- Create view for counting today's luge validations
+-- Ensure luge_validations_today view runs with invoker rights
 DROP VIEW IF EXISTS public.luge_validations_today;
 CREATE VIEW public.luge_validations_today WITH (security_invoker = true) AS
 SELECT count(*) AS count


### PR DESCRIPTION
## Summary
- recreate `luge_validations_today` view with `security_invoker`
- document view security in changelog

## Testing
- `pnpm run lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68be143cb358832b95e5157338214845