### PR TITLE
Sprint S10: allow ticket revalidation after revocation

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -268,3 +268,38 @@
   context: |
     commit: fix check admin role via JWT
   status: pending
+
+- who: ChatGPT
+  when: 2025-09-08T18:00:00Z
+  topic: Revalidation after revocation
+  did: |
+    - Ignored revoked validations during scan
+    - Added partial unique index for active validations
+    - Updated tests and schema
+  ask: |
+    Vérifier la revalidation après annulation
+  context: |
+    commit: feat allow revalidation after revocation
+  status: pending
+
+- who: ChatGPT
+  when: 2025-09-08T18:05:00Z
+  topic: Migration active validation uniqueness
+  did: |
+    - Ajouté le script de migration pour l'index partiel
+  ask: |
+    Appliquer la migration sur la base
+  context: |
+    commit: chore add migration for active validation uniqueness
+  status: pending
+- who: ChatGPT
+  when: 2025-09-08T20:00:00Z
+  topic: Supabase migration push
+  did: |
+    - Tente d'exécuter `supabase db push --db-url "$SUPABASE_DB_URL" --include-all --yes`
+    - La commande `supabase` est introuvable
+  ask: |
+    Installer `supabase` CLI et fournir `SUPABASE_DB_URL` pour appliquer les migrations
+  context: |
+    command: supabase db push --db-url "$SUPABASE_DB_URL" --include-all --yes
+  status: blocked

--- a/schema.sql
+++ b/schema.sql
@@ -913,6 +913,9 @@ CREATE TABLE IF NOT EXISTS "public"."reservation_validations" (
     "activity" "text" NOT NULL,
     "validated_by" "uuid" NOT NULL,
     "validated_at" timestamp with time zone DEFAULT "now"() NOT NULL,
+    "revoked_at" timestamp with time zone,
+    "revoked_by" "uuid",
+    "revoke_reason" "text",
     CONSTRAINT "reservation_validations_activity_check" CHECK (("activity" = ANY (ARRAY['poney'::"text", 'tir_arc'::"text", 'luge_bracelet'::"text"])))
 );
 
@@ -1096,9 +1099,6 @@ ALTER TABLE ONLY "public"."passes"
 ALTER TABLE ONLY "public"."reservation_validations"
     ADD CONSTRAINT "reservation_validations_pkey" PRIMARY KEY ("id");
 
-ALTER TABLE ONLY "public"."reservation_validations"
-    ADD CONSTRAINT "reservation_validations_reservation_activity_key" UNIQUE ("reservation_id", "activity");
-
 
 
 ALTER TABLE ONLY "public"."reservations"
@@ -1238,6 +1238,8 @@ CREATE INDEX "idx_time_slots_slot_time" ON "public"."time_slots" USING "btree" (
 
 
 
+CREATE UNIQUE INDEX "reservation_validations_unique_active" ON "public"."reservation_validations" USING "btree" ("reservation_id", "activity") WHERE ("revoked_at" IS NULL);
+
 CREATE UNIQUE INDEX "ux_webhook_events_id" ON "public"."webhook_events" USING "btree" ("id");
 
 
@@ -1346,6 +1348,9 @@ ALTER TABLE ONLY "public"."reservation_validations"
 
 ALTER TABLE ONLY "public"."reservation_validations"
     ADD CONSTRAINT "reservation_validations_validated_by_fkey" FOREIGN KEY ("validated_by") REFERENCES "public"."users"("id");
+
+ALTER TABLE ONLY "public"."reservation_validations"
+    ADD CONSTRAINT "reservation_validations_revoked_by_fkey" FOREIGN KEY ("revoked_by") REFERENCES "public"."users"("id");
 
 
 
@@ -1581,6 +1586,12 @@ CREATE POLICY "Providers can read validations" ON "public"."reservation_validati
   WHERE (("u"."id" = "auth"."uid"()) AND ("u"."role" = ANY (ARRAY['admin'::"text", 'pony_provider'::"text", 'archery_provider'::"text", 'luge_provider'::"text", 'atlm_collaborator'::"text"]))))));
 
 
+
+CREATE POLICY "Admins can revoke validations" ON "public"."reservation_validations" FOR UPDATE TO "authenticated" USING ((EXISTS ( SELECT 1
+   FROM "public"."users" "u"
+  WHERE (("u"."id" = "auth"."uid"()) AND ("u"."role" = 'admin'::"text"))))) WITH CHECK ((EXISTS ( SELECT 1
+   FROM "public"."users" "u"
+  WHERE (("u"."id" = "auth"."uid"()) AND ("u"."role" = 'admin'::"text")))));
 
 CREATE POLICY "Public can read shop products" ON "public"."shop_products" FOR SELECT USING (true);
 

--- a/src/lib/__tests__/validation.test.ts
+++ b/src/lib/__tests__/validation.test.ts
@@ -72,6 +72,7 @@ describe('validateReservation', () => {
 
     const validationsQuery = {
       eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
       then: vi.fn((resolve) => resolve({ data: [], error: null })),
     };
 
@@ -94,7 +95,7 @@ describe('validateReservation', () => {
     const usersBuilder = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({
+      maybeSingle: vi.fn().mockResolvedValue({
         data: { email: 'agent1@example.com' },
         error: null,
       }),
@@ -170,6 +171,7 @@ describe('validateReservation', () => {
 
     const validationsQuery = {
       eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
       then: vi.fn((resolve) =>
         resolve({
           data: [
@@ -194,7 +196,7 @@ describe('validateReservation', () => {
     const usersBuilder = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
-      single: vi.fn().mockResolvedValue({
+      maybeSingle: vi.fn().mockResolvedValue({
         data: { email: 'agent2@example.com' },
         error: null,
       }),
@@ -240,6 +242,86 @@ describe('validateReservation', () => {
     expect(validationsTable.insert).not.toHaveBeenCalled();
   });
 
+  it('allows re-validation after a revoked validation', async () => {
+    vi.mocked(getCurrentUser).mockResolvedValue({ id: 'agent-1' } as {
+      id: string;
+    });
+
+    const reservationsBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          id: 'res-1',
+          reservation_number: 'RES-2025-001-0001',
+          client_email: 'c@example.com',
+          payment_status: 'paid',
+          created_at: '2025-01-01T09:00:00.000Z',
+          pass: { id: 'pass-1', name: 'Pass Poney' },
+          event_activities: { activities: { name: 'poney' } },
+        },
+        error: null,
+      }),
+    };
+
+    const validationsQuery = {
+      eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
+      then: vi.fn((resolve) => resolve({ data: [], error: null })),
+    };
+
+    const insertBuilder = {
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({
+        data: {
+          validated_at: '2025-01-02T10:00:00.000Z',
+          validated_by: 'agent-1',
+        },
+        error: null,
+      }),
+    };
+
+    const validationsTable = {
+      select: vi.fn().mockReturnValue(validationsQuery),
+      insert: vi.fn().mockReturnValue(insertBuilder),
+    };
+
+    const usersBuilder = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: { email: 'agent1@example.com' },
+        error: null,
+      }),
+    };
+
+    vi.mocked(supabase.from).mockImplementation((table: string) => {
+      if (table === 'reservations') return reservationsBuilder as never;
+      if (table === 'reservation_validations') return validationsTable as never;
+      if (table === 'users') return usersBuilder as never;
+      throw new Error('unknown table ' + table);
+    });
+
+    const res = await validateReservation('RES-2025-001-0001', 'poney');
+    expect(validationsQuery.is).toHaveBeenCalledWith('revoked_at', null);
+    expect(res.status).toEqual({
+      invalid: false,
+      notFound: false,
+      unpaid: false,
+      wrongActivity: false,
+      alreadyValidated: false,
+      validated: true,
+    });
+    expect(res.ok).toBe(true);
+    expect(res.history).toEqual([
+      {
+        validated_at: '2025-01-02T10:00:00.000Z',
+        validated_by: 'agent-1',
+        validated_by_email: 'agent1@example.com',
+      },
+    ]);
+  });
+
   it('rejects reservation not matching activity', async () => {
     vi.mocked(getCurrentUser).mockResolvedValue({ id: 'agent-1' } as {
       id: string;
@@ -263,6 +345,7 @@ describe('validateReservation', () => {
 
     const validationsQuery = {
       eq: vi.fn().mockReturnThis(),
+      is: vi.fn().mockReturnThis(),
       then: vi.fn((resolve) => resolve({ data: [], error: null })),
     };
 

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -130,7 +130,8 @@ export async function validateReservation(
     .from('reservation_validations')
     .select('validated_at,validated_by')
     .eq('reservation_id', data.id)
-    .eq('activity', activity);
+    .eq('activity', activity)
+    .is('revoked_at', null);
 
   if (existing && existing.length > 0) {
     payload.history = await Promise.all(

--- a/supabase/migrations/20250908001500_old_resonance.sql
+++ b/supabase/migrations/20250908001500_old_resonance.sql
@@ -28,8 +28,7 @@ DROP POLICY IF EXISTS "Staff can read users" ON users;
 -- Drop the problematic is_admin function if it exists
 DROP FUNCTION IF EXISTS is_admin();
 
--- Create a simple function to check if current user is admin without recursion
-CREATE OR REPLACE FUNCTION auth.is_admin()
+CREATE OR REPLACE FUNCTION is_admin()
 RETURNS boolean
 LANGUAGE sql
 SECURITY DEFINER
@@ -75,11 +74,11 @@ CREATE POLICY "Admins can read all users"
   ON users
   FOR SELECT
   TO authenticated
-  USING (auth.is_admin());
+  USING (is_admin());
 
 CREATE POLICY "Admins can update users"
   ON users
   FOR UPDATE
   TO authenticated
-  USING (auth.is_admin())
-  WITH CHECK (auth.is_admin());
+  USING (is_admin())
+  WITH CHECK (is_admin());

--- a/supabase/migrations/20250908004500_active_validation_unique.sql
+++ b/supabase/migrations/20250908004500_active_validation_unique.sql
@@ -1,0 +1,15 @@
+/*
+  # Allow multiple validations after revocation
+
+  1. Drop existing unique constraint on (reservation_id, activity)
+  2. Add partial unique index enforcing uniqueness only for active validations
+*/
+
+-- Drop old unique constraint
+ALTER TABLE public.reservation_validations
+  DROP CONSTRAINT IF EXISTS reservation_validations_reservation_activity_key;
+
+-- Enforce uniqueness only for active validations
+CREATE UNIQUE INDEX IF NOT EXISTS reservation_validations_unique_active
+  ON public.reservation_validations (reservation_id, activity)
+  WHERE revoked_at IS NULL;


### PR DESCRIPTION
## Summary
- allow revalidation when previous validation was revoked
- enforce uniqueness only for active validations
- cover revalidation scenario with unit tests
- move `is_admin` helper to public schema so migrations avoid auth permissions

## Testing
- `pnpm run lint`
- `pnpm test`
- `supabase db push --db-url "$SUPABASE_DB_URL" --include-all --yes` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be28250688832bbe505a788bc03a81