### PR TITLE
Sprint S10: secure reservation email invocation

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -326,3 +326,15 @@
   context: |
     commit: fix handle env for create-checkout-session CORS
   status: pending
+- who: ChatGPT
+  when: 2025-09-09T00:00:00Z
+  topic: request-reservation-email auth & logs
+  did: |
+    - Ajout de logs de débogage pour la fonction request-reservation-email
+    - Invocation de send-reservation-email avec la clé service role
+    - Tentatives `npx supabase functions list` et `deploy` sans jeton
+  ask: |
+    Fournir SUPABASE_ACCESS_TOKEN pour lister/déployer les fonctions
+  context: |
+    commands: npx supabase functions list; npx supabase functions deploy create-checkout-session; npx supabase functions deploy stripe-webhook
+  status: blocked

--- a/supabase/functions/request-reservation-email/index.test.ts
+++ b/supabase/functions/request-reservation-email/index.test.ts
@@ -31,6 +31,7 @@ describe('request-reservation-email edge function', () => {
     vi.clearAllMocks();
     process.env.SUPABASE_URL = 'https://example.supabase.co';
     process.env.SUPABASE_ANON_KEY = 'anon-key';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-key';
     interface DenoEnv {
       get(name: string): string | undefined;
     }
@@ -72,7 +73,10 @@ describe('request-reservation-email edge function', () => {
   });
 
   it('returns 200 with found true when reservation exists and email is sent', async () => {
-    limitMock.mockResolvedValue({ data: [{ id: '1', created_at: '' }], error: null });
+    limitMock.mockResolvedValue({
+      data: [{ id: '1', created_at: '' }],
+      error: null,
+    });
     invokeMock.mockResolvedValue({ error: null });
 
     const res = await handler(
@@ -85,6 +89,7 @@ describe('request-reservation-email edge function', () => {
     await expect(res.json()).resolves.toEqual({ found: true, sent: true });
     expect(invokeMock).toHaveBeenCalledWith('send-reservation-email', {
       body: { email: 'valid@example.com', reservationId: '1' },
+      headers: { Authorization: 'Bearer service-key' },
     });
   });
 });


### PR DESCRIPTION
## Summary
- add service-role authorization when invoking send-reservation-email
- log request and email dispatch steps for easier debugging
- note missing SUPABASE_ACCESS_TOKEN for CLI deploy

## Testing
- `pnpm run lint`
- `pnpm test`
- `npx supabase functions list` *(fails: Access token not provided)*
- `npx supabase functions deploy create-checkout-session` *(fails: Access token not provided)*
- `npx supabase functions deploy stripe-webhook` *(fails: Access token not provided)*

------
https://chatgpt.com/codex/tasks/task_e_68be82e2667c832b857182b322a38851