### PR TITLE
Sprint S: harden SQL search_path and auth security

### DIFF
--- a/schema.sql
+++ b/schema.sql
@@ -25,6 +25,7 @@ COMMENT ON SCHEMA "public" IS 'standard public schema';
 
 CREATE OR REPLACE FUNCTION "public"."calculate_total_timeslot_capacity"("event_activity_uuid" "uuid") RETURNS integer
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 DECLARE
   total_capacity integer := 0;
@@ -44,6 +45,7 @@ ALTER FUNCTION "public"."calculate_total_timeslot_capacity"("event_activity_uuid
 
 CREATE OR REPLACE FUNCTION "public"."can_reserve_pass"("pass_uuid" "uuid", "quantity" integer DEFAULT 1) RETURNS boolean
     LANGUAGE "plpgsql" SECURITY DEFINER
+    SET search_path = public
     AS $$
 DECLARE
   effective_stock integer;
@@ -60,6 +62,7 @@ ALTER FUNCTION "public"."can_reserve_pass"("pass_uuid" "uuid", "quantity" intege
 
 CREATE OR REPLACE FUNCTION "public"."cleanup_expired_cart_items"() RETURNS "void"
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 BEGIN
   DELETE FROM cart_items
@@ -73,6 +76,7 @@ ALTER FUNCTION "public"."cleanup_expired_cart_items"() OWNER TO "postgres";
 
 CREATE OR REPLACE FUNCTION "public"."generate_reservation_number"() RETURNS "text"
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 BEGIN
   RETURN 'RES' || TO_CHAR(now(), 'YYYYMMDD') || '-' || LPAD(floor(random() * 10000)::text, 4, '0');
@@ -85,6 +89,7 @@ ALTER FUNCTION "public"."generate_reservation_number"() OWNER TO "postgres";
 
 CREATE OR REPLACE FUNCTION "public"."get_activity_remaining_capacity"("activity_resource_uuid" "uuid") RETURNS integer
     LANGUAGE "plpgsql" SECURITY DEFINER
+    SET search_path = public
     AS $$
 DECLARE
   total_cap integer;
@@ -143,6 +148,7 @@ ALTER FUNCTION "public"."get_activity_variant_remaining_stock"("variant_uuid" "u
 
 CREATE OR REPLACE FUNCTION "public"."get_event_activity_remaining_stock"("event_activity_id_param" "uuid") RETURNS integer
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 DECLARE
     total_stock integer;
@@ -193,6 +199,7 @@ ALTER FUNCTION "public"."get_event_activity_remaining_stock"("event_activity_id_
 
 CREATE OR REPLACE FUNCTION "public"."get_event_passes_activities_stock"("event_uuid" "uuid") RETURNS json
     LANGUAGE "sql" SECURITY DEFINER
+    SET search_path = public
     AS $$
   SELECT json_build_object(
     'passes', COALESCE((
@@ -234,6 +241,7 @@ ALTER FUNCTION "public"."get_event_passes_activities_stock"("event_uuid" "uuid")
 
 CREATE OR REPLACE FUNCTION "public"."get_parc_activities_with_variants"() RETURNS TABLE("id" "uuid", "name" "text", "description" "text", "parc_description" "text", "icon" "text", "category" "text", "requires_time_slot" boolean, "image_url" "text", "variants" "jsonb")
     LANGUAGE "sql" SECURITY DEFINER
+    SET search_path = public
     AS $$
   select
     a.id,
@@ -276,6 +284,7 @@ COMMENT ON FUNCTION "public"."get_parc_activities_with_variants"() IS 'Returns p
 
 CREATE OR REPLACE FUNCTION "public"."get_pass_activity_remaining"("pass_uuid" "uuid", "activity_name" "text") RETURNS integer
     LANGUAGE "plpgsql" SECURITY DEFINER
+    SET search_path = public
     AS $$
 DECLARE
   max_bookings integer;
@@ -315,6 +324,7 @@ ALTER FUNCTION "public"."get_pass_activity_remaining"("pass_uuid" "uuid", "activ
 
 CREATE OR REPLACE FUNCTION "public"."get_pass_effective_remaining_stock"("pass_uuid" "uuid") RETURNS integer
     LANGUAGE "plpgsql" SECURITY DEFINER
+    SET search_path = public
     AS $$
 DECLARE
   pass_stock integer;
@@ -337,6 +347,7 @@ ALTER FUNCTION "public"."get_pass_effective_remaining_stock"("pass_uuid" "uuid")
 
 CREATE OR REPLACE FUNCTION "public"."get_pass_max_stock_from_activities"("pass_uuid" "uuid") RETURNS integer
     LANGUAGE "plpgsql" SECURITY DEFINER
+    SET search_path = public
     AS $$
 DECLARE
   min_activity_stock integer := 999999;
@@ -372,6 +383,7 @@ ALTER FUNCTION "public"."get_pass_max_stock_from_activities"("pass_uuid" "uuid")
 
 CREATE OR REPLACE FUNCTION "public"."get_pass_remaining_stock"("pass_uuid" "uuid") RETURNS integer
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 DECLARE
   initial_stock_val integer;
@@ -411,6 +423,7 @@ ALTER FUNCTION "public"."get_pass_remaining_stock"("pass_uuid" "uuid") OWNER TO 
 
 CREATE OR REPLACE FUNCTION "public"."get_slot_remaining_capacity"("slot_uuid" "uuid") RETURNS integer
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 DECLARE
   total_capacity integer;
@@ -444,6 +457,7 @@ ALTER FUNCTION "public"."get_slot_remaining_capacity"("slot_uuid" "uuid") OWNER 
 
 CREATE OR REPLACE FUNCTION "public"."get_passes_with_activities"("event_uuid" "uuid") RETURNS "json"
     LANGUAGE sql SECURITY DEFINER
+    SET search_path = public
     AS $$
   select coalesce(json_agg(
     json_build_object(
@@ -495,6 +509,7 @@ ALTER FUNCTION "public"."is_admin"() OWNER TO "postgres";
 
 CREATE OR REPLACE FUNCTION "public"."reserve_pass_with_stock_check"("session_id" "text", "pass_id" "uuid", "activities" "jsonb" DEFAULT '[]'::"jsonb", "quantity" integer DEFAULT 1, "attendee_first_name" "text" DEFAULT NULL::"text", "attendee_last_name" "text" DEFAULT NULL::"text", "attendee_birth_year" integer DEFAULT NULL::integer, "access_conditions_ack" boolean DEFAULT false, "product_type" "text" DEFAULT 'event_pass'::"text", "product_id" "uuid" DEFAULT NULL::"uuid") RETURNS "void"
     LANGUAGE "plpgsql" SECURITY DEFINER
+    SET search_path = public
     AS $$
 DECLARE
   remaining integer;
@@ -574,6 +589,7 @@ ALTER FUNCTION "public"."reserve_pass_with_stock_check"("session_id" "text", "pa
 
 CREATE OR REPLACE FUNCTION "public"."reserve_pass_with_stock_check"("session_id" "text", "pass_id" "uuid", "time_slot_id" "uuid" DEFAULT NULL::"uuid", "quantity" integer DEFAULT 1, "attendee_first_name" "text" DEFAULT NULL::"text", "attendee_last_name" "text" DEFAULT NULL::"text", "attendee_birth_year" integer DEFAULT NULL::integer, "access_conditions_ack" boolean DEFAULT false, "product_type" "text" DEFAULT 'event_pass'::"text", "product_id" "uuid" DEFAULT NULL::"uuid") RETURNS "void"
     LANGUAGE "plpgsql" SECURITY DEFINER
+    SET search_path = public
     AS $$
 DECLARE
   remaining integer;
@@ -621,6 +637,7 @@ ALTER FUNCTION "public"."reserve_pass_with_stock_check"("session_id" "text", "pa
 
 CREATE OR REPLACE FUNCTION "public"."role"() RETURNS "text"
     LANGUAGE "sql" SECURITY DEFINER
+    SET search_path = public
     AS $$
   SELECT COALESCE(
     (SELECT users.role FROM users WHERE users.id = auth.uid()),
@@ -634,6 +651,7 @@ ALTER FUNCTION "public"."role"() OWNER TO "postgres";
 
 CREATE OR REPLACE FUNCTION "public"."set_reservation_number"() RETURNS "trigger"
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 BEGIN
   NEW.reservation_number := 'RES-' || EXTRACT(YEAR FROM NOW()) || '-' || LPAD(EXTRACT(DOY FROM NOW())::text, 3, '0') || '-' || LPAD((RANDOM() * 9999)::int::text, 4, '0');
@@ -647,6 +665,7 @@ ALTER FUNCTION "public"."set_reservation_number"() OWNER TO "postgres";
 
 CREATE OR REPLACE FUNCTION "public"."sync_activity_stock_with_timeslots"("event_activity_uuid" "uuid") RETURNS "void"
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 DECLARE
   total_capacity integer;
@@ -679,6 +698,7 @@ ALTER FUNCTION "public"."sync_activity_stock_with_timeslots"("event_activity_uui
 
 CREATE OR REPLACE FUNCTION "public"."trigger_sync_activity_stock"() RETURNS "trigger"
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 BEGIN
   -- Synchroniser pour l'ancienne activité (en cas de UPDATE/DELETE)
@@ -701,6 +721,7 @@ ALTER FUNCTION "public"."trigger_sync_activity_stock"() OWNER TO "postgres";
 
 CREATE OR REPLACE FUNCTION "public"."trigger_sync_on_requires_timeslot_change"() RETURNS "trigger"
     LANGUAGE "plpgsql"
+    SET search_path = public
     AS $$
 BEGIN
   -- Si on active requires_time_slot, synchroniser avec les créneaux existants

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -7,3 +7,9 @@ verify_jwt = false
 # La fonction d'email reste protégée (appelée avec service_role)
 [functions.send-reservation-email]
 verify_jwt = true
+
+[auth]
+# Enable leaked password protection and MFA options for improved security
+leaked_password_protection = true
+mfa_enabled_types = ["totp", "webauthn"]
+

--- a/supabase/migrations/20250902001000_update_reserve_pass_with_stock_check.sql
+++ b/supabase/migrations/20250902001000_update_reserve_pass_with_stock_check.sql
@@ -82,4 +82,4 @@ BEGIN
     VALUES (cart_item_uuid, act.event_activity_id, act.time_slot_id);
   END LOOP;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$ LANGUAGE plpgsql SECURITY DEFINER SET search_path = public;

--- a/supabase/migrations/20250905162000_sync_functions.sql
+++ b/supabase/migrations/20250905162000_sync_functions.sql
@@ -3,6 +3,7 @@ set check_function_bodies = off;
 CREATE OR REPLACE FUNCTION public.calculate_total_timeslot_capacity(event_activity_uuid uuid)
  RETURNS integer
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 DECLARE
   total_capacity integer := 0;
@@ -21,6 +22,7 @@ CREATE OR REPLACE FUNCTION public.can_reserve_pass(pass_uuid uuid, quantity inte
  RETURNS boolean
  LANGUAGE plpgsql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
 DECLARE
   effective_stock integer;
@@ -35,6 +37,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.cleanup_expired_cart_items()
  RETURNS void
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 BEGIN
   DELETE FROM cart_items
@@ -46,6 +49,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.generate_reservation_number()
  RETURNS text
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 BEGIN
   RETURN 'RES' || TO_CHAR(now(), 'YYYYMMDD') || '-' || LPAD(floor(random() * 10000)::text, 4, '0');
@@ -57,6 +61,7 @@ CREATE OR REPLACE FUNCTION public.get_activity_remaining_capacity(activity_resou
  RETURNS integer
  LANGUAGE plpgsql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
 DECLARE
   total_cap integer;
@@ -86,6 +91,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.get_event_activity_remaining_stock(event_activity_id_param uuid)
  RETURNS integer
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 DECLARE
     total_stock integer;
@@ -135,6 +141,7 @@ CREATE OR REPLACE FUNCTION public.get_event_passes_activities_stock(event_uuid u
  RETURNS json
  LANGUAGE sql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
   SELECT json_build_object(
     'passes', COALESCE((
@@ -175,6 +182,7 @@ CREATE OR REPLACE FUNCTION public.get_parc_activities_with_variants()
  RETURNS TABLE(id uuid, name text, description text, parc_description text, icon text, category text, requires_time_slot boolean, image_url text, variants jsonb)
  LANGUAGE sql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
   select
     a.id,
@@ -212,6 +220,7 @@ CREATE OR REPLACE FUNCTION public.get_pass_activity_remaining(pass_uuid uuid, ac
  RETURNS integer
  LANGUAGE plpgsql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
 DECLARE
   max_bookings integer;
@@ -250,6 +259,7 @@ CREATE OR REPLACE FUNCTION public.get_pass_effective_remaining_stock(pass_uuid u
  RETURNS integer
  LANGUAGE plpgsql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
 DECLARE
   pass_stock integer;
@@ -271,6 +281,7 @@ CREATE OR REPLACE FUNCTION public.get_pass_max_stock_from_activities(pass_uuid u
  RETURNS integer
  LANGUAGE plpgsql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
 DECLARE
   min_activity_stock integer := 999999;
@@ -304,6 +315,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.get_pass_remaining_stock(pass_uuid uuid)
  RETURNS integer
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 DECLARE
   initial_stock_val integer;
@@ -342,6 +354,7 @@ CREATE OR REPLACE FUNCTION public.get_passes_with_activities(event_uuid uuid)
  RETURNS json
  LANGUAGE sql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
   select coalesce(json_agg(
     json_build_object(
@@ -382,6 +395,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.get_slot_remaining_capacity(slot_uuid uuid)
  RETURNS integer
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 DECLARE
   total_capacity integer;
@@ -415,6 +429,7 @@ CREATE OR REPLACE FUNCTION public.role()
  RETURNS text
  LANGUAGE sql
  SECURITY DEFINER
+SET search_path = public
 AS $function$
   SELECT COALESCE(
     (SELECT users.role FROM users WHERE users.id = auth.uid()),
@@ -426,6 +441,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.set_reservation_number()
  RETURNS trigger
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 BEGIN
   NEW.reservation_number := 'RES-' || EXTRACT(YEAR FROM NOW()) || '-' || LPAD(EXTRACT(DOY FROM NOW())::text, 3, '0') || '-' || LPAD((RANDOM() * 9999)::int::text, 4, '0');
@@ -437,6 +453,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.sync_activity_stock_with_timeslots(event_activity_uuid uuid)
  RETURNS void
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 DECLARE
   total_capacity integer;
@@ -467,6 +484,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.trigger_sync_activity_stock()
  RETURNS trigger
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 BEGIN
   -- Synchroniser pour l'ancienne activité (en cas de UPDATE/DELETE)
@@ -487,6 +505,7 @@ $function$
 CREATE OR REPLACE FUNCTION public.trigger_sync_on_requires_timeslot_change()
  RETURNS trigger
  LANGUAGE plpgsql
+SET search_path = public
 AS $function$
 BEGIN
   -- Si on active requires_time_slot, synchroniser avec les créneaux existants

--- a/supabase/sql/get_passes_with_activities.sql
+++ b/supabase/sql/get_passes_with_activities.sql
@@ -2,6 +2,7 @@ create or replace function public.get_passes_with_activities(event_uuid uuid)
 returns json
 language sql
 security definer
+set search_path = public
 as $$
   select coalesce(json_agg(
     json_build_object(

--- a/supabase/sql/update_get_parc_activities_with_variants.sql
+++ b/supabase/sql/update_get_parc_activities_with_variants.sql
@@ -21,6 +21,7 @@ returns table (
 )
 language sql
 security definer
+set search_path = public
 as $$
   select
     a.id,


### PR DESCRIPTION
## Summary
- enforce `search_path` on all SQL functions to satisfy database linter
- enable leaked password protection and multiple MFA types in Supabase Auth

## Testing
- `pnpm run lint`
- `pnpm test`
- `pnpm run format` *(fails: docs/sprints/S1/INTERACTIONS.yaml: Nested mappings are not allowed in compact mappings)*

------
https://chatgpt.com/codex/tasks/task_e_68be8d765084832ba3a40a0c0ba2f84f