### PR TITLE
Sprint S10: correct pass reservation linkage

### DIFF
--- a/docs/sprints/S10/INTERACTIONS.yaml
+++ b/docs/sprints/S10/INTERACTIONS.yaml
@@ -349,3 +349,22 @@
   context: |
     command: npx -y supabase db push --db-url "$SUPABASE_DB_URL" --include-all --yes
   status: blocked
+- who: ChatGPT
+  when: 2025-09-08T15:03:37Z
+  topic: pass time slots linkage
+  did: |
+    - Ajout du `pass_id` lors de la création des créneaux
+    - Correction de `getCartItems` pour inclure `event_activity_id`
+    - Ajout d'une migration de correction des données existantes
+  status: done
+- who: ChatGPT
+  when: 2025-09-09T15:30:00Z
+  topic: search path migration parameter fix
+  did: |
+    - Conserver `activity_resource_uuid` dans `get_activity_remaining_capacity`
+    - Éviter l'erreur `cannot change name of input parameter`
+  ask: |
+    Exécuter `supabase db push` pour valider la migration
+  context: |
+    migration: 20250908090656_divine_breeze.sql
+  status: pending

--- a/src/components/admin/TimeSlotsManager.tsx
+++ b/src/components/admin/TimeSlotsManager.tsx
@@ -320,8 +320,20 @@ function CreateTimeSlotsForm({
     try {
       setCreating(true);
 
+      // Récupérer le pass associé à cette activité pour le lier aux créneaux
+      const { data: passActivity, error: passError } = await supabase
+        .from('pass_activities')
+        .select('pass_id')
+        .eq('event_activity_id', eventActivity.id)
+        .single();
+
+      if (passError || !passActivity?.pass_id) {
+        throw passError || new Error('Pass associé introuvable');
+      }
+
       const slotsToCreate = previewSlots.map((slot) => ({
         event_activity_id: eventActivity.id,
+        pass_id: passActivity.pass_id,
         slot_time: slot.start.toISOString(),
         capacity: formData.capacity,
       }));

--- a/src/lib/__tests__/cart.test.ts
+++ b/src/lib/__tests__/cart.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import {
   getSessionId,
   addToCart,
@@ -26,7 +26,7 @@ Object.defineProperty(window, 'localStorage', { value: mockLocalStorage });
 
 // Mock crypto
 Object.defineProperty(global, 'crypto', {
-  value: { randomUUID: () => 'test-session-id' }
+  value: { randomUUID: () => 'test-session-id' },
 });
 
 function createRepo(overrides: Partial<CartRepository> = {}): CartRepository {
@@ -58,7 +58,10 @@ describe('Cart Functions', () => {
       mockLocalStorage.getItem.mockReturnValue(null);
       const sessionId = getSessionId();
       expect(sessionId).toBe('test-session-id');
-      expect(mockLocalStorage.setItem).toHaveBeenCalledWith('cart_session_id', 'test-session-id');
+      expect(mockLocalStorage.setItem).toHaveBeenCalledWith(
+        'cart_session_id',
+        'test-session-id',
+      );
     });
 
     it('should fall back to memory when localStorage is unavailable', () => {
@@ -71,17 +74,30 @@ describe('Cart Functions', () => {
       expect(sessionId1).toBe('test-session-id');
       expect(sessionId2).toBe('test-session-id');
 
-      Object.defineProperty(window, 'localStorage', { value: original, configurable: true });
+      Object.defineProperty(window, 'localStorage', {
+        value: original,
+        configurable: true,
+      });
     });
   });
 
   describe('calculateCartTotal', () => {
     it('should calculate total correctly', () => {
-      const pass1: Pass = { id: '1', name: 'Pass 1', price: 10, description: 'Test' };
-      const pass2: Pass = { id: '2', name: 'Pass 2', price: 15, description: 'Test' };
+      const pass1: Pass = {
+        id: '1',
+        name: 'Pass 1',
+        price: 10,
+        description: 'Test',
+      };
+      const pass2: Pass = {
+        id: '2',
+        name: 'Pass 2',
+        price: 15,
+        description: 'Test',
+      };
       const items: CartItem[] = [
         { id: '1', pass: pass1, quantity: 2 },
-        { id: '2', pass: pass2, quantity: 1 }
+        { id: '2', pass: pass2, quantity: 1 },
       ];
       expect(calculateCartTotal(items)).toBe(35);
     });
@@ -97,7 +113,10 @@ describe('Cart Functions', () => {
       const notify = vi.fn();
       const result = await addToCart('pass-id', [], 1, repo, notify);
       expect(result).toBe(false);
-      expect(notify).toHaveBeenCalledWith('error', 'Configuration requise. Veuillez connecter Supabase.');
+      expect(notify).toHaveBeenCalledWith(
+        'error',
+        'Configuration requise. Veuillez connecter Supabase.',
+      );
     });
 
     it('should add item to cart when repository is configured', async () => {
@@ -108,7 +127,10 @@ describe('Cart Functions', () => {
       const result = await addToCart('pass-id', [], 1, repo, notify);
       expect(result).toBe(true);
       expect(repo.insertCartItem).toHaveBeenCalled();
-      expect(notify).toHaveBeenCalledWith('success', 'Article ajouté au panier');
+      expect(notify).toHaveBeenCalledWith(
+        'success',
+        'Article ajouté au panier',
+      );
     });
 
     it('should return false for invalid quantity', async () => {
@@ -116,11 +138,16 @@ describe('Cart Functions', () => {
       const notify = vi.fn();
       const result = await addToCart('pass-id', [], 0, repo, notify);
       expect(result).toBe(false);
-      expect(notify).toHaveBeenCalledWith('error', 'La quantité doit être un entier positif');
+      expect(notify).toHaveBeenCalledWith(
+        'error',
+        'La quantité doit être un entier positif',
+      );
     });
 
     it('should handle repository errors gracefully', async () => {
-      const repo = createRepo({ insertCartItem: vi.fn().mockRejectedValue(new Error('fail')) });
+      const repo = createRepo({
+        insertCartItem: vi.fn().mockRejectedValue(new Error('fail')),
+      });
       const notify = vi.fn();
       const spy = vi.spyOn(logger, 'error').mockImplementation(() => {});
       const result = await addToCart('pass-id', [], 1, repo, notify);
@@ -138,7 +165,9 @@ describe('Cart Functions', () => {
     });
 
     it('should return error message when stock is insufficient', async () => {
-      const repo = createRepo({ getPassRemainingStock: vi.fn().mockResolvedValue(0) });
+      const repo = createRepo({
+        getPassRemainingStock: vi.fn().mockResolvedValue(0),
+      });
       const result = await validateStock(repo, 'pass', [], 1);
       expect(result).toBe('Stock insuffisant pour ce pass');
     });
@@ -148,7 +177,11 @@ describe('Cart Functions', () => {
     it('should update quantity using repository', async () => {
       const updateCartItem = vi.fn().mockResolvedValue(true);
       const repo = createRepo({ updateCartItem });
-      const success = await updateExistingItem(repo, { id: '1', quantity: 2 }, 1);
+      const success = await updateExistingItem(
+        repo,
+        { id: '1', quantity: 2 },
+        1,
+      );
       expect(success).toBe(true);
       expect(updateCartItem).toHaveBeenCalledWith('1', 3);
     });
@@ -160,7 +193,14 @@ describe('Cart Functions', () => {
       const repo = createRepo({ insertCartItem });
       const success = await insertNewItem(repo, 'sess', 'pass', [], 1);
       expect(success).toBe(true);
-      expect(insertCartItem).toHaveBeenCalledWith('sess', 'pass', [], 1, undefined, undefined);
+      expect(insertCartItem).toHaveBeenCalledWith(
+        'sess',
+        'pass',
+        [],
+        1,
+        undefined,
+        undefined,
+      );
     });
   });
 
@@ -180,6 +220,66 @@ describe('Cart Functions', () => {
       const result = await getCartItems();
       expect(result).toEqual([]);
     });
+
+    it('should include event activity and time slot when present', async () => {
+      const { supabase, isSupabaseConfigured } = await import('../supabase');
+      vi.mocked(isSupabaseConfigured).mockReturnValue(true);
+      const builderCartItems = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        gt: vi.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'ci1',
+              quantity: 1,
+              pass_id: 'p1',
+              product_type: 'event_pass',
+              product_id: null,
+            },
+          ],
+          error: null,
+        }),
+      };
+      const builderPasses = {
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockResolvedValue({
+          data: [{ id: 'p1', name: 'Pass', price: 10, description: 'Desc' }],
+        }),
+      };
+      const builderActivities = {
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockResolvedValue({
+          data: [
+            {
+              cart_item_id: 'ci1',
+              event_activity_id: 'ea1',
+              time_slot_id: 'ts1',
+              event_activities: {
+                id: 'ea1',
+                activities: { id: 'a1', name: 'Act', icon: '🎯' },
+              },
+            },
+          ],
+        }),
+      };
+      const builderSlots = {
+        select: vi.fn().mockReturnThis(),
+        in: vi.fn().mockResolvedValue({
+          data: [{ id: 'ts1', slot_time: '2025-09-06T10:00:00.000Z' }],
+        }),
+      };
+
+      (supabase.from as unknown as Mock)
+        .mockReturnValueOnce(builderCartItems as unknown)
+        .mockReturnValueOnce(builderPasses as unknown)
+        .mockReturnValueOnce(builderActivities as unknown)
+        .mockReturnValueOnce(builderSlots as unknown);
+
+      const items = await getCartItems();
+      expect(items).toHaveLength(1);
+      expect(items[0].eventActivity?.id).toBe('ea1');
+      expect(items[0].timeSlot?.id).toBe('ts1');
+    });
   });
 
   describe('removeFromCart', () => {
@@ -191,7 +291,7 @@ describe('Cart Functions', () => {
         })),
       };
       vi.mocked(supabase.from).mockReturnValue(
-        builder as unknown as ReturnType<typeof supabase.from>
+        builder as unknown as ReturnType<typeof supabase.from>,
       );
 
       const result = await removeFromCart('item-id');
@@ -208,7 +308,7 @@ describe('Cart Functions', () => {
         })),
       };
       vi.mocked(supabase.from).mockReturnValue(
-        builder as unknown as ReturnType<typeof supabase.from>
+        builder as unknown as ReturnType<typeof supabase.from>,
       );
       mockLocalStorage.getItem.mockReturnValue('session-123');
 

--- a/supabase/migrations/20250908090656_divine_breeze.sql
+++ b/supabase/migrations/20250908090656_divine_breeze.sql
@@ -287,17 +287,17 @@ AS $$
   );
 $$;
 
-CREATE OR REPLACE FUNCTION public.get_activity_remaining_capacity(activity_uuid uuid)
+CREATE OR REPLACE FUNCTION public.get_activity_remaining_capacity(activity_resource_uuid uuid)
 RETURNS integer
 LANGUAGE sql
 SECURITY DEFINER
 SET search_path = public
 AS $$
   SELECT COALESCE(
-    (SELECT stock_limit FROM event_activities WHERE id = activity_uuid) - 
-    (SELECT COUNT(*)::integer FROM reservations r 
-     JOIN time_slots ts ON ts.id = r.time_slot_id 
-     WHERE ts.event_activity_id = activity_uuid AND r.payment_status = 'paid'),
+    (SELECT stock_limit FROM event_activities WHERE id = activity_resource_uuid) -
+    (SELECT COUNT(*)::integer FROM reservations r
+     JOIN time_slots ts ON ts.id = r.time_slot_id
+     WHERE ts.event_activity_id = activity_resource_uuid AND r.payment_status = 'paid'),
     0
   );
 $$;

--- a/supabase/migrations/20250909010000_backfill_pass_and_event_activity.sql
+++ b/supabase/migrations/20250909010000_backfill_pass_and_event_activity.sql
@@ -1,0 +1,23 @@
+-- Backfill missing pass_id in time_slots and event_activity_id in reservations
+
+-- Populate pass_id for existing time slots based on pass_activities
+UPDATE time_slots ts
+SET pass_id = pa.pass_id
+FROM pass_activities pa
+WHERE ts.pass_id IS NULL
+  AND ts.event_activity_id = pa.event_activity_id;
+
+-- Populate event_activity_id in reservations from related time slot
+UPDATE reservations r
+SET event_activity_id = ts.event_activity_id
+FROM time_slots ts
+WHERE r.event_activity_id IS NULL
+  AND r.time_slot_id = ts.id;
+
+-- Fallback: populate event_activity_id using pass_activities when no time slot
+UPDATE reservations r
+SET event_activity_id = pa.event_activity_id
+FROM pass_activities pa
+WHERE r.event_activity_id IS NULL
+  AND r.time_slot_id IS NULL
+  AND r.pass_id = pa.pass_id;


### PR DESCRIPTION
## Summary
- attach pass identifiers when creating time slots
- persist event activity on cart items and reservations
- backfill missing pass_id and event_activity_id in existing records
- keep original parameter name in search-path migration to avoid Supabase push errors

## Testing
- `pnpm run lint`
- `pnpm test` *(fails: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader; HTMLMediaElement.prototype.pause not implemented)*

------
https://chatgpt.com/codex/tasks/task_e_68beebd2108c832ba996652e3157546c