### PR TITLE
Sprint S10 : fix Supabase user role query error

### DIFF
--- a/src/lib/__tests__/auth.test.ts
+++ b/src/lib/__tests__/auth.test.ts
@@ -21,15 +21,15 @@ vi.mock('../logger', () => ({ logger: loggerMock }));
 // Mock supabase
 const {
   insertMock,
-  singleMock,
+  maybeSingleMock,
   fromMock,
   signInWithPasswordMock,
   signOutMock,
   getUserMock,
 } = vi.hoisted(() => {
   const insertMock = vi.fn();
-  const singleMock = vi.fn();
-  const eqMock = vi.fn().mockReturnValue({ single: singleMock });
+  const maybeSingleMock = vi.fn();
+  const eqMock = vi.fn().mockReturnValue({ maybeSingle: maybeSingleMock });
   const selectMock = vi.fn().mockReturnValue({ eq: eqMock });
   const fromMock = vi
     .fn()
@@ -39,7 +39,7 @@ const {
   const getUserMock = vi.fn();
   return {
     insertMock,
-    singleMock,
+    maybeSingleMock,
     fromMock,
     signInWithPasswordMock,
     signOutMock,
@@ -61,7 +61,7 @@ vi.mock('../supabase', () => ({
 beforeEach(() => {
   vi.clearAllMocks();
   insertMock.mockReset();
-  singleMock.mockReset();
+  maybeSingleMock.mockReset();
   signInWithPasswordMock.mockReset();
   signOutMock.mockReset();
   getUserMock.mockReset();
@@ -69,7 +69,7 @@ beforeEach(() => {
   loggerMock.error.mockReset();
 
   insertMock.mockResolvedValue({ error: null });
-  singleMock.mockResolvedValue({ data: { role: 'admin' }, error: null });
+  maybeSingleMock.mockResolvedValue({ data: { role: 'admin' }, error: null });
 });
 
 describe('createUser', () => {
@@ -98,10 +98,7 @@ describe('signInWithEmail', () => {
       data: { user: { id: '2', email: 'client@test.com' } },
       error: null,
     });
-    singleMock.mockResolvedValue({
-      data: null,
-      error: { message: 'No user', code: 'PGRST116' },
-    });
+    maybeSingleMock.mockResolvedValue({ data: null, error: null });
 
     const result = await signInWithEmail('client@test.com', 'pass');
 
@@ -123,7 +120,7 @@ describe('signInWithEmail', () => {
       data: { user: { id: '3', email: 'err@test.com' } },
       error: null,
     });
-    singleMock.mockResolvedValue({
+    maybeSingleMock.mockResolvedValue({
       data: null,
       error: { message: 'server', code: '500' },
     });
@@ -188,7 +185,10 @@ describe('getCurrentUser', () => {
     getUserMock.mockResolvedValue({
       data: { user: { id: '1', email: 'u@test.com' } },
     });
-    singleMock.mockResolvedValue({ data: null, error: { message: 'fail' } });
+    maybeSingleMock.mockResolvedValue({
+      data: null,
+      error: { message: 'fail' },
+    });
 
     const result = await getCurrentUser();
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -139,7 +139,7 @@ export async function validateReservation(
           .from('users')
           .select('email')
           .eq('id', v.validated_by as string)
-          .single();
+          .maybeSingle();
         return {
           validated_at: v.validated_at as string,
           validated_by: v.validated_by as string,
@@ -175,7 +175,7 @@ export async function validateReservation(
         .from('users')
         .select('email')
         .eq('id', inserted.validated_by)
-        .single();
+        .maybeSingle();
       payload.history.push({
         validated_at: inserted.validated_at as string,
         validated_by: inserted.validated_by as string,


### PR DESCRIPTION
## Summary
- avoid Supabase 500 by using `maybeSingle` for user role lookups and auto-create missing records
- guard validation history lookups against missing user emails
- adjust auth tests for new `maybeSingle` behaviour

## Testing
- `pnpm run lint`
- `pnpm test`
- `pnpm run format` *(fails: docs/sprints/S1/INTERACTIONS.yaml: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68be197bfdd8832bad73792e8880e1a1