### PR TITLE
Sprint S10: fix users policy recursion

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -256,3 +256,15 @@
   context: |
     migration: 20250907120000_luge_validations_today_security_invoker.sql
   status: pending
+
+- who: ChatGPT
+  when: 2025-09-08T17:00:00Z
+  topic: Sprint S10 — users policy recursion
+  did: |
+    - Checked admin role from JWT to avoid recursive users policy
+    - Updated schema.sql accordingly
+  ask: |
+    Confirm that user role queries no longer error
+  context: |
+    commit: fix check admin role via JWT
+  status: pending

--- a/docs/sprints/S10/PREFLIGHT.md
+++ b/docs/sprints/S10/PREFLIGHT.md
@@ -27,8 +27,8 @@
 
 ## 5) Schéma SQL (`schema.sql`)
 
-- **RefreshedAt**: 2025-09-05T00:00:00Z
-- Ou justification `unchanged`: 
+- **RefreshedAt**: 2025-09-08T17:00:00Z
+- Ou justification `unchanged`:
 
 ## 6) Sécurité
 

--- a/schema.sql
+++ b/schema.sql
@@ -486,9 +486,7 @@ CREATE OR REPLACE FUNCTION "public"."is_admin"() RETURNS boolean
     LANGUAGE "sql" STABLE SECURITY DEFINER
     SET "search_path" TO 'public'
     AS $$
-  SELECT EXISTS (
-    SELECT 1 FROM public.users WHERE id = auth.uid() AND role = 'admin'
-  );
+  SELECT coalesce(auth.jwt() ->> 'role', '') = 'admin';
 $$;
 
 

--- a/supabase/migrations/20250829021500_fix_users_policies.sql
+++ b/supabase/migrations/20250829021500_fix_users_policies.sql
@@ -13,9 +13,7 @@ STABLE
 SECURITY DEFINER
 SET search_path = public
 AS $$
-  SELECT EXISTS (
-    SELECT 1 FROM public.users WHERE id = auth.uid() AND role = 'admin'
-  );
+  SELECT coalesce(auth.jwt() ->> 'role', '') = 'admin';
 $$;
 -- Safe admin read policy using definer function (no recursion)
 CREATE POLICY "Admins can read all users"


### PR DESCRIPTION
## Summary
- avoid recursive user-role policy by checking admin status from JWT
- refresh schema and sprint docs

## Testing
- `npm run lint`
- `npm test` *(fails: supabase.from(...).select(...).eq(...).maybeSingle is not a function)*

------
https://chatgpt.com/codex/tasks/task_e_68be1c84c158832babb7cabda233309f